### PR TITLE
feat(update-json): add image_generation to supported field for image models

### DIFF
--- a/general/open-ai.json
+++ b/general/open-ai.json
@@ -2121,11 +2121,11 @@
   },
   "gpt-image-1-mini": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "text", "supported": ["image_generation"] }
   },
   "gpt-image-1": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "text", "supported": ["image_generation"] }
   },
   "gpt-realtime-mini-2025-10-06": {
     "disablePlayground": true,
@@ -2440,13 +2440,15 @@
   },
   "dall-e-2": {
     "type": {
-      "primary": "image"
+      "primary": "image",
+      "supported": ["image_generation"]
     },
     "disablePlayground": true
   },
   "dall-e-3": {
     "type": {
-      "primary": "image"
+      "primary": "image",
+      "supported": ["image_generation"]
     },
     "disablePlayground": true
   },

--- a/general/openai.json
+++ b/general/openai.json
@@ -2121,11 +2121,11 @@
   },
   "gpt-image-1-mini": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "text", "supported": ["image_generation"] }
   },
   "gpt-image-1": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "text", "supported": ["image_generation"] }
   },
   "gpt-realtime-mini-2025-10-06": {
     "disablePlayground": true,
@@ -2440,13 +2440,15 @@
   },
   "dall-e-2": {
     "type": {
-      "primary": "image"
+      "primary": "image",
+      "supported": ["image_generation"]
     },
     "disablePlayground": true
   },
   "dall-e-3": {
     "type": {
-      "primary": "image"
+      "primary": "image",
+      "supported": ["image_generation"]
     },
     "disablePlayground": true
   },


### PR DESCRIPTION
# Adding image_generation to supported field for image models

## Summary

Added `image_generation` to the `supported` array in the `type` field for the following OpenAI image generation models:

- `gpt-image-1`
- `gpt-image-1-mini`  
- `dall-e-2`
- `dall-e-3`

This change enables proper identification of models that support image generation capability.

**Changes made in:**
- [general/open-ai.json](cci:7://file:///Users/sachinchoudhary/Documents/models/general/open-ai.json:0:0-0:0)
- [general/openai.json](cci:7://file:///Users/sachinchoudhary/Documents/models/general/openai.json:0:0-0:0)

- [ ] New model pricing
- [ ] Update existing pricing
- [x] New model configuration
- [ ] Bug fix

## Source Verification

**Source Link:** https://platform.openai.com/docs/models

> [!IMPORTANT]
> This is a configuration update to add capability metadata, not a pricing change.

## Checklist

- [x] I have validated the JSON using `jq` or an online validator
- [x] I have included the source link above
- [ ] I have signed the CLA (if first-time contributor)

## Related Issue

N/A - Internal improvement to model capability metadata