### PR TITLE
fixing the gemini and vertex pricing

### DIFF
--- a/pricing/google.json
+++ b/pricing/google.json
@@ -910,9 +910,6 @@
           "price": 0.001
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.001
-          },
           "web_search": {
             "price": 3.5
           },
@@ -941,9 +938,6 @@
           "price": 0.0015
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.001
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1084,9 +1078,6 @@
           "price": 0.00006
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00035
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1115,10 +1106,7 @@
           "price": 0.00006
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00035
-          },
-          "web_search": {
+         "web_search": {
             "price": 3.5
           },
           "search": {
@@ -1282,9 +1270,6 @@
           "price": 0.00006
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00035
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1313,9 +1298,6 @@
           "price": 0.00006
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00035
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1344,9 +1326,6 @@
           "price": 0.00004
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00004
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1375,9 +1354,6 @@
           "price": 0.00004
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00004
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1406,9 +1382,6 @@
           "price": 0.00025
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00025
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1437,9 +1410,6 @@
           "price": 0.00025
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00025
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1468,9 +1438,6 @@
           "price": 0.00004
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00004
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1539,9 +1506,6 @@
           "price": 0.00025
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00025
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1570,9 +1534,6 @@
           "price": 0.00025
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00025
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1601,9 +1562,6 @@
           "price": 0.0012
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.0012
-          },
           "web_search": {
             "price": 1.4
           },
@@ -1635,9 +1593,6 @@
           "price": 0.0012
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.0012
-          },
           "web_search": {
             "price": 1.4
           },
@@ -1893,9 +1848,6 @@
           "price": 0.00025
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00025
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1924,9 +1876,6 @@
           "price": 0.00025
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00025
-          },
           "web_search": {
             "price": 3.5
           },

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -1251,9 +1251,6 @@
           "price": 0.00006
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00035
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1282,9 +1279,6 @@
           "price": 0.00006
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00035
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1425,9 +1419,6 @@
           "price": 0.00004
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00004
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1456,9 +1447,6 @@
           "price": 0.00025
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00025
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1492,9 +1480,6 @@
           "price": 0.00025
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00025
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1528,9 +1513,6 @@
           "price": 0.0012
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.0012
-          },
           "web_search": {
             "price": 1.4
           },
@@ -1564,9 +1546,6 @@
           "price": 0.001
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.001
-          },
           "web_search": {
             "price": 3.5
           },
@@ -1600,9 +1579,6 @@
           "price": 0.00004
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00004
-          },
           "web_search": {
             "price": 3.5
           },
@@ -2451,9 +2427,6 @@
           "price": 0.00025
         },
         "additional_units": {
-          "thinking_token": {
-            "price": 0.00025
-          },
           "web_search": {
             "price": 3.5
           },


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- [ ] New model pricing
- [x] Update existing pricing
- [ ] New model configuration
- [ ] Bug fix

## Source Verification

**Source Link:**
Gemini link which shows both are included in completion tokens - https://ai.google.dev/gemini-api/docs/pricing#gemini-3-pro-image-preview
Vertex: https://cloud.google.com/vertex-ai/generative-ai/pricing

> [!IMPORTANT]
> Please include a link to the official pricing page from the provider. Simple "I heard it from somewhere" or screenshot sources are not accepted.

## Checklist

- [x] I have validated the JSON using `jq` or an online validator
- [ ] I have verified that prices are in **cents per token** (not dollars)
- [ ] I have included the source link above
- [ ] I have signed the CLA (if first-time contributor)

## Related Issue

Fixes # (issue)
