### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -124,6 +124,12 @@
         },
         "response_token": {
           "price": 0.003
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -136,14 +142,12 @@
         },
         "response_token": {
           "price": 0.003
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0005
         },
-        "response_token": {
-          "price": 0.0015
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -156,6 +160,12 @@
         },
         "response_token": {
           "price": 0.003
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -168,14 +178,12 @@
         },
         "response_token": {
           "price": 0.003
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0005
         },
-        "response_token": {
-          "price": 0.0015
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -189,13 +197,11 @@
         "response_token": {
           "price": 0.006
         },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -208,14 +214,12 @@
         },
         "response_token": {
           "price": 0.006
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0015
         },
-        "response_token": {
-          "price": 0.003
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -228,14 +232,12 @@
         },
         "response_token": {
           "price": 0.006
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0015
         },
-        "response_token": {
-          "price": 0.003
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -248,14 +250,12 @@
         },
         "response_token": {
           "price": 0.003
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0005
         },
-        "response_token": {
-          "price": 0.0015
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -344,6 +344,12 @@
         },
         "response_token": {
           "price": 0.00015
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -356,14 +362,12 @@
         },
         "response_token": {
           "price": 0.0002
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00005
         },
-        "response_token": {
-          "price": 0.0001
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -376,14 +380,12 @@
         },
         "response_token": {
           "price": 0.00015
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
         },
-        "response_token": {
-          "price": 0.000075
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -396,6 +398,12 @@
         },
         "response_token": {
           "price": 0.0004
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -408,6 +416,12 @@
         },
         "response_token": {
           "price": 0.0002
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -432,13 +446,11 @@
         },
         "response_token": {
           "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000005
         },
-        "response_token": {
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
           "price": 0
         }
       }
@@ -452,13 +464,11 @@
         },
         "response_token": {
           "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000001
         },
-        "response_token": {
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
           "price": 0
         }
       }
@@ -472,13 +482,11 @@
         },
         "response_token": {
           "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000065
         },
-        "response_token": {
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
           "price": 0
         }
       }
@@ -499,73 +507,31 @@
   "dall-e-3": {
     "pricing_config": {
       "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 4
-            },
-            "1024x1024": {
-              "price": 4
-            },
-            "1024x1792": {
-              "price": 8
-            },
-            "1792x1024": {
-              "price": 8
-            }
-          },
-          "standard": {
-            "default": {
-              "price": 4
-            },
-            "1024x1024": {
-              "price": 4
-            },
-            "1024x1792": {
-              "price": 8
-            },
-            "1792x1024": {
-              "price": 8
-            }
-          },
-          "hd": {
-            "default": {
-              "price": 8
-            },
-            "1024x1024": {
-              "price": 8
-            },
-            "1024x1792": {
-              "price": 12
-            },
-            "1792x1024": {
-              "price": 12
-            }
-          }
-        }
-      },
-      "calculate": {
-        "request": {
-          "operation": "multiply",
-          "operands": [
-            {
-              "value": "0"
-            },
-            {
-              "value": "input_tokens"
-            }
-          ]
+        "request_token": {
+          "price": 0
         },
-        "response": {
-          "operation": "multiply",
-          "operands": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "rates.image"
-            }
-          ]
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "image_standard_1024x1024": {
+            "price": 4
+          },
+          "image_standard_1024x1792": {
+            "price": 8
+          },
+          "image_standard_1792x1024": {
+            "price": 8
+          },
+          "image_hd_1024x1024": {
+            "price": 8
+          },
+          "image_hd_1024x1792": {
+            "price": 12
+          },
+          "image_hd_1792x1024": {
+            "price": 12
+          }
         }
       }
     }
