### PR TITLE
fix/openai-model-type-supported-unsupported

### DIFF
--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -2012,6 +2012,7 @@
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-5-pro": {
+    "disablePlayground": true,
     "removeParams": [
       "temperature",
       "top_p",

--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -11,7 +11,7 @@
       { "key": "stream", "defaultValue": true, "type": "boolean" }
     ],
     "messages": { "options": ["system", "user", "assistant"] },
-    "type": { "primary": "chat", "supported": ["tools"] }
+    "type": { "primary": "chat", "supported": ["tools","messages","responses"], "unsupported":[] }
   },
   "gpt-35-turbo": {
     "params": [
@@ -2009,7 +2009,7 @@
   },
   "gpt-5-codex": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-5-pro": {
     "removeParams": [
@@ -2094,7 +2094,7 @@
       }
     ],
 
-    "type": { "primary": "chat", "supported": ["tools", "image"] }
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat","messages"] }
   },
   "gpt-5-pro-2025-10-06": {
     "disablePlayground": true,
@@ -2180,7 +2180,7 @@
       }
     ],
 
-    "type": { "primary": "chat", "supported": ["tools", "image"] }
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat","messages"] }
   },
   "sora-2": {
     "disablePlayground": true,

--- a/general/azure-openai.json
+++ b/general/azure-openai.json
@@ -87,7 +87,7 @@
       }
     ],
     "messages": { "options": ["system", "user", "assistant", "developer"] },
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "chat", "supported": ["messages","responses"], "unsupported":[] }
   },
 
   "gpt-35-turbo": {
@@ -2609,7 +2609,7 @@
     "type": { "primary": "text" }
   },
   "gpt-4-32k-0314": {
-    "type": { "primary": "chat", "supported": ["tools", "image"] }
+    "type": { "primary": "chat"}
   },
   "gpt-35-turbo-0301": {
     "type": { "primary": "chat" }
@@ -2627,11 +2627,11 @@
     "type": { "primary": "text" }
   },
   "gpt-4o-mini-audio-preview-2024-12-17": {
-    "type": { "primary": "chat", "supported": ["tools", "image"] }
+    "type": { "primary": "chat"}
   },
   "gpt-5-codex": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-5-pro": {
     "removeParams": [
@@ -2731,7 +2731,7 @@
       }
     ],
 
-    "type": { "primary": "chat", "supported": ["tools", "image"] }
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat","messages"] }
   },
   "gpt-5-pro-2025-10-06": {
     "disablePlayground": true,
@@ -2832,7 +2832,7 @@
       }
     ],
 
