### PR TITLE
chore(pricing): Update mistral-ai pricing

### DIFF
--- a/general/mistral-ai.json
+++ b/general/mistral-ai.json
@@ -348,5 +348,15 @@
     "type": {
       "primary": "embedding"
     }
+  },
+  "mistral-small-2603": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "labs-leanstral-2603": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/mistral-ai.json
+++ b/pricing/mistral-ai.json
@@ -196,10 +196,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0006
         }
       }
     }

--- a/pricing/mistral-ai.json
+++ b/pricing/mistral-ai.json
@@ -196,10 +196,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0006
         }
       }
     }
@@ -400,10 +400,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00003
         }
       }
     }

--- a/pricing/mistral-ai.json
+++ b/pricing/mistral-ai.json
@@ -196,10 +196,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00015
         }
       }
     }

--- a/pricing/mistral-ai.json
+++ b/pricing/mistral-ai.json
@@ -124,10 +124,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00006
         }
       }
     }
@@ -196,10 +196,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00015
         }
       }
     }
@@ -304,10 +304,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.0002
         }
       }
     }
@@ -316,10 +316,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.0002
         }
       }
     }
@@ -400,10 +400,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00006
         }
       }
     }
@@ -448,10 +448,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000004
+          "price": 0.00001
         }
       }
     }
@@ -472,10 +472,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000015
         }
       }
     }
@@ -496,10 +496,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -604,10 +604,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "mistral-vibe-cli-fast": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -616,142 +628,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0
         },
         "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "leanstral-latest": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "magistral-medium-2507": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0005
-        }
-      }
-    }
-  },
-  "magistral-small-2507": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
-  "magistral-medium-2506": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0005
-        }
-      }
-    }
-  },
-  "magistral-small-2506": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
-  "mistral-small-2503": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "codestral-2501": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00009
-        }
-      }
-    }
-  },
-  "ministral-3b-2410": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.000004
-        }
-      }
-    }
-  },
-  "ministral-8b-2410": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "pixtral-12b-2409": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "mistral-small-2409": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
+          "price": 0
         }
       }
     }

--- a/pricing/mistral-ai.json
+++ b/pricing/mistral-ai.json
@@ -124,10 +124,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000006
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.000018
         }
       }
     }
@@ -400,10 +400,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000006
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000018
         }
       }
     }
@@ -412,10 +412,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000006
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000018
         }
       }
     }
@@ -520,10 +520,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00003
         }
       }
     }
@@ -532,10 +532,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00003
         }
       }
     }
@@ -544,10 +544,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00003
         }
       }
     }
@@ -556,10 +556,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00003
         }
       }
     }
@@ -604,10 +604,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000006
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.000018
         }
       }
     }
@@ -616,22 +616,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000006
         },
         "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "labs-leanstral-2603": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.000018
         }
       }
     }

--- a/pricing/mistral-ai.json
+++ b/pricing/mistral-ai.json
@@ -196,10 +196,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00015
         }
       }
     }
@@ -400,10 +400,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00006
         }
       }
     }
@@ -620,6 +620,18 @@
         },
         "response_token": {
           "price": 0.00006
+        }
+      }
+    }
+  },
+  "labs-leanstral-2603": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/mistral-ai.json
+++ b/pricing/mistral-ai.json
@@ -124,10 +124,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00003
         }
       }
     }
@@ -304,10 +304,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00003
         }
       }
     }
@@ -316,10 +316,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00003
         }
       }
     }
@@ -448,10 +448,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000004
         }
       }
     }
@@ -472,10 +472,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }
@@ -496,10 +496,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -604,22 +604,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "mistral-vibe-cli-fast": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
+          "price": 0.00003
         }
       }
     }
@@ -628,10 +616,142 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "leanstral-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "magistral-medium-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "magistral-small-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "magistral-medium-2506": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "magistral-small-2506": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "mistral-small-2503": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "codestral-2501": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "ministral-3b-2410": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.000004
+        }
+      }
+    }
+  },
+  "ministral-8b-2410": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "pixtral-12b-2409": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "mistral-small-2409": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }

--- a/pricing/mistral-ai.json
+++ b/pricing/mistral-ai.json
@@ -124,10 +124,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00006
         }
       }
     }
@@ -593,6 +593,42 @@
       "pay_as_you_go": {
         "request_token": {
           "price": 0.000015
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-small-2603": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "mistral-vibe-cli-fast": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "labs-leanstral-2603": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
         },
         "response_token": {
           "price": 0

--- a/pricing/mistral-ai.json
+++ b/pricing/mistral-ai.json
@@ -124,10 +124,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000006
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000018
+          "price": 0.00003
         }
       }
     }