@@ -573,59 +539,22 @@
   "dall-e-2": {
     "pricing_config": {
       "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 2
-            },
-            "1024x1024": {
-              "price": 2
-            },
-            "512x512": {
-              "price": 1.8
-            },
-            "256x256": {
-              "price": 1.6
-            }
-          },
-          "standard": {
-            "default": {
-              "price": 2
-            },
-            "1024x1024": {
-              "price": 2
-            },
-            "512x512": {
-              "price": 1.8
-            },
-            "256x256": {
-              "price": 1.6
-            }
-          }
-        }
-      },
-      "calculate": {
-        "request": {
-          "operation": "multiply",
-          "operands": [
-            {
-              "value": "0"
-            },
-            {
-              "value": "input_tokens"
-            }
-          ]
+        "request_token": {
+          "price": 0
         },
-        "response": {
-          "operation": "multiply",
-          "operands": [
-            {
-              "value": "1"
-            },
-            {
-              "value": "rates.image"
-            }
-          ]
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "image_standard_256x256": {
+            "price": 1.6
+          },
+          "image_standard_512x512": {
+            "price": 1.8
+          },
+          "image_standard_1024x1024": {
+            "price": 2
+          }
         }
       }
     }
@@ -768,22 +697,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000125
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000125
-        },
-        "response_token": {
-          "price": 0.0005
         }
       }
     }
@@ -817,21 +730,11 @@
         "response_token": {
           "price": 0.0015
         },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00025
+        "cache_write_input_token": {
+          "price": 0
         },
-        "response_token": {
-          "price": 0.00075
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -850,19 +753,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000125
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "finetune_config": {
-        "pay_per_token": {
-          "price": 0.0025
         }
       }
     }
@@ -881,22 +771,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000075
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
         }
       }
     }
@@ -915,19 +789,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000075
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "finetune_config": {
-        "pay_per_token": {
-          "price": 0.0003
         }
       }
     }
@@ -969,19 +830,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00075
-        },
-        "additional_units": {
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00075
-        },
-        "response_token": {
-          "price": 0.003
         }
       }
     }
@@ -1000,11 +848,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00075
-        },
-        "additional_units": {
-          "file_search": {
-            "price": 0.25
-          }
         }
       }
     }
@@ -1128,14 +971,11 @@
         "cache_read_input_token": {
           "price": 0.00025
         },
-        "cache_read_audio_input_token": {
-          "price": 0.00025
+        "request_audio_token": {
+          "price": 0.004
         },
         "response_audio_token": {
           "price": 0.008
-        },
-        "request_audio_token": {
-          "price": 0.004
         }
       }
     }
@@ -1155,14 +995,11 @@
         "cache_read_input_token": {
           "price": 0.00025
         },
-        "cache_read_audio_input_token": {
-          "price": 0.00025
+        "request_audio_token": {
+          "price": 0.004
         },
         "response_audio_token": {
           "price": 0.008
-        },
-        "request_audio_token": {
-          "price": 0.004
         }
       }
     }
@@ -1175,14 +1012,12 @@
         },
         "response_token": {
           "price": 0.0002
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000075
         },
-        "response_token": {
-          "price": 0.0001
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -1220,15 +1055,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000125
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
+          "price": 0
         }
       }
     }
@@ -1247,14 +1074,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000125
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
         }
       }
     }
@@ -1268,19 +1087,17 @@
         "response_token": {
           "price": 0.001
         },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
+          "price": 0.008
         }
       }
     }
@@ -1327,17 +1144,14 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.006
+          "price": 0
         },
         "response_token": {
           "price": 0
         },
         "additional_units": {
-          "request_audio_token": {
+          "transcription_minute": {
             "price": 0.6
-          },
-          "response_audio_token": {
-            "price": 0
           }
         }
       }
@@ -1347,10 +1161,15 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0015
+          "price": 0
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "tts_character": {
+            "price": 0.0015
+          }
         }
       }
     }
@@ -1359,10 +1178,15 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.003
+          "price": 0
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "tts_character": {
+            "price": 0.003
+          }
         }
       }
     }
@@ -1376,13 +1200,17 @@
         "response_token": {
           "price": 0
         },
-        "additional_units": {
-          "request_audio_token": {
-            "price": 0
-          },
-          "response_audio_token": {
-            "price": 1.5
-          }
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.0012
         }
       }
     }
@@ -1396,13 +1224,17 @@
         "response_token": {
           "price": 0.001
         },
