### PR TITLE
chore(pricing): Update deepinfra pricing

### DIFF
--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -88,7 +88,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000002
         },
         "response_token": {
           "price": 0.000005
@@ -115,7 +115,7 @@
           "price": 0.000003
         },
         "response_token": {
-          "price": 0.000006
+          "price": 0.000004
         }
       }
     }
@@ -148,10 +148,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.000008
+          "price": 0.00004
         }
       }
     }
@@ -310,7 +310,7 @@
           "price": 0.00002
         },
         "response_token": {
-          "price": 0.000088
+          "price": 0.000077
         },
         "cache_read_input_token": {
           "price": 0.0000106
@@ -475,7 +475,7 @@
           "price": 0.00002
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.000088
         }
       }
     }
@@ -727,7 +727,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00004
         },
         "response_token": {
           "price": 0.0002
@@ -874,10 +874,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000029
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.0001
         }
       }
     }
@@ -898,10 +898,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000023
         },
         "response_token": {
-          "price": 0.00029
+          "price": 0.00023
         }
       }
     }
@@ -934,7 +934,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000014
+          "price": 0.000009
         },
         "response_token": {
           "price": 0.00011
@@ -970,7 +970,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000012
         },
         "response_token": {
           "price": 0.000024
@@ -994,10 +994,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.000032
         }
       }
     }
@@ -1117,7 +1117,7 @@
           "price": 0.0000071
         },
         "response_token": {
-          "price": 0.0000463
+          "price": 0.00001
         }
       }
     }
@@ -1150,7 +1150,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000038
+          "price": 0.000032
         },
         "response_token": {
           "price": 0.000089
@@ -1252,7 +1252,7 @@
           "price": 0.000043
         },
         "response_token": {
-          "price": 0.000175
+          "price": 0.000174
         },
         "cache_read_input_token": {
           "price": 0.00000799999993
@@ -1348,10 +1348,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.00008
         }
       }
     }
@@ -1447,7 +1447,7 @@
           "price": 0.000008
         },
         "response_token": {
-          "price": 0.000029
+          "price": 0.000028
         }
       }
     }
@@ -1468,7 +1468,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000009
+          "price": 0.000008
         },
         "response_token": {
           "price": 0.000016
@@ -1504,7 +1504,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000008
         },
         "response_token": {
           "price": 0.000028
@@ -1580,6 +1580,258 @@
         },
         "response_token": {
           "price": 0.00825
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3-Max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00012
+        },
+        "response_token": {
+          "price": 0.0006
+        },
+        "cache_read_input_token": {
+          "price": 0.000024
+        }
+      }
+    }
+  },
+  "Bria/fibo_edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "allenai/Olmo-3.1-32B-Instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "black-forest-labs/FLUX-2-klein-4b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00008
+        },
+        "response_token": {
+          "price": 0.000256
+        },
+        "cache_read_input_token": {
+          "price": 0.000016
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3-Max-Thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00012
+        },
+        "response_token": {
+          "price": 0.0006
+        },
+        "cache_read_input_token": {
+          "price": 0.000024
+        }
+      }
+    }
+  },
+  "zai-org/GLM-4.7-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000006
+        },
+        "response_token": {
+          "price": 0.00004
+        },
+        "cache_read_input_token": {
+          "price": 0.00000100000002
+        }
+      }
+    }
+  },
+  "zai-org/GLM-4.7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.000175
+        },
+        "cache_read_input_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "MiniMaxAI/MiniMax-M2.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000027
+        },
+        "response_token": {
+          "price": 0.000095
+        },
+        "cache_read_input_token": {
+          "price": 0.00000299999997
+        }
+      }
+    }
+  },
+  "moonshotai/Kimi-K2.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000225
+        },
+        "cache_read_input_token": {
+          "price": 0.0000070000002
+        }
+      }
+    }
+  },
+  "ClarityAI/crystal": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "black-forest-labs/FLUX-2-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "ClarityAI/flux": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "black-forest-labs/FLUX-2-klein-9b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "nvidia/Nemotron-3-Nano-30B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "deepseek-ai/DeepSeek-V3.2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        }
+      }
+    }
+  },
+  "ByteDance/Seedream-4.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "zai-org/GLM-4.6V": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "ClarityAI/creative": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Models Update: deepinfra

### 📊 Summary

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 19 |
| 🔄 Prices updated | 18 |


### ➕ New Models
- `Qwen/Qwen3-Max`
- `Bria/fibo_edit`
- `allenai/Olmo-3.1-32B-Instruct`
- `black-forest-labs/FLUX-2-klein-4b`
- `zai-org/GLM-5`
- `Qwen/Qwen3-Max-Thinking`
- `zai-org/GLM-4.7-Flash`
- `zai-org/GLM-4.7`
- `MiniMaxAI/MiniMax-M2.1`
- `moonshotai/Kimi-K2.5`
- `ClarityAI/crystal`
- `black-forest-labs/FLUX-2-max`
- `ClarityAI/flux`
- `black-forest-labs/FLUX-2-klein-9b`
- `nvidia/Nemotron-3-Nano-30B-A3B`
- `deepseek-ai/DeepSeek-V3.2`
- `ByteDance/Seedream-4.5`
- `zai-org/GLM-4.6V`
- `ClarityAI/creative`

### 🔄 Updated Prices
- `Qwen/Qwen3-30B-A3B`
- `moonshotai/Kimi-K2-Instruct-0905`
- `Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo`
- `zai-org/GLM-4.6`
- `Gryphe/MythoMax-L2-13b`
- `Qwen/Qwen3-32B`
- `Qwen/Qwen3-235B-A22B-Instruct-2507`
- `deepseek-ai/DeepSeek-V3`
- `meta-llama/Meta-Llama-3-8B-Instruct`
- `Qwen/Qwen3-Next-80B-A3B-Instruct`
- `Qwen/Qwen3-235B-A22B-Thinking-2507`
- `deepseek-ai/DeepSeek-V3-0324`
- `google/gemma-3-27b-it`
- `Qwen/Qwen3-VL-235B-A22B-Instruct`
- `Qwen/Qwen3-14B`
- `meta-llama/Meta-Llama-3.1-8B-Instruct`
- `deepseek-ai/DeepSeek-R1-Distill-Llama-70B`
- `meta-llama/Llama-3.3-70B-Instruct-Turbo`



---
*Generated by Direct Converter on 2026-02-17*