### PR TITLE
chore(pricing): Update openrouter pricing

### DIFF
--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -160,10 +160,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000038
         }
       }
     }
@@ -196,10 +196,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.000085
         }
       }
     }
@@ -376,10 +376,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000045
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.000235
+          "price": 0.000175
         }
       }
     }
@@ -463,7 +463,7 @@
           "price": 0.0000255
         },
         "response_token": {
-          "price": 0.000102
+          "price": 0.0001
         }
       }
     }
@@ -472,10 +472,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000002
         }
       }
     }
@@ -484,10 +484,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000002
         }
       }
     }
@@ -556,10 +556,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000064
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00005
         }
       }
     }
@@ -616,10 +616,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000056
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000224
+          "price": 0.000028
         }
       }
     }
@@ -640,10 +640,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000016
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00008
+          "price": 0.0001
         }
       }
     }
@@ -676,10 +676,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.000035
         },
         "response_token": {
-          "price": 0.000175
+          "price": 0.00015
         }
       }
     }
@@ -688,10 +688,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000043
+          "price": 0.000044
         },
         "response_token": {
-          "price": 0.000175
+          "price": 0.000176
         }
       }
     }
@@ -712,10 +712,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000021
+          "price": 0.000027
         },
         "response_token": {
-          "price": 0.000032
+          "price": 0.000041
         }
       }
     }
@@ -772,10 +772,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000045
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.00035
         }
       }
     }
@@ -904,10 +904,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.000039
         }
       }
     }
@@ -916,7 +916,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00012
@@ -928,10 +928,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000009
         },
         "response_token": {
-          "price": 0.00008
+          "price": 0.00011
         }
       }
     }
@@ -952,10 +952,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00008
         }
       }
     }
@@ -1120,10 +1120,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.0003
         }
       }
     }
@@ -1144,10 +1144,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00008
+          "price": 0.000075
         }
       }
     }
@@ -1180,10 +1180,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000056
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000224
+          "price": 0.000028
         }
       }
     }
@@ -1192,10 +1192,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000112
+          "price": 0.000014
         },
         "response_token": {
-          "price": 0.0000448
+          "price": 0.000056
         }
       }
     }
@@ -1204,10 +1204,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000048
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.000144
+          "price": 0.00018
         }
       }
     }
@@ -1324,10 +1324,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000014
+          "price": 0.00001
         }
       }
     }
@@ -1360,10 +1360,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000006
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000025
+          "price": 0.000027
         }
       }
     }
@@ -1408,10 +1408,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000104
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000068
+          "price": 0.000022
         }
       }
     }
@@ -1468,10 +1468,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000038
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000153
+          "price": 0.00018
         }
       }
     }
@@ -1540,10 +1540,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000456
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.000184
+          "price": 0.00024
         }
       }
     }
@@ -1576,10 +1576,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000028
+          "price": 0.00003
         }
       }
     }
@@ -1648,10 +1648,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.000085
         }
       }
     }
@@ -1684,10 +1684,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000336
+          "price": 0.000042
         },
         "response_token": {
-          "price": 0.0001
+          "price": 0.000125
         }
       }
     }
@@ -1696,10 +1696,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000224
+          "price": 0.000028
         },
         "response_token": {
-          "price": 0.000088
+          "price": 0.00011
         }
       }
     }
@@ -1864,10 +1864,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.00045
+          "price": 0.000175
         }
       }
     }
@@ -1948,10 +1948,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00001
         }
       }
     }
@@ -2104,10 +2104,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000028
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00001104
+          "price": 0.00004
         }
       }
     }
@@ -2152,10 +2152,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000018
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.000054
+          "price": 0.00006
         }
       }
     }
@@ -2356,10 +2356,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000136
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.000068
+          "price": 0.00006
         }
       }
     }
@@ -2392,10 +2392,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000019
         },
         "response_token": {
-          "price": 0.00007
+          "price": 0.000087
         }
       }
     }
@@ -2548,10 +2548,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.000015
         }
       }
     }