-        "additional_units": {
-          "request_audio_token": {
-            "price": 0.6
-          },
-          "response_audio_token": {
-            "price": 0
-          }
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0.0006
+        },
+        "response_audio_token": {
+          "price": 0
         }
       }
     }
@@ -1416,13 +1248,17 @@
         "response_token": {
           "price": 0.0005
         },
-        "additional_units": {
-          "request_audio_token": {
-            "price": 0.3
-          },
-          "response_audio_token": {
-            "price": 0
-          }
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0.0003
+        },
+        "response_audio_token": {
+          "price": 0
         }
       }
     }
@@ -1441,11 +1277,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000055
-        },
-        "additional_units": {
-          "file_search": {
-            "price": 0.25
-          }
         }
       }
     }
@@ -1464,19 +1295,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000055
-        },
-        "additional_units": {
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000055
-        },
-        "response_token": {
-          "price": 0.00022
         }
       }
     }
@@ -1513,18 +1331,11 @@
         "response_token": {
           "price": 0.06
         },
-        "additional_units": {
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0075
+        "cache_write_input_token": {
+          "price": 0
         },
-        "response_token": {
-          "price": 0.03
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -1538,10 +1349,11 @@
         "response_token": {
           "price": 0.06
         },
-        "additional_units": {
-          "file_search": {
-            "price": 0.25
-          }
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -1554,14 +1366,12 @@
         },
         "response_token": {
           "price": 0.0012
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00015
         },
-        "response_token": {
-          "price": 0.0006
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -1574,6 +1384,12 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -1592,19 +1408,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00005
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "finetune_config": {
-        "pay_per_token": {
-          "price": 0.0025
         }
       }
     }
@@ -1623,22 +1426,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00005
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0004
         }
       }
     }
@@ -1657,19 +1444,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "finetune_config": {
-        "pay_per_token": {
-          "price": 0.0005
         }
       }
     }
@@ -1688,22 +1462,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00008
         }
       }
     }
@@ -1721,12 +1479,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
-        }
-      },
-      "finetune_config": {
-        "pay_per_token": {
-          "price": 0.00015
+          "price": 0.0000025
         }
       }
     }
@@ -1762,23 +1515,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.00002
+          "price": 0.0000025
         }
       }
     }
@@ -1797,22 +1534,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00005
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0004
         }
       }
     }
@@ -1831,11 +1552,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00005
-        },
-        "additional_units": {
-          "file_search": {
-            "price": 0.25
-          }
         }
       }
     }
@@ -1849,18 +1565,11 @@
         "response_token": {
           "price": 0.008
         },
-        "additional_units": {
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.001
+        "cache_write_input_token": {
+          "price": 0
         },
-        "response_token": {
-          "price": 0.004
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -1874,10 +1583,11 @@
         "response_token": {
           "price": 0.008
         },
-        "additional_units": {
-          "file_search": {
-            "price": 0.25
-          }
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -1896,22 +1606,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000275
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000055
-        },
-        "response_token": {
-          "price": 0.00022
         }
       }
     }
@@ -1930,19 +1624,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000275
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "finetune_config": {
-        "pay_per_hour": {
-          "price": 10000
         }
       }
     }
@@ -2140,22 +1821,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0005
-        },
-        "response_token": {
-          "price": 0.002
         }
       }
     }
@@ -2174,14 +1839,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
         }
       }
     }
@@ -2190,24 +1847,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
+          "price": 0.00005
         }
       }
     }
@@ -2226,22 +1875,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00005
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0004
         }
       }
     }
@@ -2259,16 +1892,13 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
-        },
-        "cache_read_audio_input_token": {
-          "price": 0.0003
-        },
-        "response_audio_token": {
-          "price": 0.02
+          "price": 0.00003
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.002
         }
       }
     }
@@ -2286,16 +1916,13 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
-        },
-        "cache_read_audio_input_token": {
-          "price": 0.0003
-        },
-        "response_audio_token": {
-          "price": 0.02
+          "price": 0.00003
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.002
         }
       }
     }