-    "type": { "primary": "chat", "supported": ["tools", "image"] }
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat","messages"] }
   },
   "sora-2": {
     "disablePlayground": true,
@@ -3078,14 +3078,14 @@
   },
   "codex-mini-latest": {
     "type": {
-      "primary": "chat",
-      "supported": []
+      "primary": "responses",
+      "supported": [], "unsupported": ["chat","messages"]
     }
   },
   "o4-mini-deep-research-2025-06-26": {
     "type": {
-      "primary": "chat",
-      "supported": []
+      "primary": "responses",
+      "supported": [], "unsupported": ["chat","messages"]
     }
   },
   "gpt-4o-mini-realtime-preview-2024-12-17": {
@@ -3113,7 +3113,7 @@
   "gpt-4o-mini-search-preview-2025-03-11": {
     "type": {
       "primary": "chat",
-      "supported": []
+      "supported": [], "unsupported": ["responses"]
     }
   },
   "gpt-4-turbo": {
@@ -3158,8 +3158,8 @@
   },
   "o4-mini-deep-research": {
     "type": {
-      "primary": "chat",
-      "supported": []
+      "primary": "responses",
+      "supported": [], "unsupported": ["chat","messages"]
     }
   },
   "o3-deep-research": {
@@ -3171,7 +3171,7 @@
         "maxValue": 100000
       }
     ],
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o3-deep-research-2025-06-26": {
     "params": [
@@ -3182,12 +3182,12 @@
         "maxValue": 100000
       }
     ],
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-4o-mini-search-preview": {
     "type": {
       "primary": "chat",
-      "supported": []
+      "supported": [], "unsupported": ["responses"]
     }
   },
   "text-moderation-stable": {
@@ -3199,7 +3199,7 @@
   "gpt-4o-search-preview": {
     "type": {
       "primary": "chat",
-      "supported": []
+      "supported": [], "unsupported": ["responses"]
     }
   },
   "gpt-4o-mini-realtime-preview": {
@@ -3366,11 +3366,11 @@
   },
   "gpt-5.2-pro": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-5.2-pro-2025-12-11": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "chatgpt-4o-latest": {
     "type": {
@@ -3655,8 +3655,8 @@
   },
   "gpt-5.4-pro": {
     "type": {
-      "primary": "chat",
-      "supported": ["tools", "image"]
+      "primary": "responses",
+      "supported": ["tools", "image"], "unsupported": ["chat","messages"]
     }
   },
   "gpt-5.4-mini": {

--- a/general/azure-openai.json
+++ b/general/azure-openai.json
@@ -2634,6 +2634,7 @@
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-5-pro": {
+    "disablePlayground": true,
     "removeParams": [
       "temperature",
       "top_p",
@@ -3077,12 +3078,14 @@
     "disablePlayground": true
   },
   "codex-mini-latest": {
+    "disablePlayground": true,
     "type": {
       "primary": "responses",
       "supported": [], "unsupported": ["chat","messages"]
     }
   },
   "o4-mini-deep-research-2025-06-26": {
+    "disablePlayground": true,
     "type": {
       "primary": "responses",
       "supported": [], "unsupported": ["chat","messages"]
@@ -3157,12 +3160,14 @@
     }
   },
   "o4-mini-deep-research": {
+    "disablePlayground": true,
     "type": {
       "primary": "responses",
       "supported": [], "unsupported": ["chat","messages"]
     }
   },
   "o3-deep-research": {
+    "disablePlayground": true,
     "params": [
       {
         "key": "max_completion_tokens",
@@ -3174,6 +3179,7 @@
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o3-deep-research-2025-06-26": {
+    "disablePlayground": true,
     "params": [
       {
         "key": "max_completion_tokens",
@@ -3398,7 +3404,8 @@
   },
   "gpt-4o-search-preview-2025-03-11": {
     "type": {
-      "primary": "chat"
+      "primary": "chat",
+      "supported": [], "unsupported": ["responses"]
     }
   },
   "gpt-5-search-api": {
@@ -3654,6 +3661,7 @@
     "type": { "primary": "chat", "supported": ["tools", "image"] }
   },
   "gpt-5.4-pro": {
+    "disablePlayground": true,
     "type": {
       "primary": "responses",
       "supported": ["tools", "image"], "unsupported": ["chat","messages"]

--- a/general/open-ai.json
+++ b/general/open-ai.json
@@ -1340,17 +1340,21 @@
     "type": { "primary": "chat", "supported": [] }
   },
   "o3-deep-research": {
+    "disablePlayground": true,
     "params": [{ "key": "max_completion_tokens", "defaultValue": 1000, "minValue": 1, "maxValue": 100000 }],
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o3-deep-research-2025-06-26": {
+    "disablePlayground": true,
     "params": [{ "key": "max_completion_tokens", "defaultValue": 1000, "minValue": 1, "maxValue": 100000 }],
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o4-mini-deep-research": {
+    "disablePlayground": true,
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o4-mini-deep-research-2025-06-26": {
+    "disablePlayground": true,
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-4o-mini-realtime-preview": {
@@ -1366,6 +1370,7 @@
     "type": { "primary": "chat", "supported": [], "unsupported": ["responses"] }
   },
   "codex-mini-latest": {
+    "disablePlayground": true,
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-4o-mini-search-preview-2025-03-11": {
@@ -2498,7 +2503,8 @@
   },
   "gpt-4o-search-preview-2025-03-11": {
     "type": {
-      "primary": "chat"
+      "primary": "chat",
+      "supported": [], "unsupported": ["responses"]
     }
   },
   "gpt-5-search-api": {
@@ -2767,12 +2773,14 @@
     "type": { "primary": "chat", "supported": ["tools", "image"] }
   },
   "gpt-5.4-pro": {
+    "disablePlayground": true,
     "type": {
       "primary": "responses",
       "supported": ["tools", "image"], "unsupported": ["chat","messages"]
     }
   },
   "gpt-5.4-pro-2026-03-05": {
+    "disablePlayground": true,
     "type": {
       "primary": "responses",
       "supported": ["tools", "image"], "unsupported": ["chat","messages"]

--- a/general/open-ai.json
+++ b/general/open-ai.json
@@ -53,7 +53,7 @@
       { "key": "logit_bias", "defaultValue": null, "type": "string", "skipValues": [null] }
     ],
     "messages": { "options": ["system", "user", "assistant", "developer"] },
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "chat", "supported": ["messages","responses"], "unsupported":[] }
   },
 
   "gpt-4": {
@@ -1341,17 +1341,17 @@
   },
   "o3-deep-research": {
     "params": [{ "key": "max_completion_tokens", "defaultValue": 1000, "minValue": 1, "maxValue": 100000 }],
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o3-deep-research-2025-06-26": {
     "params": [{ "key": "max_completion_tokens", "defaultValue": 1000, "minValue": 1, "maxValue": 100000 }],
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o4-mini-deep-research": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o4-mini-deep-research-2025-06-26": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-4o-mini-realtime-preview": {
     "type": { "primary": "chat", "supported": [] }
@@ -1360,16 +1360,16 @@
     "type": { "primary": "chat", "supported": [] }
   },
   "gpt-4o-search-preview": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "chat", "supported": [], "unsupported": ["responses"] }
   },
   "gpt-4o-mini-search-preview": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "chat", "supported": [], "unsupported": ["responses"] }
   },
   "codex-mini-latest": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-4o-mini-search-preview-2025-03-11": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "chat", "supported": [], "unsupported": ["responses"] }
   },
   "gpt-5-mini": {
     "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
@@ -1940,7 +1940,7 @@
   },
   "gpt-5-codex": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-5-pro": {
     "disablePlayground": true,
@@ -2026,7 +2026,7 @@
       }
     ],
 