@@ -2560,7 +2560,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000055
         },
         "response_token": {
           "price": 0.00008
@@ -2752,10 +2752,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00016
         }
       }
     }
@@ -2788,10 +2788,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.000013
+          "price": 0.00006
         }
       }
     }
@@ -2836,10 +2836,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.000008
+          "price": 0.000011
         }
       }
     }
@@ -2848,10 +2848,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000024
+          "price": 0.000029
         },
         "response_token": {
-          "price": 0.000024
+          "price": 0.000029
         }
       }
     }
@@ -2899,7 +2899,7 @@
           "price": 0.000003
         },
         "response_token": {
-          "price": 0.000013
+          "price": 0.000011
         }
       }
     }
@@ -2908,10 +2908,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.00025
         }
       }
     }
@@ -3028,7 +3028,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000108
+          "price": 0.00001
         },
         "response_token": {
           "price": 0.000032
@@ -3352,10 +3352,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000012
         },
         "response_token": {
-          "price": 0.000026
+          "price": 0.000039
         }
       }
     }
@@ -3535,7 +3535,7 @@
           "price": 0.000002
         },
         "response_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       }
     }
@@ -3640,10 +3640,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.000014
         },
         "response_token": {
-          "price": 0.000008
+          "price": 0.000014
         }
       }
     }
@@ -3664,10 +3664,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000028
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.0000054
+          "price": 0.00002
         }
       }
     }
@@ -3760,10 +3760,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000051
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000074
         }
       }
     }
@@ -3928,10 +3928,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0006
+          "price": 0.000375
         },
         "response_token": {
-          "price": 0.0008
+          "price": 0.00075
         }
       }
     }
@@ -4000,10 +4000,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001125
+          "price": 0.000075
         },
         "response_token": {
-          "price": 0.0001125
+          "price": 0.0001
         }
       }
     }
@@ -4064,6 +4064,510 @@
         },
         "response_token": {
           "price": 0.00015
+        }
+      }
+    }
+  },
+  "openrouter/free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "stepfun/step-3.5-flash:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "arcee-ai/trinity-large-preview:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "moonshotai/kimi-k2.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00028
+        }
+      }
+    }
+  },
+  "upstage/solar-pro-3:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "minimax/minimax-m2-her": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "writer/palmyra-x5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "liquid/lfm-2.5-1.2b-thinking:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "liquid/lfm-2.5-1.2b-instruct:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "openai/gpt-audio": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "openai/gpt-audio-mini": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "z-ai/glm-4.7-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "openai/gpt-5.2-codex": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000175
+        },
+        "response_token": {
+          "price": 0.0014
+        }
+      }
+    }
+  },
+  "allenai/molmo-2-8b:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "allenai/olmo-3.1-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "bytedance-seed/seed-1.6-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "bytedance-seed/seed-1.6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "minimax/minimax-m2.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000027
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "z-ai/glm-4.7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "google/gemini-3-flash-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        }
+      }
+    }
+  },
+  "mistralai/mistral-small-creative": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "allenai/olmo-3.1-32b-think": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00005
+        }
+      }
+    }
+  },
+  "xiaomi/mimo-v2-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000009
+        },
+        "response_token": {
+          "price": 0.000029
+        }
+      }
+    }
+  },
+  "nvidia/nemotron-3-nano-30b-a3b:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "nvidia/nemotron-3-nano-30b-a3b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "openai/gpt-5.2-chat": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000175
+        },
+        "response_token": {
+          "price": 0.0014
+        }
+      }
+    }
+  },
+  "openai/gpt-5.2-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0021
+        },
+        "response_token": {
+          "price": 0.0168
+        }
+      }
+    }
+  },
+  "openai/gpt-5.2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000175
+        },
+        "response_token": {
+          "price": 0.0014
+        }
+      }
+    }
+  },
+  "mistralai/devstral-2512": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.000022
+        }
+      }
+    }
+  },
+  "relace/relace-search": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0003
+        }
+      }
+    }
+  },
+  "z-ai/glm-4.6v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "nex-agi/deepseek-v3.1-nex-n1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000027
+        },
+        "response_token": {
+          "price": 0.0001
+        }
+      }
+    }
+  },
+  "essentialai/rnj-1-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "openai/gpt-5.1-codex-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "allenai/olmo-3-32b-think": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00005
+        }
+      }
+    }
+  },
+  "kwaipilot/kat-coder-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000207
+        },
+        "response_token": {
+          "price": 0.0000828
+        }
+      }
+    }
+  },
+  "qwen/qwen3-vl-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "qwen/qwen3-next-80b-a3b-instruct:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "openai/gpt-oss-120b:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek/deepseek-r1-0528:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen/qwen-2.5-vl-7b-instruct:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama-3.1-405b-instruct:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openrouter