@@ -2308,6 +1935,12 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -2320,6 +1953,12 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -2332,6 +1971,12 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -2344,6 +1989,12 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -2358,10 +2009,10 @@
           "price": 0.0006
         },
         "cache_write_input_token": {
-          "price": 0.0000375
+          "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0006
+          "price": 0.0000375
         }
       }
     }
@@ -2380,14 +2031,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000125
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
         }
       }
     }
@@ -2406,25 +2049,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000125
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000625
-        },
-        "response_token": {
-          "price": 0.0005
-        },
-        "cache_read_input_token": {
-          "price": 0.00000625
         }
       }
     }
@@ -2443,25 +2067,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000125
-        },
-        "response_token": {
-          "price": 0.0001
-        },
-        "cache_read_input_token": {
-          "price": 0.00000125
         }
       }
     }
@@ -2480,14 +2085,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
         }
       }
     }
@@ -2506,17 +2103,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000005
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00000025
         }
       }
     }
@@ -2553,14 +2139,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000125
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
         }
       }
     }
@@ -2592,11 +2170,17 @@
         "response_token": {
           "price": 0.00006
         },
-        "response_audio_token": {
-          "price": 0.002
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         },
         "request_audio_token": {
           "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.002
         }
       }
     }
@@ -2605,15 +2189,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0015
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00006
         },
-        "response_audio_token": {
-          "price": 0.001
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         },
         "request_audio_token": {
+          "price": 0.001
+        },
+        "response_audio_token": {
           "price": 0.002
         }
       }
@@ -2632,23 +2222,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000005
-        }
-      },
-      "additional_units": {
-        "web_search": {
-          "price": 1
-        },
-        "file_search": {
-          "price": 0.25
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00075
-        },
-        "response_token": {
-          "price": 0.006
+          "price": 0
         }
       }
     }
@@ -2666,15 +2240,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000005
-        }
-      },
-      "additional_units": {
-        "web_search": {
-          "price": 1
-        },
-        "file_search": {
-          "price": 0.25
+          "price": 0
         }
       }
     }
@@ -2689,19 +2255,16 @@
           "price": 0.0016
         },
         "cache_write_input_token": {
-          "price": 0.00005
+          "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0016
-        },
-        "cache_read_audio_input_token": {
-          "price": 0.0064
-        },
-        "response_audio_token": {
-          "price": 0.0064
+          "price": 0.00004
         },
         "request_audio_token": {
           "price": 0.0032
+        },
+        "response_audio_token": {
+          "price": 0.0064
         }
       }
     }
@@ -2716,19 +2279,16 @@
           "price": 0.0016
         },
         "cache_write_input_token": {
-          "price": 0.00005
+          "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0016
-        },
-        "cache_read_audio_input_token": {
-          "price": 0.0064
-        },
-        "response_audio_token": {
-          "price": 0.0064
+          "price": 0.00004
         },
         "request_audio_token": {
           "price": 0.0032
+        },
+        "response_audio_token": {
+          "price": 0.0064
         }
       }
     }
@@ -2742,11 +2302,17 @@
         "response_token": {
           "price": 0.001
         },
-        "response_audio_token": {
-          "price": 0.0064
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         },
         "request_audio_token": {
           "price": 0.0032
+        },
+        "response_audio_token": {
+          "price": 0.0064
         }
       }
     }
@@ -2760,11 +2326,17 @@
         "response_token": {
           "price": 0.00024
         },
-        "response_audio_token": {
-          "price": 0.0002
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.002
         }
       }
     }