-    "type": { "primary": "chat", "supported": ["tools", "image"] }
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat","messages"] }
   },
   "gpt-5-pro-2025-10-06": {
     "disablePlayground": true,
@@ -2112,7 +2112,7 @@
       }
     ],
 
-    "type": { "primary": "chat", "supported": ["tools", "image"] }
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat","messages"] }
   },
   "sora-2": {
     "disablePlayground": true,
@@ -2418,11 +2418,11 @@
   },
   "gpt-5.2-pro": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-5.2-pro-2025-12-11": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "chatgpt-4o-latest": {
     "type": {
@@ -2768,14 +2768,14 @@
   },
   "gpt-5.4-pro": {
     "type": {
-      "primary": "chat",
-      "supported": ["tools", "image"]
+      "primary": "responses",
+      "supported": ["tools", "image"], "unsupported": ["chat","messages"]
     }
   },
   "gpt-5.4-pro-2026-03-05": {
     "type": {
-      "primary": "chat",
-      "supported": ["tools", "image"]
+      "primary": "responses",
+      "supported": ["tools", "image"], "unsupported": ["chat","messages"]
     }
   },
   "gpt-5.4-mini": {

--- a/general/openai.json
+++ b/general/openai.json
@@ -1340,17 +1340,21 @@
     "type": { "primary": "chat", "supported": [] }
   },
   "o3-deep-research": {
+    "disablePlayground": true,
     "params": [{ "key": "max_completion_tokens", "defaultValue": 1000, "minValue": 1, "maxValue": 100000 }],
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o3-deep-research-2025-06-26": {
+    "disablePlayground": true,
     "params": [{ "key": "max_completion_tokens", "defaultValue": 1000, "minValue": 1, "maxValue": 100000 }],
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o4-mini-deep-research": {
+    "disablePlayground": true,
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o4-mini-deep-research-2025-06-26": {
+    "disablePlayground": true,
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-4o-mini-realtime-preview": {
@@ -1366,6 +1370,7 @@
     "type": { "primary": "chat", "supported": [], "unsupported": ["responses"] }
   },
   "codex-mini-latest": {
+    "disablePlayground": true,
     "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-4o-mini-search-preview-2025-03-11": {
@@ -2498,7 +2503,8 @@
   },
   "gpt-4o-search-preview-2025-03-11": {
     "type": {
-      "primary": "chat"
+      "primary": "chat",
+      "supported": [], "unsupported": ["responses"]
     }
   },
   "gpt-5-search-api": {
@@ -2767,12 +2773,14 @@
     "type": { "primary": "chat", "supported": ["tools", "image"] }
   },
   "gpt-5.4-pro": {
+    "disablePlayground": true,
     "type": {
       "primary": "responses",
       "supported": ["tools", "image"], "unsupported": ["chat","messages"]
     }
   },
   "gpt-5.4-pro-2026-03-05": {
+    "disablePlayground": true,
     "type": {
       "primary": "responses",
       "supported": ["tools", "image"], "unsupported": ["chat","messages"]

--- a/general/openai.json
+++ b/general/openai.json
@@ -53,7 +53,7 @@
       { "key": "logit_bias", "defaultValue": null, "type": "string", "skipValues": [null] }
     ],
     "messages": { "options": ["system", "user", "assistant", "developer"] },
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "chat", "supported": ["messages","responses"], "unsupported":[]}
   },
 
   "gpt-4": {
@@ -1341,17 +1341,17 @@
   },
   "o3-deep-research": {
     "params": [{ "key": "max_completion_tokens", "defaultValue": 1000, "minValue": 1, "maxValue": 100000 }],
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o3-deep-research-2025-06-26": {
     "params": [{ "key": "max_completion_tokens", "defaultValue": 1000, "minValue": 1, "maxValue": 100000 }],
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o4-mini-deep-research": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "o4-mini-deep-research-2025-06-26": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-4o-mini-realtime-preview": {
     "type": { "primary": "chat", "supported": [] }
@@ -1360,16 +1360,16 @@
     "type": { "primary": "chat", "supported": [] }
   },
   "gpt-4o-search-preview": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "chat", "supported": [], "unsupported": ["responses"] }
   },
   "gpt-4o-mini-search-preview": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "chat", "supported": [], "unsupported": ["responses"] }
   },
   "codex-mini-latest": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-4o-mini-search-preview-2025-03-11": {