@@ -172,10 +172,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0006
         }
       }
     }
@@ -184,10 +184,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0006
         }
       }
     }
@@ -304,10 +304,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00003
         }
       }
     }
@@ -316,10 +316,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00003
         }
       }
     }
@@ -340,10 +340,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00003
         }
       }
     }
@@ -400,10 +400,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000006
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000018
+          "price": 0.00003
         }
       }
     }
@@ -412,10 +412,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000006
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000018
+          "price": 0.00003
         }
       }
     }
@@ -448,10 +448,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000004
         }
       }
     }
@@ -460,10 +460,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000004
         }
       }
     }
@@ -472,10 +472,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }
@@ -484,10 +484,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }
@@ -496,10 +496,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000015
         }
       }
     }
@@ -508,10 +508,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000015
         }
       }
     }
@@ -520,10 +520,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000015
         }
       }
     }
@@ -532,10 +532,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000015
         }
       }
     }
@@ -544,10 +544,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000015
         }
       }
     }
@@ -556,10 +556,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000015
         }
       }
     }
@@ -604,22 +604,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000006
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000018
+          "price": 0.00003
         }
       }
     }
   },
-  "mistral-vibe-cli-fast": {
+  "labs-leanstral-2603": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000006
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000018
+          "price": 0.00003
         }
       }
     }

--- a/pricing/mistral-ai.json
+++ b/pricing/mistral-ai.json
@@ -196,10 +196,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0006
         }
       }
     }
@@ -620,18 +620,6 @@
         },
         "response_token": {
           "price": 0.00006
-        }
-      }
-    }
-  },
-  "labs-leanstral-2603": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: mistral-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 12 |

### ➕ New Models
- `mistral-small-2603`
- `labs-leanstral-2603`

### 🔄 Updated Models
- `mistral-large-2512`
- `mistral-large-latest`
- `mistral-large-2411`
- `ministral-3b-2512`
- `ministral-3b-latest`
- `ministral-8b-2512`
- `ministral-8b-latest`
- `ministral-14b-2512`
- `ministral-14b-latest`
- `devstral-2512`
- `devstral-latest`
- `mistral-vibe-cli-latest`


## Model → Pricing Family Mapping

| Model ID | Pricing Family | Input ($/MTok) | Output ($/MTok) |
|---|---|---|---|
| mistral-large-2512, mistral-large-latest, mistral-large-2411 | Mistral Large 3 / 2.1 | $2.00 | $6.00 |
| pixtral-large-2411, pixtral-large-latest | Pixtral Large | $2.00 | $6.00 |
| mistral-medium-2508, mistral-medium-latest, mistral-medium-2505 | Mistral Medium 3.1 / 3 | $0.40 | $2.00 |
| magistral-medium-2509, magistral-medium-latest | Magistral Medium 1.2 | $2.00 | $5.00 |
| magistral-small-2509, magistral-small-latest | Magistral Small 1.2 | $0.50 | $1.50 |
| codestral-2508, codestral-latest | Codestral | $0.30 | $0.90 |
| mistral-small-2603, mistral-small-latest, mistral-small-2506 | Mistral Small 4 / 3.2 | $0.10 | $0.30 |
| ministral-3b-2512, ministral-3b-latest | Ministral 3 3B | $0.04 | $0.04 |
| ministral-8b-2512, ministral-8b-latest | Ministral 3 8B | $0.10 | $0.10 |
| ministral-14b-2512, ministral-14b-latest | Ministral 3 14B | $0.15 | $0.15 |
| open-mistral-nemo, open-mistral-nemo-2407 | Mistral Nemo | $0.15 | $0.15 |
| devstral-2512, devstral-latest, devstral-small-2507 | Devstral 2 / Small | $0.10 | $0.30 |
| devstral-medium-2507 | Devstral Medium 1.0 | $0.40 | $2.00 |
| labs-leanstral-2603 | Labs (Small tier) | $0.10 | $0.30 |
| labs-mistral-small-creative | Mistral Small Creative | $0.10 | $0.30 |
| mistral-embed-2312, mistral-embed | Mistral Embed | $0.10 | — |
| codestral-embed-2505, codestral-embed | Codestral Embed | $0.15 | — |
| mistral-vibe-cli-latest | Vibe CLI (Small tier) | $0.10 | $0.30 |
| mistral-tiny-2407, mistral-tiny-latest | Mistral Tiny (Nemo tier) | $0.15 | $0.15 |

**Data sources:** Mistral Models API (43 models fetched) + `https://docs.mistral.ai/getting-started/models/models_overview/` (pricing extracted from Next.js RSC payload)

---
*Generated by Pricing Agent on 2026-04-07*