@@ -2772,77 +2344,16 @@
   "gpt-image-1": {
     "pricing_config": {
       "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 16.7
-            },
-            "1024x1024": {
-              "price": 16.7
-            },
-            "1024x1536": {
-              "price": 25
-            },
-            "1536x1024": {
-              "price": 25
-            }
-          },
-          "high": {
-            "default": {
-              "price": 16.7
-            },
-            "1024x1024": {
-              "price": 16.7
-            },
-            "1024x1536": {
-              "price": 25
-            },
-            "1536x1024": {
-              "price": 25
-            }
-          },
-          "medium": {
-            "default": {
-              "price": 4.2
-            },
-            "1024x1024": {
-              "price": 4.2
-            },
-            "1024x1536": {
-              "price": 6.3
-            },
-            "1536x1024": {
-              "price": 6.3
-            }
-          },
-          "low": {
-            "default": {
-              "price": 1.1
-            },
-            "1024x1024": {
-              "price": 1.1
-            },
-            "1024x1536": {
-              "price": 1.6
-            },
-            "1536x1024": {
-              "price": 1.6
-            }
-          }
-        },
-        "request_image_token": {
-          "price": 0.001
-        },
-        "response_image_token": {
-          "price": 0.004
-        },
-        "request_text_token": {
+        "request_token": {
           "price": 0.0005
         },
-        "cached_image_input_token": {
-          "price": 0.00025
+        "response_token": {
+          "price": 0
         },
-        "cached_text_input_token": {
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
           "price": 0.000125
         }
       }
@@ -2908,25 +2419,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000125
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000625
-        },
-        "response_token": {
-          "price": 0.0005
-        },
-        "cache_read_input_token": {
-          "price": 0.00000625
         }
       }
     }
@@ -2945,14 +2437,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000125
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
         }
       }
     }
@@ -3061,25 +2545,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000175
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000875
-        },
-        "response_token": {
-          "price": 0.0007
-        },
-        "cache_read_input_token": {
-          "price": 0.00000875
         }
       }
     }
@@ -3098,14 +2563,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000175
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
         }
       }
     }
@@ -3124,14 +2581,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000175
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
         }
       }
     }
@@ -3148,21 +2597,8 @@
         "cache_write_input_token": {
           "price": 0
         },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00105
-        },
-        "response_token": {
-          "price": 0.0084
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -3179,13 +2615,8 @@
         "cache_write_input_token": {
           "price": 0
         },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }
@@ -3223,9 +2654,6 @@
         "cache_read_input_token": {
           "price": 0.000006
         },
-        "cache_read_audio_input_token": {
-          "price": 0.000008
-        },
         "request_audio_token": {
           "price": 0.001
         },
@@ -3244,8 +2672,17 @@
         "response_token": {
           "price": 0.001
         },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
         "request_audio_token": {
           "price": 0.0006
+        },
+        "response_audio_token": {
+          "price": 0
         }
       }
     }