### 📊 Summary

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 42 |
| 🔄 Prices updated | 53 |

### ➕ New Models
- `openrouter/free`
- `stepfun/step-3.5-flash:free`
- `arcee-ai/trinity-large-preview:free`
- `moonshotai/kimi-k2.5`
- `upstage/solar-pro-3:free`
- `minimax/minimax-m2-her`
- `writer/palmyra-x5`
- `liquid/lfm-2.5-1.2b-thinking:free`
- `liquid/lfm-2.5-1.2b-instruct:free`
- `openai/gpt-audio`
- `openai/gpt-audio-mini`
- `z-ai/glm-4.7-flash`
- `openai/gpt-5.2-codex`
- `allenai/molmo-2-8b:free`
- `allenai/olmo-3.1-32b-instruct`
- `bytedance-seed/seed-1.6-flash`
- `bytedance-seed/seed-1.6`
- `minimax/minimax-m2.1`
- `z-ai/glm-4.7`
- `google/gemini-3-flash-preview`
- `mistralai/mistral-small-creative`
- `allenai/olmo-3.1-32b-think`
- `xiaomi/mimo-v2-flash`
- `nvidia/nemotron-3-nano-30b-a3b:free`
- `nvidia/nemotron-3-nano-30b-a3b`
- `openai/gpt-5.2-chat`
- `openai/gpt-5.2-pro`
- `openai/gpt-5.2`
- `mistralai/devstral-2512`
- `relace/relace-search`
- ... and 12 more

### 🔄 Updated Models
- `deepseek/deepseek-v3.2`
- `tngtech/tng-r1t-chimera`
- `moonshotai/kimi-k2-thinking`
- `minimax/minimax-m2`
- `liquid/lfm2-8b-a1b`
- `liquid/lfm-2.2-6b`
- `qwen/qwen3-vl-8b-instruct`
- `baidu/ernie-4.5-21b-a3b-thinking`
- `qwen/qwen3-vl-30b-a3b-thinking`
- `z-ai/glm-4.6`
- `z-ai/glm-4.6:exacto`
- `deepseek/deepseek-v3.2-exp`
- `qwen/qwen3-vl-235b-a22b-thinking`
- `opengvlab/internvl3-78b`
- `qwen/qwen3-next-80b-a3b-thinking`
- `qwen/qwen3-next-80b-a3b-instruct`
- `meituan/longcat-flash-chat`
- `nousresearch/hermes-4-405b`
- `deepseek/deepseek-chat-v3.1`
- `baidu/ernie-4.5-21b-a3b`
- `baidu/ernie-4.5-vl-28b-a3b`
- `z-ai/glm-4.5v`
- `openai/gpt-oss-20b`
- `qwen/qwen3-coder-30b-a3b-instruct`
- `z-ai/glm-4.5-air`
- `qwen/qwen3-coder:exacto`
- `moonshotai/kimi-k2`
- `mistralai/devstral-small`
- `tngtech/deepseek-r1t2-chimera`
- `baidu/ernie-4.5-vl-424b-a47b`
- ... and 23 more


---
*Generated by Direct Converter on 2026-02-03*