### PR TITLE
chore(pricing): Update openrouter pricing

### DIFF
--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -160,10 +160,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.0000224
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000032
         }
       }
     }
@@ -376,10 +376,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000045
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.000235
+          "price": 0.000175
         }
       }
     }
@@ -460,10 +460,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000255
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.000102
+          "price": 0.0001
         }
       }
     }
@@ -676,10 +676,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.000039
         },
         "response_token": {
-          "price": 0.000175
+          "price": 0.00019
         }
       }
     }
@@ -688,10 +688,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000043
+          "price": 0.000044
         },
         "response_token": {
-          "price": 0.000175
+          "price": 0.000176
         }
       }
     }
@@ -904,10 +904,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.000039
         }
       }
     }
@@ -928,10 +928,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000009
         },
         "response_token": {
-          "price": 0.00008
+          "price": 0.00011
         }
       }
     }
@@ -952,10 +952,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00008
         }
       }
     }
@@ -1144,10 +1144,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00008
+          "price": 0.000075
         }
       }
     }
@@ -1360,10 +1360,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000006
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000025
+          "price": 0.000027
         }
       }
     }
@@ -1468,10 +1468,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000038
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000153
+          "price": 0.00018
         }
       }
     }
@@ -1864,10 +1864,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.00045
+          "price": 0.000175
         }
       }
     }
@@ -1948,10 +1948,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00001
         }
       }
     }
@@ -2356,10 +2356,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000136
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.000068
+          "price": 0.00006
         }
       }
     }
@@ -2392,10 +2392,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00007
+          "price": 0.000088
         }
       }
     }
@@ -2548,10 +2548,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.000015
         }
       }
     }
@@ -2560,7 +2560,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000055
         },
         "response_token": {
           "price": 0.00008
@@ -2752,10 +2752,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00016
         }
       }
     }
@@ -2788,10 +2788,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000013
+          "price": 0.000026
         }
       }
     }
@@ -2836,10 +2836,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.000008
+          "price": 0.000011
         }
       }
     }
@@ -2899,7 +2899,7 @@
           "price": 0.000003
         },
         "response_token": {
-          "price": 0.000013
+          "price": 0.000011
         }
       }
     }
@@ -3028,7 +3028,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000108
+          "price": 0.00001
         },
         "response_token": {
           "price": 0.000032
@@ -3352,10 +3352,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000012
         },
         "response_token": {
-          "price": 0.000026
+          "price": 0.000039
         }
       }
     }
@@ -4000,10 +4000,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001125
+          "price": 0.000075
         },
         "response_token": {
-          "price": 0.0001125
+          "price": 0.0001
         }
       }
     }
@@ -4064,6 +4064,306 @@
         },
         "response_token": {
           "price": 0.00015
+        }
+      }
+    }
+  },
+  "bytedance-seed/seed-1.6-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "bytedance-seed/seed-1.6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "minimax/minimax-m2.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "z-ai/glm-4.7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "google/gemini-3-flash-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        }
+      }
+    }
+  },
+  "mistralai/mistral-small-creative": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "allenai/olmo-3.1-32b-think:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "xiaomi/mimo-v2-flash:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "nvidia/nemotron-3-nano-30b-a3b:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "nvidia/nemotron-3-nano-30b-a3b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000006
+        },
+        "response_token": {
+          "price": 0.000024
+        }
+      }
+    }
+  },
+  "openai/gpt-5.2-chat": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000175
+        },
+        "response_token": {
+          "price": 0.0014
+        }
+      }
+    }
+  },
+  "openai/gpt-5.2-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0021
+        },
+        "response_token": {
+          "price": 0.0168
+        }
+      }
+    }
+  },
+  "openai/gpt-5.2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000175
+        },
+        "response_token": {
+          "price": 0.0014
+        }
+      }
+    }
+  },
+  "mistralai/devstral-2512:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistralai/devstral-2512": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.000022
+        }
+      }
+    }
+  },
+  "relace/relace-search": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0003
+        }
+      }
+    }
+  },
+  "z-ai/glm-4.6v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "nex-agi/deepseek-v3.1-nex-n1:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "essentialai/rnj-1-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "openai/gpt-5.1-codex-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen/qwen3-vl-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "openai/gpt-oss-120b:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek/deepseek-r1-0528:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen/qwen-2.5-vl-7b-instruct:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama-3.1-405b-instruct:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openrouter

### 📊 Summary

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 25 |
| 🔄 Prices updated | 24 |

### ➕ New Models
- `bytedance-seed/seed-1.6-flash`
- `bytedance-seed/seed-1.6`
- `minimax/minimax-m2.1`
- `z-ai/glm-4.7`
- `google/gemini-3-flash-preview`
- `mistralai/mistral-small-creative`
- `allenai/olmo-3.1-32b-think:free`
- `xiaomi/mimo-v2-flash:free`
- `nvidia/nemotron-3-nano-30b-a3b:free`
- `nvidia/nemotron-3-nano-30b-a3b`
- `openai/gpt-5.2-chat`
- `openai/gpt-5.2-pro`
- `openai/gpt-5.2`
- `mistralai/devstral-2512:free`
- `mistralai/devstral-2512`
- `relace/relace-search`
- `z-ai/glm-4.6v`
- `nex-agi/deepseek-v3.1-nex-n1:free`
- `essentialai/rnj-1-instruct`
- `openai/gpt-5.1-codex-max`
- `qwen/qwen3-vl-32b-instruct`
- `openai/gpt-oss-120b:free`
- `deepseek/deepseek-r1-0528:free`
- `qwen/qwen-2.5-vl-7b-instruct:free`
- `meta-llama/llama-3.1-405b-instruct:free`

### 🔄 Updated Models
- `deepseek/deepseek-v3.2`
- `moonshotai/kimi-k2-thinking`
- `minimax/minimax-m2`
- `z-ai/glm-4.6`
- `z-ai/glm-4.6:exacto`
- `opengvlab/internvl3-78b`
- `qwen/qwen3-next-80b-a3b-instruct`
- `meituan/longcat-flash-chat`
- `deepseek/deepseek-chat-v3.1`
- `qwen/qwen3-coder-30b-a3b-instruct`
- `qwen/qwen3-coder:exacto`
- `deepseek/deepseek-r1-0528`
- `nousresearch/deephermes-3-mistral-24b-preview`
- `meta-llama/llama-4-maverick`
- `deepseek/deepseek-chat-v3-0324`
- `google/gemma-3-27b-it`
- `thedrummer/skyfall-36b-v2`
- `aion-labs/aion-rp-llama-3.1-8b`
- `qwen/qwen2.5-vl-72b-instruct`
- `mistralai/mistral-small-24b-instruct-2501`
- `deepseek/deepseek-r1-distill-llama-70b`
- `meta-llama/llama-3.3-70b-instruct`
- `qwen/qwen-2.5-72b-instruct`
- `mancer/weaver`


---
*Generated by Direct Converter on 2025-12-29*