@@ -3253,80 +2690,16 @@
   "gpt-image-1.5": {
     "pricing_config": {
       "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 13.3
-            },
-            "1024x1024": {
-              "price": 13.3
-            },
-            "1024x1536": {
-              "price": 20
-            },
-            "1536x1024": {
-              "price": 20
-            }
-          },
-          "high": {
-            "default": {
-              "price": 13.3
-            },
-            "1024x1024": {
-              "price": 13.3
-            },
-            "1024x1536": {
-              "price": 20
-            },
-            "1536x1024": {
-              "price": 20
-            }
-          },
-          "medium": {
-            "default": {
-              "price": 3.4
-            },
-            "1024x1024": {
-              "price": 3.4
-            },
-            "1024x1536": {
-              "price": 5
-            },
-            "1536x1024": {
-              "price": 5
-            }
-          },
-          "low": {
-            "default": {
-              "price": 0.9
-            },
-            "1024x1024": {
-              "price": 0.9
-            },
-            "1024x1536": {
-              "price": 1.3
-            },
-            "1536x1024": {
-              "price": 1.3
-            }
-          }
-        },
-        "request_image_token": {
-          "price": 0.0008
-        },
-        "response_image_token": {
-          "price": 0.0032
-        },
-        "request_text_token": {
+        "request_token": {
           "price": 0.0005
         },
-        "response_text_token": {
+        "response_token": {
           "price": 0.001
         },
-        "cached_image_input_token": {
-          "price": 0.0002
+        "cache_write_input_token": {
+          "price": 0
         },
-        "cached_text_input_token": {
+        "cache_read_input_token": {
           "price": 0.000125
         }
       }
@@ -3428,6 +2801,454 @@
         },
         "cache_read_input_token": {
           "price": 0.0000175
+        }
+      }
+    }
+  },
+  "gpt-realtime-mini-2025-10-06": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        },
+        "request_audio_token": {
+          "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.002
+        }
+      }
+    }
+  },
+  "gpt-realtime-mini-2025-12-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        },
+        "request_audio_token": {
+          "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.002
+        }
+      }
+    }
+  },
+  "gpt-4o-realtime-preview-2024-12-17": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.002
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0.00025
+        },
+        "request_audio_token": {
+          "price": 0.004
+        },
+        "response_audio_token": {
+          "price": 0.008
+        }
+      }
+    }
+  },
+  "gpt-audio-2025-08-28": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0.0032
+        },
+        "response_audio_token": {
+          "price": 0.0064
+        }
+      }
+    }
+  },
+  "gpt-audio-mini-2025-10-06": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.002
+        }
+      }
+    }
+  },
+  "gpt-audio-mini-2025-12-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.002
+        }
+      }
+    }
+  },
+  "gpt-4o-audio-preview-2024-12-17": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0.004
+        },
+        "response_audio_token": {
+          "price": 0.008
+        }
+      }
+    }
+  },
+  "gpt-4o-audio-preview-2025-06-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0.004
+        },
+        "response_audio_token": {
+          "price": 0.008
+        }
+      }
+    }
+  },
+  "gpt-4o-mini-transcribe-2025-03-20": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.0005
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0.0003
+        },
+        "response_audio_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gpt-4o-mini-transcribe-2025-12-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.0005
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0.0003
+        },
+        "response_audio_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gpt-4o-mini-tts-2025-03-20": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "gpt-4o-mini-tts-2025-12-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "tts-1-1106": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "tts_character": {
+            "price": 0.0015
+          }
+        }
+      }
+    }
+  },
+  "tts-1-hd-1106": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "tts_character": {
+            "price": 0.003
+          }
+        }
+      }
+    }
+  },
+  "chatgpt-image-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
+        }
+      }
+    }
+  },
+  "gpt-image-1-mini": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "omni-moderation-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "omni-moderation-2024-09-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gpt-3.5-turbo-instruct-0914": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.0002
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "davinci-002": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0002
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "babbage-002": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00004
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 21 |
| 🔄 Prices updated | 45 |

### ➕ New Models
- `gpt-realtime-mini-2025-10-06`
- `gpt-realtime-mini-2025-12-15`
- `gpt-4o-realtime-preview-2024-12-17`
- `gpt-audio-2025-08-28`
- `gpt-audio-mini-2025-10-06`
- `gpt-audio-mini-2025-12-15`
- `gpt-4o-audio-preview-2024-12-17`
- `gpt-4o-audio-preview-2025-06-03`
- `gpt-4o-mini-transcribe-2025-03-20`
- `gpt-4o-mini-transcribe-2025-12-15`
- `gpt-4o-mini-tts-2025-03-20`
- `gpt-4o-mini-tts-2025-12-15`
- `tts-1-1106`
- `tts-1-hd-1106`
- `chatgpt-image-latest`
- `gpt-image-1-mini`
- `omni-moderation-latest`
- `omni-moderation-2024-09-26`
- `gpt-3.5-turbo-instruct-0914`
- `davinci-002`
- ... and 1 more

### 🔄 Updated Models
- `gpt-5.1-codex-mini`
- `gpt-5-mini`
- `gpt-5-mini-2025-08-07`
- `gpt-5-nano`
- `gpt-5-nano-2025-08-07`
- `gpt-4.1`
- `gpt-4.1-2025-04-14`
- `gpt-4.1-mini`
- `gpt-4.1-mini-2025-04-14`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `gpt-4o-mini`
- `gpt-4o-mini-2024-07-18`
- `gpt-4o-mini-search-preview`
- `gpt-4o-mini-search-preview-2025-03-11`
- `o3`
- `o3-2025-04-16`
- `o4-mini-deep-research`
- `o4-mini-deep-research-2025-06-26`
- `computer-use-preview`
- ... and 25 more


---
*Generated by Pricing Agent on 2026-02-16*