### PR TITLE
chore(pricing): Update deepinfra pricing

### DIFF
--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -1835,5 +1835,98 @@
         }
       }
     }
+  },
+  "ByteDance/Seed-2.0-mini": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00004
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.6-T2I": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-1.8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0002
+        },
+        "cache_read_input_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.6-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "MiniMaxAI/MiniMax-M2.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000027
+        },
+        "response_token": {
+          "price": 0.000095
+        },
+        "cache_read_input_token": {
+          "price": 0.00000299999997
+        }
+      }
+    }
+  },
+  "Qwen/Qwen-Image-Edit-Max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen-Image-Max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## 🔄 Models Update: deepinfra

### 📊 Summary

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 7 |
| 🔄 Prices updated | 0 |


### ➕ New Models
- `ByteDance/Seed-2.0-mini`
- `Wan-AI/Wan2.6-T2I`
- `ByteDance/Seed-1.8`
- `Wan-AI/Wan2.6-Image-Edit`
- `MiniMaxAI/MiniMax-M2.5`
- `Qwen/Qwen-Image-Edit-Max`
- `Qwen/Qwen-Image-Max`




---
*Generated by Direct Converter on 2026-02-19*