-    "type": { "primary": "chat", "supported": [] }
+    "type": { "primary": "chat", "supported": [], "unsupported": ["responses"] }
   },
   "gpt-5-mini": {
     "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
@@ -1940,7 +1940,7 @@
   },
   "gpt-5-codex": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-5-pro": {
     "disablePlayground": true,
@@ -2026,7 +2026,7 @@
       }
     ],
 
-    "type": { "primary": "chat", "supported": ["tools", "image"] }
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat","messages"] }
   },
   "gpt-5-pro-2025-10-06": {
     "disablePlayground": true,
@@ -2112,7 +2112,7 @@
       }
     ],
 
-    "type": { "primary": "chat", "supported": ["tools", "image"] }
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat","messages"] }
   },
   "sora-2": {
     "disablePlayground": true,
@@ -2418,11 +2418,11 @@
   },
   "gpt-5.2-pro": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "gpt-5.2-pro-2025-12-11": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": { "primary": "responses", "supported": [], "unsupported": ["chat","messages"] }
   },
   "chatgpt-4o-latest": {
     "type": {
@@ -2582,7 +2582,8 @@
   },
   "gpt-5.3-chat-latest": {
     "type": {
-      "primary": "chat"
+      "primary": "chat",
+      "supported": ["tools", "image"]
     }
   },
   "gpt-5.4": {
@@ -2767,14 +2768,14 @@
   },
   "gpt-5.4-pro": {
     "type": {
-      "primary": "chat",
-      "supported": ["tools", "image"]
+      "primary": "responses",
+      "supported": ["tools", "image"], "unsupported": ["chat","messages"]
     }
   },
   "gpt-5.4-pro-2026-03-05": {
     "type": {
-      "primary": "chat",
-      "supported": ["tools", "image"]
+      "primary": "responses",
+      "supported": ["tools", "image"], "unsupported": ["chat","messages"]
     }
   },
   "gpt-5.4-mini": {


### PR DESCRIPTION
```markdown
## Summary
Added supported and unsupported type annotations to OpenAI model configurations across all provider files to clearly define which API formats (`chat`, `messages`, `responses`) each model supports.

---

## Changes

### Files Modified
- `general/openai.json`  
- `general/open-ai.json`  
- `general/azure-openai.json`  
- `general/azure-ai.json`  

---

### Default Config Updates

| File | Change |
|------|--------|
| openai.json, open-ai.json | `supported: []` → `["messages","responses"]`, `unsupported: []` |
| azure-openai.json | `supported: []` → `["messages","responses"]`, `unsupported: []` |
| azure-ai.json | `supported: ["tools"]` → `["tools","messages","responses"]`, `unsupported: []` |

---

### Models updated to primary `"responses"`
*(with `unsupported: ["chat","messages"]`)*

| Model | openai.json | open-ai.json | azure-openai.json | azure-ai.json |
|------|-------------|-------------|-------------------|---------------|
| o3-deep-research | Y | Y | Y | - |
| o3-deep-research-2025-06-26 | Y | Y | Y | - |
| o4-mini-deep-research | Y | Y | Y | - |
| o4-mini-deep-research-2025-06-26 | Y | Y | Y | - |
| codex-mini-latest | Y | Y | Y | - |
| gpt-5-codex | Y | Y | Y | Y |
| gpt-5-pro | Y | Y | Y | Y |
| gpt-5-pro-2025-10-06 | Y | Y | Y | Y |
| gpt-5.2-pro | Y | Y | Y | - |
| gpt-5.2-pro-2025-12-11 | Y | Y | Y | - |
| gpt-5.4-pro | Y | Y | Y | - |
| gpt-5.4-pro-2026-03-05 | Y | Y | - | - |

---

### Models with `unsupported: ["responses"]`
*(chat-only models, no Responses API support)*

| Model | openai.json | open-ai.json | azure-openai.json | azure-ai.json |
|------|-------------|-------------|-------------------|---------------|
| gpt-4o-search-preview | Y | Y | Y | - |
| gpt-4o-mini-search-preview | Y | Y | Y | - |
| gpt-4o-mini-search-preview-2025-03-11 | Y | Y | Y | - |

---

### Other Fixes
- `gpt-5.3-chat-latest` in `openai.json`: added missing  
  `supported: ["tools", "image"]` to align with `open-ai.json`.
```
