### PR TITLE
chore: Update deepinfra pricing and config

### DIFF
--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,39 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,22 +1246,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
@@ -1238,31 +1254,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1278,15 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,39 +1190,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,7 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1222,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1230,31 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1270,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1279,14 @@
     }
   },
   "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,14 +1190,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
@@ -1206,7 +1198,15 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1230,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,7 +1246,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1254,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1262,15 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1279,14 +1287,6 @@
     }
   },
   "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,47 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1214,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1230,47 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,71 +1190,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1206,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1230,63 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,23 @@
       ]
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,31 +1222,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,6 +1246,14 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
@@ -1262,7 +1262,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1278,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,6 +1190,14 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
@@ -1198,31 +1206,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1231,22 +1215,6 @@
     }
   },
   "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,14 +1238,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1246,47 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,23 +1190,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,6 +1206,14 @@
       ]
     }
   },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
@@ -1230,47 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1238,55 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,7 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,38 +1214,6 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
@@ -1254,7 +1222,31 @@
       ]
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1270,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1279,14 @@
     }
   },
   "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,79 +1190,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,6 +1206,30 @@
       ]
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1238,55 @@
       ]
     }
   },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,79 +1190,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,6 +1206,38 @@
       ]
     }
   },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1246,47 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,14 +1190,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
@@ -1206,47 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1214,47 @@
       ]
     }
   },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1270,15 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,55 +1190,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1214,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,6 +1238,22 @@
       ]
     }
   },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1262,31 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,38 +1190,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
@@ -1230,7 +1198,15 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1230,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1254,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1270,23 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,31 +1190,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,23 +1206,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1230,15 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1254,39 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,15 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,15 +1206,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,23 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,15 +1238,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1247,46 @@
     }
   },
   "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,39 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1231,6 +1199,14 @@
     }
   },
   "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1230,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1238,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1246,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1262,31 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,7 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,7 +1206,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,7 +1222,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1230,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1254,15 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1278,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,15 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,15 +1190,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,55 +1206,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1230,63 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,7 +1198,15 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,7 +1222,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,7 +1230,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1231,6 +1247,30 @@
     }
   },
   "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1247,46 +1287,6 @@
     }
   },
   "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,23 +1190,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,6 +1222,30 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
@@ -1230,7 +1254,23 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1247,46 +1287,6 @@
     }
   },
   "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,6 +1190,14 @@
       ]
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
@@ -1198,7 +1206,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,15 +1214,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1230,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1262,23 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1263,30 +1287,6 @@
     }
   },
   "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,7 +1198,23 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,39 +1230,15 @@
       ]
     }
   },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,6 +1262,22 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
@@ -1278,15 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,31 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,7 +1214,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,7 +1222,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1230,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,6 +1254,22 @@
       ]
     }
   },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
@@ -1278,7 +1278,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,15 +1206,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,23 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1238,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1246,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1262,31 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,23 +1198,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1214,31 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1262,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,23 +1278,15 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,31 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1206,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,23 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1247,46 @@
     }
   },
   "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,47 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,31 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1222,71 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,79 +1190,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1214,79 @@
       ]
     }
   },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,23 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,7 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,7 +1230,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,6 +1246,14 @@
       ]
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
@@ -1238,7 +1262,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1263,30 +1287,6 @@
     }
   },
   "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,55 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1206,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1230,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1279,6 +1239,46 @@
     }
   },
   "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,55 +1198,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,15 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1230,63 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,31 +1190,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,15 +1206,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1230,39 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1278,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,6 +1190,46 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
@@ -1206,55 +1246,15 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1270,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1278,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,31 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,38 +1206,6 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
@@ -1270,7 +1214,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1230,63 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,7 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,23 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1238,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,6 +1254,22 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
@@ -1278,7 +1278,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,54 +1190,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
@@ -1254,7 +1206,47 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,14 +1262,6 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1270,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,7 +1222,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,30 +1262,6 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
@@ -1270,23 +1278,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,14 +1190,6 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
@@ -1206,23 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,7 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1230,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,14 +1254,6 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1262,31 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,63 +1190,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1214,15 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1238,55 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,7 +1206,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,7 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,39 +1230,39 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1278,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,23 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,6 +1206,14 @@
       ]
     }
   },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
@@ -1230,7 +1222,55 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1247,46 +1287,6 @@
     }
   },
   "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,46 +1190,6 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
@@ -1238,7 +1198,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,31 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1222,71 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,23 +1190,23 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,6 +1230,30 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
@@ -1246,47 +1270,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,39 +1190,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,23 +1206,15 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1230,47 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,14 +1198,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
@@ -1214,7 +1206,15 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1230,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,6 +1262,14 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
@@ -1262,23 +1278,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,23 +1198,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,7 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,7 +1230,23 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,14 +1262,6 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
@@ -1278,7 +1270,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1278,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,71 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1222,71 @@
       ]
     }
   },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,38 +1214,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
@@ -1254,15 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,6 +1238,22 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1262,31 @@
       ]
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,23 +1206,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,7 +1222,55 @@
       ]
     }
   },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1255,38 +1287,6 @@
     }
   },
   "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,54 +1206,6 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
@@ -1262,7 +1214,15 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1238,47 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,15 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,47 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1222,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1254,39 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,14 +1206,6 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
@@ -1222,23 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,14 +1230,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
@@ -1270,7 +1238,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1254,39 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1206,14 +1206,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
@@ -1222,55 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1230,63 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,6 +1190,54 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
@@ -1206,31 +1254,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,39 +1270,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1279,14 @@
     }
   },
   "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,87 +1190,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1206,87 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,6 +1190,30 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
@@ -1206,23 +1230,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,23 +1246,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1262,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1270,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1279,14 @@
     }
   },
   "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,14 +1206,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
@@ -1222,15 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,7 +1230,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1238,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1262,15 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1279,14 @@
     }
   },
   "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,7 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,31 +1206,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,7 +1222,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1238,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1254,31 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,15 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,6 +1214,30 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
@@ -1214,7 +1246,23 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1231,54 +1279,6 @@
     }
   },
   "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,31 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,47 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1222,71 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,79 +1190,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1206,55 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1263,30 @@
     }
   },
   "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,23 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1199,6 +1215,38 @@
     }
   },
   "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,55 +1270,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,31 +1206,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1230,47 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,23 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,23 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,23 +1230,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,6 +1246,22 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1270,23 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,38 +1190,6 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
@@ -1230,7 +1198,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,7 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,6 +1230,22 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
@@ -1270,7 +1254,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1270,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,39 +1198,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1239,6 +1207,14 @@
     }
   },
   "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1238,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1262,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1270,23 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,63 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,7 +1270,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,63 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,39 +1198,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,7 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1238,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1254,39 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,23 +1198,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,7 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1238,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1246,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1270,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1278,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,6 +1190,22 @@
       ]
     }
   },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
@@ -1198,7 +1214,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,7 +1222,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1254,15 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,47 +1278,15 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,46 +1206,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
@@ -1254,15 +1214,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1238,55 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,15 +1198,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,7 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,15 +1222,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,23 +1246,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1255,38 @@
     }
   },
   "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,23 +1190,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,7 +1214,55 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,47 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,47 +1190,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,23 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1222,31 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1255,38 @@
     }
   },
   "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,31 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,7 +1214,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1246,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1262,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1270,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1278,15 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,39 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,7 +1206,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,30 +1230,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1238,55 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,55 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1238,55 @@
       ]
     }
   },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,7 +1214,47 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,14 +1278,6 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
@@ -1247,46 +1287,6 @@
     }
   },
   "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,15 +1190,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,39 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,6 +1222,14 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
@@ -1270,7 +1238,39 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,23 +1190,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,7 +1206,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1254,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1262,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1278,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1199,6 +1215,38 @@
     }
   },
   "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,23 +1270,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,39 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,6 +1206,30 @@
       ]
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
@@ -1214,15 +1238,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,6 +1262,22 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
@@ -1255,38 +1287,6 @@
     }
   },
   "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,14 +1198,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
@@ -1214,7 +1206,15 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1223,14 +1223,6 @@
     }
   },
   "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1246,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1254,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1278,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,6 +1198,46 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
@@ -1214,39 +1254,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1270,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,15 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,79 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,79 +1286,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,15 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,14 +1214,6 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
@@ -1238,31 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,6 +1238,14 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1254,39 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,30 +1190,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
@@ -1222,7 +1198,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,39 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1230,63 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,15 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,7 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1231,6 +1223,54 @@
     }
   },
   "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1247,46 +1287,6 @@
     }
   },
   "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,23 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,31 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1222,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1230,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1247,46 @@
     }
   },
   "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,31 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1206,15 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,14 +1238,6 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
@@ -1270,7 +1246,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1254,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1262,31 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,30 +1190,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
@@ -1230,14 +1206,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
@@ -1246,31 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1230,63 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,47 +1190,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1214,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1230,31 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1271,22 @@
     }
   },
   "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,63 +1190,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,6 +1206,22 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
@@ -1270,7 +1230,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1254,39 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,6 +1190,54 @@
       ]
     }
   },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
@@ -1206,71 +1254,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1271,22 @@
     }
   },
   "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,54 +1190,6 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
@@ -1246,7 +1198,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1222,55 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,14 +1214,6 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
@@ -1222,7 +1222,55 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1239,54 +1287,6 @@
     }
   },
   "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,7 +1198,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,7 +1222,31 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,30 +1270,6 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
@@ -1270,7 +1278,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,15 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,7 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,7 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,23 +1246,23 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1278,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,62 +1190,6 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
@@ -1254,7 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1214,47 @@
       ]
     }
   },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1270,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,31 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,6 +1222,14 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
@@ -1254,7 +1238,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1246,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,31 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,7 +1230,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,15 +1254,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,31 +1270,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1279,14 @@
     }
   },
   "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,47 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,31 +1206,31 @@
       ]
     }
   },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1246,47 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1206,39 +1206,15 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1230,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1238,31 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1278,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,23 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,7 +1230,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1246,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,14 +1262,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
@@ -1262,31 +1270,23 @@
       ]
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,23 +1190,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,39 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1222,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1254,39 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,22 +1190,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
@@ -1214,7 +1198,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,15 +1206,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,7 +1222,39 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,14 +1270,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
@@ -1278,7 +1278,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,55 +1190,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,23 +1206,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1222,71 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,55 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1255,6 +1207,14 @@
     }
   },
   "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1246,47 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,39 +1190,7 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,7 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,7 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,22 +1230,6 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1238,55 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,55 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1214,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1230,39 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1287,6 +1271,22 @@
     }
   },
   "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,71 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1206,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1230,63 @@
       ]
     }
   },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,71 @@
       ]
     }
   },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,46 +1278,6 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
@@ -1262,31 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,31 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,31 +1214,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,6 +1230,14 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1246,47 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1198,71 +1198,15 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1230,63 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,38 +1190,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
@@ -1230,15 +1198,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1254,7 +1214,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,7 +1222,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1278,7 +1238,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1246,47 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,7 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,6 +1222,30 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
@@ -1238,39 +1262,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1278,15 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,30 +1190,6 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
@@ -1222,39 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1214,47 @@
       ]
     }
   },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1270,23 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,22 +1190,6 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
@@ -1222,39 +1206,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,14 +1222,6 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
@@ -1286,7 +1230,63 @@
       ]
     }
   },
-  "zai-org/GLM-5.1": {
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,7 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1198,23 +1198,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,47 +1214,7 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1230,63 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,15 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,14 +1214,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
@@ -1246,14 +1230,6 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
@@ -1262,7 +1238,15 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1270,23 @@
       ]
     }
   },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,23 +1190,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1222,7 +1206,7 @@
       ]
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,7 +1214,15 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1246,7 +1238,31 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,23 +1286,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-0.8B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,63 +1190,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1214,63 @@
       ]
     }
   },
+  "stepfun-ai/Step-3.5-Flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "google/gemma-4-26B-A4B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1286,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,31 +1190,7 @@
       ]
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
   "Qwen/Qwen3.5-27B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1230,31 +1206,15 @@
       ]
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-35B-A3B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1270,7 +1230,39 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-397B-A17B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1286,7 +1278,15 @@
       ]
     }
   },
-  "google/gemma-4-31B-it": {
+  "ByteDance/Seed-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/deepinfra.json
+++ b/general/deepinfra.json
@@ -1190,6 +1190,14 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "type": {
       "primary": "chat",
@@ -1198,7 +1206,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-26B-A4B-it": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1214,7 +1222,7 @@
       ]
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-2B": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1238,15 +1246,7 @@
       ]
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "zai-org/GLM-5.1": {
+  "stepfun-ai/Step-3.5-Flash": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1262,6 +1262,14 @@
       ]
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "Qwen/Qwen3.5-397B-A17B": {
     "type": {
       "primary": "chat",
@@ -1270,7 +1278,7 @@
       ]
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "zai-org/GLM-5.1": {
     "type": {
       "primary": "chat",
       "supported": [
@@ -1279,14 +1287,6 @@
     }
   },
   "Wan-AI/Wan2.7-Image-Edit": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,44 +2298,17 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000002
         }
       }
     }
@@ -2355,68 +2328,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
           "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
         }
       }
     }
@@ -2433,14 +2355,41 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2460,17 +2409,68 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2313,56 +2313,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
+          "price": 0.00026
         }
       }
     }
@@ -2375,33 +2333,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
         }
       }
     }
@@ -2421,21 +2352,6 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2444,6 +2360,18 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -2463,14 +2391,86 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,21 @@
       }
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2313,14 +2328,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }
@@ -2337,17 +2355,14 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.00001
         }
       }
     }
@@ -2379,32 +2394,17 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000002
         }
       }
     }
@@ -2417,6 +2417,18 @@
         },
         "response_token": {
           "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -2436,14 +2448,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2456,21 +2471,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,48 +2298,6 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2351,63 +2309,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
         }
       }
     }
@@ -2436,6 +2337,63 @@
       }
     }
   },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2447,6 +2405,48 @@
         },
         "cache_read_input_token": {
           "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
@@ -2463,14 +2463,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2310,29 +2310,32 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.000011
         }
       }
     }
@@ -2349,21 +2352,6 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2375,6 +2363,21 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }
@@ -2406,17 +2409,26 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
         },
-        "cache_read_input_token": {
-          "price": 0.000002
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -2433,44 +2445,32 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.000002
         }
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.00000199999995
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,14 +2298,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
@@ -2318,21 +2321,6 @@
         },
         "response_token": {
           "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
         }
       }
     }
@@ -2352,26 +2340,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
+          "price": 0.000038
         },
-        "response_token": {
-          "price": 0.000015
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
@@ -2391,6 +2370,21 @@
       }
     }
   },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2402,21 +2396,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
         }
       }
     }
@@ -2448,17 +2427,26 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2471,6 +2459,18 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,18 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2321,33 +2309,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -2367,17 +2328,17 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.000011
         }
       }
     }
@@ -2394,47 +2355,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00026
         }
       }
     }
@@ -2471,6 +2399,78 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2310,18 +2310,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2330,78 +2318,6 @@
         },
         "response_token": {
           "price": 0.000015
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -2421,21 +2337,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2444,6 +2345,21 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }
@@ -2463,6 +2379,75 @@
       }
     }
   },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2456,21 @@
         },
         "response_token": {
           "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,21 @@
       }
     }
   },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2309,6 +2324,102 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
@@ -2340,72 +2451,6 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2418,59 +2463,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,102 +2298,6 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2409,14 +2313,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.000015
         }
       }
     }
@@ -2436,6 +2340,45 @@
       }
     }
   },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2447,6 +2390,33 @@
         },
         "cache_read_input_token": {
           "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2463,14 +2433,44 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2313,33 +2325,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2348,48 +2333,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
         }
       }
     }
@@ -2424,6 +2367,36 @@
       }
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2434,6 +2407,42 @@
           "price": 0.0003
         },
         "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
           "price": 0.00001
         }
       }
@@ -2451,26 +2460,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
+          "price": 0.00003
         },
-        "response_token": {
-          "price": 0.000005
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,14 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00026
         }
       }
     }
@@ -2328,56 +2325,17 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
+          "price": 0.000027
         }
       }
     }
@@ -2409,6 +2367,60 @@
       }
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2417,6 +2429,18 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2436,41 +2460,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
+          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,72 @@
       }
     }
   },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2313,14 +2379,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }
@@ -2340,29 +2406,44 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000001
         }
       }
     }
@@ -2390,87 +2471,6 @@
         },
         "response_token": {
           "price": 0.00026
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,14 +2298,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.00001
         }
       }
     }
@@ -2337,29 +2337,32 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.0000260000006
         }
       }
     }
@@ -2391,6 +2394,33 @@
       }
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2402,33 +2432,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000002
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
         }
       }
     }
@@ -2445,6 +2448,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2456,21 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,83 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
@@ -2328,25 +2394,16 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
+          "price": 0.0003
         },
-        "response_token": {
+        "cache_read_input_token": {
           "price": 0.00001
         }
       }
@@ -2376,48 +2433,6 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
   "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2433,44 +2448,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,14 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000005
         }
       }
     }
@@ -2325,75 +2322,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2406,29 +2334,14 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0
         },
         "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
+          "price": 0
         }
       }
     }
@@ -2463,14 +2376,101 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,45 @@
       }
     }
   },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2306,6 +2345,18 @@
         },
         "response_token": {
           "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2325,6 +2376,33 @@
       }
     }
   },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2336,30 +2414,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
         }
       }
     }
@@ -2379,6 +2433,21 @@
       }
     }
   },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2394,83 +2463,14 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,83 +2298,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000027
         }
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
+          "price": 0.000015
         }
       }
     }
@@ -2391,17 +2337,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.00001
         }
       }
     }
@@ -2433,17 +2376,17 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.0000260000006
         }
       }
     }
@@ -2463,14 +2406,71 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,81 @@
       }
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2325,6 +2400,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
   "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2336,90 +2423,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
         }
       }
     }
@@ -2436,29 +2439,26 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0
         }
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,30 +2298,6 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2330,21 +2306,6 @@
         },
         "response_token": {
           "price": 0.00026
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
         }
       }
     }
@@ -2364,6 +2325,18 @@
       }
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2375,42 +2348,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
         }
       }
     }
@@ -2430,6 +2367,30 @@
       }
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2441,6 +2402,33 @@
         },
         "cache_read_input_token": {
           "price": 0.000027
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
         }
       }
     }
@@ -2460,17 +2448,29 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,21 @@
       }
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2309,6 +2324,87 @@
         },
         "cache_read_input_token": {
           "price": 0.000011
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }
@@ -2343,14 +2439,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         }
       }
     }
@@ -2367,110 +2463,14 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.00002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,26 +2298,14 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
+          "price": 0.00002
         }
       }
     }
@@ -2334,75 +2322,6 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2414,21 +2333,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000027
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
         }
       }
     }
@@ -2460,6 +2364,48 @@
       }
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2417,60 @@
         },
         "cache_read_input_token": {
           "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,33 @@
       }
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2309,33 +2336,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
         }
       }
     }
@@ -2367,6 +2367,45 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2394,6 +2433,33 @@
       }
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2405,72 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000011
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,87 +2298,6 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2390,18 +2309,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -2421,6 +2328,33 @@
       }
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2432,6 +2366,69 @@
         },
         "cache_read_input_token": {
           "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -2451,25 +2448,28 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         }
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.00005
         },
         "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
           "price": 0.00001
         }
       }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,18 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2318,33 +2306,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
         }
       }
     }
@@ -2364,86 +2325,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000001
         }
       }
     }
@@ -2463,6 +2355,48 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2405,72 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2313,17 +2313,41 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }
@@ -2340,6 +2364,21 @@
       }
     }
   },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2350,57 +2389,6 @@
           "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
           "price": 0.00001
         }
       }
@@ -2436,6 +2424,33 @@
       }
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2448,29 +2463,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.00002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,74 +2298,17 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.0000260000006
         }
       }
     }
@@ -2382,6 +2325,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2390,30 +2345,6 @@
         },
         "response_token": {
           "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
         }
       }
     }
@@ -2433,14 +2364,83 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2460,17 +2460,17 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2313,18 +2313,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2340,17 +2328,29 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2367,17 +2367,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000002
         }
       }
     }
@@ -2409,6 +2421,21 @@
       }
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2424,41 +2451,14 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,21 +2298,6 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2324,111 +2309,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000011
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
         }
       }
     }
@@ -2448,6 +2328,60 @@
       }
     }
   },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2460,17 +2394,83 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,47 +2298,38 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
           "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2358,53 +2349,74 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.000027
         }
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0
+          "price": 0.000015
         }
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
           "price": 0.000002
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
         },
         "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
           "price": 0.00001
         }
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2424,6 +2436,33 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2432,45 +2471,6 @@
         },
         "response_token": {
           "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,59 +2298,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.00002
         }
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.00001
         }
       }
     }
@@ -2379,14 +2349,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }
@@ -2406,29 +2379,44 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.0000260000006
         }
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2445,32 +2433,44 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000027
         }
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.00000199999995
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,153 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
   "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2324,153 @@
         },
         "cache_read_input_token": {
           "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,21 +2298,6 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2325,41 +2310,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000015
         }
       }
     }
@@ -2391,29 +2349,44 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.00001
         }
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }
@@ -2433,6 +2406,48 @@
       }
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2448,29 +2463,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0
         },
         "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2313,95 +2313,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.0000260000006
         }
       }
     }
@@ -2421,14 +2343,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2448,17 +2373,68 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
         }
       }
     }
@@ -2471,6 +2447,30 @@
         },
         "response_token": {
           "price": 0.00026
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,18 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2325,83 +2313,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0
         },
         "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
+          "price": 0
         }
       }
     }
@@ -2421,6 +2340,21 @@
       }
     }
   },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2429,6 +2363,60 @@
         },
         "response_token": {
           "price": 0.00026
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }
@@ -2448,14 +2436,26 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,33 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2336,6 +2309,21 @@
         },
         "cache_read_input_token": {
           "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
@@ -2352,6 +2340,42 @@
       }
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2363,6 +2387,48 @@
         },
         "cache_read_input_token": {
           "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2394,18 +2460,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2417,60 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,90 @@
       }
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2306,6 +2390,18 @@
         },
         "response_token": {
           "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }
@@ -2337,14 +2433,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }
@@ -2364,75 +2463,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2441,36 +2471,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,51 +2298,6 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2358,65 +2313,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
+          "price": 0.000015
         }
       }
     }
@@ -2436,6 +2340,33 @@
       }
     }
   },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2444,6 +2375,48 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2463,14 +2436,41 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,54 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2361,17 +2313,29 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2403,17 +2367,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }
@@ -2433,17 +2409,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.000001
         }
       }
     }
@@ -2460,17 +2436,41 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,21 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2321,6 +2306,21 @@
         },
         "response_token": {
           "price": 0.00026
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2352,6 +2352,48 @@
       }
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2379,26 +2421,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0
+          "price": 0.00002
         }
       }
     }
@@ -2418,59 +2463,14 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0
         },
         "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,59 +2298,26 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.00002
         }
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
           "price": 0.000002
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.00001
         }
       }
     }
@@ -2370,14 +2337,59 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000003
         },
         "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }
@@ -2406,14 +2418,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2433,6 +2448,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2444,33 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,21 +2298,6 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2328,53 +2313,26 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.00026
         }
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }
@@ -2394,56 +2352,14 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.00002
         }
       }
     }
@@ -2463,14 +2379,98 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000022
         },
         "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2313,6 +2313,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2321,117 +2333,6 @@
         },
         "response_token": {
           "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
         }
       }
     }
@@ -2451,6 +2352,117 @@
       }
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2459,18 +2471,6 @@
         },
         "response_token": {
           "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,74 +2298,17 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
           "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
         }
       }
     }
@@ -2385,26 +2328,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0
         }
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2424,33 +2370,6 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2463,6 +2382,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2402,75 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2313,18 +2313,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2337,17 +2325,26 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -2360,21 +2357,6 @@
         },
         "response_token": {
           "price": 0.000005
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
         }
       }
     }
@@ -2406,29 +2388,44 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2448,29 +2445,32 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.000011
         }
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,14 +2298,47 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2322,6 +2355,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2330,21 +2375,6 @@
         },
         "response_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
         }
       }
     }
@@ -2364,6 +2394,18 @@
       }
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2376,17 +2418,17 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000001
         }
       }
     }
@@ -2429,48 +2471,6 @@
         },
         "response_token": {
           "price": 0.00002
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,30 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2306,6 +2330,108 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2337,48 +2463,6 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2387,90 +2471,6 @@
         },
         "response_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,114 +2298,6 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2421,17 +2313,26 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
         },
-        "cache_read_input_token": {
-          "price": 0.000011
+        "response_token": {
+          "price": 0.00026
         }
       }
     }
@@ -2451,18 +2352,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2360,117 @@
         },
         "response_token": {
           "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2309,6 +2321,33 @@
         },
         "cache_read_input_token": {
           "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }
@@ -2325,14 +2364,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }
@@ -2364,29 +2403,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
+          "price": 0.000027
         }
       }
     }
@@ -2406,44 +2433,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.000011
         }
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.00026
         }
       }
     }
@@ -2459,18 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,14 +2298,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.000005
         }
       }
     }
@@ -2340,57 +2340,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2406,29 +2355,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.00002
         }
       }
     }
@@ -2448,6 +2382,33 @@
       }
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2456,6 +2417,33 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
@@ -2471,6 +2459,18 @@
         },
         "cache_read_input_token": {
           "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,47 +2298,14 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.00026
         }
       }
     }
@@ -2355,14 +2322,32 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2421,17 +2406,41 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -2451,26 +2460,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
+          "price": 0.00003
         },
-        "response_token": {
-          "price": 0.00026
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,32 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2325,6 +2340,48 @@
       }
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2337,17 +2394,41 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000260000006
         }
       }
     }
@@ -2375,87 +2456,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,18 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2325,6 +2313,30 @@
       }
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2333,6 +2345,60 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2352,6 +2418,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2363,21 +2441,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
         }
       }
     }
@@ -2408,69 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,83 +2298,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
           "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.00001
         }
       }
     }
@@ -2391,6 +2322,45 @@
       }
     }
   },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2399,48 +2369,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
         }
       }
     }
@@ -2460,17 +2388,89 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,14 +2298,44 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2321,6 +2351,57 @@
         },
         "cache_read_input_token": {
           "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }
@@ -2352,38 +2433,17 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
+          "price": 0.00044
         },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2403,74 +2463,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.00002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.0000260000006
         }
       }
     }
@@ -2328,32 +2328,29 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.00026
         }
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000027
         }
       }
     }
@@ -2373,60 +2370,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2435,6 +2378,60 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }
@@ -2451,14 +2448,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,90 +2298,6 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2394,17 +2310,14 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.00002
         }
       }
     }
@@ -2436,14 +2349,101 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
@@ -2463,14 +2463,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000005
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,32 +2298,29 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.0000260000006
         }
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.00001
         }
       }
     }
@@ -2340,17 +2337,14 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0
         },
         "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0
         }
       }
     }
@@ -2370,56 +2364,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
+          "price": 0.00000199999995
         }
       }
     }
@@ -2439,18 +2406,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2463,14 +2418,59 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,44 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }
@@ -2328,48 +2355,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2382,14 +2367,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2424,6 +2412,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2436,33 +2436,6 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2444,33 @@
         },
         "response_token": {
           "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.00026
         }
       }
     }
@@ -2328,6 +2325,21 @@
       }
     }
   },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2343,56 +2355,41 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000027
         }
       }
     }
@@ -2409,17 +2406,14 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000015
         }
       }
     }
@@ -2439,26 +2433,32 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,87 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2409,6 +2328,45 @@
       }
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2417,6 +2375,33 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
@@ -2436,21 +2421,6 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2463,14 +2433,44 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,14 +2298,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }
@@ -2318,6 +2318,45 @@
         },
         "response_token": {
           "price": 0.00002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }
@@ -2337,29 +2376,14 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.000015
         }
       }
     }
@@ -2391,6 +2415,36 @@
       }
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2417,60 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,87 @@
       }
     }
   },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
   "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2325,30 +2406,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2360,87 +2417,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
         }
       }
     }
@@ -2471,6 +2447,30 @@
         },
         "cache_read_input_token": {
           "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,18 @@
       }
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2306,6 +2318,18 @@
         },
         "response_token": {
           "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }
@@ -2325,59 +2349,17 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.0000260000006
         }
       }
     }
@@ -2409,6 +2391,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2421,14 +2415,17 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }
@@ -2448,29 +2445,32 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000002
         }
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2313,17 +2313,41 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
         }
       }
     }
@@ -2343,72 +2367,6 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2421,17 +2379,17 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000027
         }
       }
     }
@@ -2451,14 +2409,56 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,71 +2298,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
           "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.000005
         }
       }
     }
@@ -2382,14 +2325,32 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }
@@ -2409,6 +2370,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2421,41 +2394,41 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0
         }
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
+          "price": 0.000011
         }
       }
     }
@@ -2471,6 +2444,33 @@
         },
         "cache_read_input_token": {
           "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,95 +2298,17 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
+          "price": 0.000011
         }
       }
     }
@@ -2403,44 +2325,14 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000005
         }
       }
     }
@@ -2460,6 +2352,57 @@
       }
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2414,63 @@
         },
         "cache_read_input_token": {
           "price": 0.000001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,83 +2298,17 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000260000006
         }
       }
     }
@@ -2406,17 +2340,14 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00002
         }
       }
     }
@@ -2433,14 +2364,56 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }
@@ -2471,6 +2444,33 @@
         },
         "cache_read_input_token": {
           "price": 0.000011
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,38 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
         },
-        "cache_read_input_token": {
-          "price": 0.000011
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -2328,14 +2349,47 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }
@@ -2367,48 +2421,6 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2436,30 +2448,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2459,18 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,36 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2340,44 +2310,32 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000001
         }
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
+          "price": 0.000027
         }
       }
     }
@@ -2397,6 +2355,51 @@
       }
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2405,6 +2408,21 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2421,21 +2439,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2448,17 +2451,14 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,14 +2298,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }
@@ -2318,75 +2321,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
         }
       }
     }
@@ -2406,6 +2340,36 @@
       }
     }
   },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2414,21 +2378,6 @@
         },
         "response_token": {
           "price": 0.000015
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
         }
       }
     }
@@ -2448,6 +2397,21 @@
       }
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2460,17 +2424,53 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,30 @@
       }
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2306,33 +2330,6 @@
         },
         "response_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
         }
       }
     }
@@ -2352,29 +2349,44 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.0000260000006
         }
       }
     }
@@ -2394,45 +2406,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2448,17 +2421,44 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2313,95 +2313,17 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
           "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
         }
       }
     }
@@ -2418,32 +2340,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0
         }
       }
     }
@@ -2463,14 +2367,110 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,30 +2298,6 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2349,71 +2325,17 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.0000260000006
         }
       }
     }
@@ -2426,21 +2348,6 @@
         },
         "response_token": {
           "price": 0.000005
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
         }
       }
     }
@@ -2460,17 +2367,110 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,18 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2322,14 +2310,32 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2364,14 +2370,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }
@@ -2391,47 +2400,50 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
         },
-        "cache_read_input_token": {
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
         }
       }
     }
@@ -2459,18 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,41 +2298,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000027
         }
       }
     }
@@ -2345,30 +2321,6 @@
         },
         "response_token": {
           "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -2388,21 +2340,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2418,29 +2355,29 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.0000260000006
         }
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000015
         }
       }
     }
@@ -2471,6 +2408,69 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,29 +2298,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0
         },
         "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0
         }
       }
     }
@@ -2355,21 +2340,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2400,18 +2370,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2427,14 +2385,29 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -2463,6 +2436,21 @@
       }
     }
   },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2459,18 @@
         },
         "response_token": {
           "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,53 +2298,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2364,33 +2340,6 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2406,17 +2355,14 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.00026
         }
       }
     }
@@ -2436,6 +2382,72 @@
       }
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2451,26 +2463,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
+          "price": 0.000005
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,56 +2298,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
         }
       }
     }
@@ -2367,17 +2328,26 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
         },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
+        "response_token": {
+          "price": 0.00002
         }
       }
     }
@@ -2409,18 +2379,6 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2436,40 +2394,82 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
           "price": 0.00001
         }
       }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,18 @@
       }
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2310,44 +2322,29 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
           "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2367,17 +2364,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
         }
       }
     }
@@ -2409,17 +2418,44 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2435,42 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,14 +2298,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
@@ -2322,41 +2325,17 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
+          "price": 0.000027
         }
       }
     }
@@ -2376,6 +2355,45 @@
       }
     }
   },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2384,6 +2402,48 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2411,66 +2471,6 @@
         },
         "response_token": {
           "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,33 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2336,21 +2309,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000027
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
         }
       }
     }
@@ -2367,17 +2325,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000002
         }
       }
     }
@@ -2397,6 +2355,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2409,18 +2379,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2429,6 +2387,48 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }
@@ -2460,17 +2460,17 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,47 +2298,26 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.000015
         }
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.00002
         }
       }
     }
@@ -2358,29 +2337,56 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.00001
         }
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }
@@ -2400,41 +2406,32 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000002
         }
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
@@ -2451,18 +2448,6 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2456,21 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,48 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2355,86 +2313,26 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000005
         }
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.00002
         }
       }
     }
@@ -2463,14 +2361,116 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2310,26 +2310,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
+          "price": 0.0003
         },
-        "response_token": {
-          "price": 0.000015
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2349,21 +2340,6 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2376,59 +2352,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000001
         }
       }
     }
@@ -2448,6 +2382,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2463,6 +2409,48 @@
       }
     }
   },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2459,18 @@
         },
         "response_token": {
           "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,45 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2361,18 +2322,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2388,59 +2337,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000005
         }
       }
     }
@@ -2460,6 +2364,45 @@
       }
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2414,63 @@
         },
         "cache_read_input_token": {
           "price": 0.000027
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,87 +2298,6 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2390,30 +2309,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
         }
       }
     }
@@ -2433,17 +2328,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.0000260000006
         }
       }
     }
@@ -2463,6 +2370,48 @@
       }
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2420,57 @@
         },
         "response_token": {
           "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,56 +2298,17 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
           "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
         }
       }
     }
@@ -2364,29 +2325,14 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.000005
         }
       }
     }
@@ -2406,29 +2352,80 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000027
         }
       }
     }
@@ -2448,29 +2445,32 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000002
         }
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,36 @@
       }
     }
   },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2313,32 +2343,41 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000011
         }
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
         },
-        "cache_read_input_token": {
-          "price": 0.000027
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2370,17 +2409,29 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000002
         }
       }
     }
@@ -2397,6 +2448,21 @@
       }
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2405,72 +2471,6 @@
         },
         "response_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,32 +2298,17 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.00000199999995
         }
       }
     }
@@ -2340,33 +2325,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2379,17 +2337,38 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
         },
-        "cache_read_input_token": {
-          "price": 0.000011
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }
@@ -2409,41 +2388,59 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
@@ -2463,13 +2460,16 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.00005
         },
         "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
           "price": 0.00001
         }
       }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2313,6 +2313,75 @@
       }
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2337,30 +2406,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2369,36 +2414,6 @@
         },
         "response_token": {
           "price": 0.00026
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
         }
       }
     }
@@ -2418,14 +2433,14 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0
+          "price": 0.000005
         }
       }
     }
@@ -2445,32 +2460,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.0000260000006
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,59 +2298,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.00026
         }
       }
     }
@@ -2385,6 +2340,72 @@
       }
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2395,6 +2416,33 @@
           "price": 0.0003
         },
         "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
           "price": 0.00001
         }
       }
@@ -2415,42 +2463,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2459,18 +2471,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,59 +2298,14 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000005
         }
       }
     }
@@ -2370,38 +2325,17 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
+          "price": 0.00044
         },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2421,29 +2355,41 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.000015
         }
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000011
         }
       }
     }
@@ -2463,14 +2409,68 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2325,18 +2325,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2352,98 +2340,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0
         },
         "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
+          "price": 0
         }
       }
     }
@@ -2463,14 +2367,110 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,71 +2298,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
+          "price": 0
         }
       }
     }
@@ -2375,6 +2318,21 @@
         },
         "response_token": {
           "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2406,41 +2364,41 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.000027
         }
       }
     }
@@ -2460,6 +2418,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2441,36 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,45 @@
       }
     }
   },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2325,41 +2364,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
+          "price": 0.000001
         }
       }
     }
@@ -2372,18 +2387,6 @@
         },
         "response_token": {
           "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
         }
       }
     }
@@ -2403,18 +2406,6 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2430,32 +2421,26 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000015
         }
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00002
         }
       }
     }
@@ -2471,6 +2456,21 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,30 @@
       }
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2313,44 +2337,14 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.00002
         }
       }
     }
@@ -2370,29 +2364,53 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
         },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2412,14 +2430,32 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.00005
         },
         "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
@@ -2435,42 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,84 @@
       }
     }
   },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2325,33 +2403,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2360,21 +2411,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
         }
       }
     }
@@ -2394,68 +2430,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000001
         }
       }
     }
@@ -2471,6 +2456,21 @@
         },
         "cache_read_input_token": {
           "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,14 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.00002
         }
       }
     }
@@ -2321,21 +2318,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
         }
       }
     }
@@ -2355,44 +2337,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.00026
         }
       }
     }
@@ -2412,18 +2364,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2436,14 +2376,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2463,14 +2406,71 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,57 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2361,29 +2310,29 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000002
         }
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00002
         }
       }
     }
@@ -2403,6 +2352,33 @@
       }
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2414,6 +2390,18 @@
         },
         "cache_read_input_token": {
           "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -2445,17 +2433,17 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.00001
         }
       }
     }
@@ -2471,6 +2459,18 @@
         },
         "cache_read_input_token": {
           "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,26 +2298,26 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.00026
         }
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.000015
         }
       }
     }
@@ -2337,18 +2337,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2361,6 +2349,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2369,6 +2369,78 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2399,78 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,45 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2348,75 +2309,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
         }
       }
     }
@@ -2436,14 +2328,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
@@ -2460,6 +2355,60 @@
       }
     }
   },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2420,57 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,56 +2298,32 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
           "price": 0.00001
         }
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }
@@ -2379,29 +2355,56 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.00002
         }
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
@@ -2414,21 +2417,6 @@
         },
         "response_token": {
           "price": 0.00026
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
         }
       }
     }
@@ -2448,29 +2436,41 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0
         },
         "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0
         }
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,44 +2298,26 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.00002
         }
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
+          "price": 0.00026
         }
       }
     }
@@ -2355,38 +2337,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000005
         }
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
+          "price": 0.00022
         },
-        "response_token": {
-          "price": 0.000015
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2421,41 +2394,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000001
         }
       }
     }
@@ -2470,6 +2419,57 @@
           "price": 0.0003
         },
         "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
           "price": 0.00001
         }
       }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,44 +2298,29 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.000038
         },
         "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.000001
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
+          "price": 0.000005
         }
       }
     }
@@ -2355,65 +2340,17 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }
@@ -2433,29 +2370,53 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.00026
         }
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2471,6 +2432,45 @@
         },
         "cache_read_input_token": {
           "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,21 +2298,6 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2321,54 +2306,6 @@
         },
         "response_token": {
           "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
         }
       }
     }
@@ -2388,44 +2325,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
           "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000005
         }
       }
     }
@@ -2445,17 +2352,56 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -2471,6 +2417,60 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,80 +2298,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
+          "price": 0.000011
         }
       }
     }
@@ -2391,59 +2328,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0
         }
       }
     }
@@ -2463,14 +2355,122 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,156 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2321,156 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,44 +2298,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.00000199999995
         }
       }
     }
@@ -2352,32 +2325,41 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000002
         }
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
         },
-        "cache_read_input_token": {
-          "price": 0.000001
+        "response_token": {
+          "price": 0.00002
         }
       }
     }
@@ -2397,14 +2379,62 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2433,44 +2463,14 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.000005
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,44 +2298,44 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.00000199999995
         }
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.00026
         }
       }
     }
@@ -2355,32 +2355,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.00001
         }
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.00001
         }
       }
     }
@@ -2400,14 +2397,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.000015
         }
       }
     }
@@ -2424,26 +2421,44 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       }
     }
@@ -2456,21 +2471,6 @@
         },
         "response_token": {
           "price": 0.000005
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,25 +2298,16 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
+          "price": 0.0003
         },
-        "response_token": {
+        "cache_read_input_token": {
           "price": 0.00001
         }
       }
@@ -2337,48 +2328,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2390,30 +2339,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -2433,17 +2358,41 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2460,17 +2409,68 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2313,77 +2313,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000001
         }
       }
     }
@@ -2403,17 +2343,17 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000027
         }
       }
     }
@@ -2430,17 +2370,80 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "stepfun-ai/Step-3.5-Flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2460,17 +2463,14 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000015
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,87 +2298,6 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2391,14 +2310,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00002
         }
       }
     }
@@ -2418,17 +2337,80 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2448,14 +2430,17 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2471,6 +2456,21 @@
         },
         "cache_read_input_token": {
           "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,41 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-0.8B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000027
         }
       }
     }
@@ -2340,14 +2364,17 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2367,17 +2394,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.00001
         }
       }
     }
@@ -2390,18 +2414,6 @@
         },
         "response_token": {
           "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
         }
       }
     }
@@ -2421,6 +2433,33 @@
       }
     }
   },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
   "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2432,45 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,41 +2298,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000002
         }
       }
     }
@@ -2364,17 +2340,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.00001
         }
       }
     }
@@ -2394,6 +2370,30 @@
       }
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2402,18 +2402,6 @@
         },
         "response_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
         }
       }
     }
@@ -2433,18 +2421,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2460,17 +2436,41 @@
       }
     }
   },
-  "stepfun-ai/Step-3.5-Flash": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,86 +2298,29 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.000038
         },
         "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
         }
       }
     }
@@ -2390,6 +2333,21 @@
         },
         "response_token": {
           "price": 0.00002
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2421,17 +2379,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.0000260000006
         }
       }
     }
@@ -2448,29 +2418,59 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,14 +2298,71 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -2334,33 +2391,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2376,36 +2406,6 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2417,21 +2417,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
         }
       }
     }
@@ -2463,14 +2448,29 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,21 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2321,72 +2306,6 @@
         },
         "response_token": {
           "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
         }
       }
     }
@@ -2417,6 +2336,18 @@
         },
         "cache_read_input_token": {
           "price": 0.000001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2463,6 +2394,63 @@
       }
     }
   },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2471,6 +2459,18 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,41 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.0003
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
         }
       }
     }
@@ -2324,6 +2348,63 @@
         },
         "cache_read_input_token": {
           "price": 0.000002
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2355,21 +2436,6 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2378,72 +2444,6 @@
         },
         "response_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
         }
       }
     }
@@ -2460,17 +2460,17 @@
       }
     }
   },
-  "ByteDance/Seed-2.0-pro": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000011
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,44 +2298,14 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "stepfun-ai/Step-3.5-Flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.000002
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.00026
         }
       }
     }
@@ -2355,6 +2325,21 @@
       }
     }
   },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2363,6 +2348,30 @@
         },
         "response_token": {
           "price": 0.00002
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
         }
       }
     }
@@ -2382,33 +2391,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2424,14 +2406,14 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000015
         }
       }
     }
@@ -2451,26 +2433,44 @@
       }
     }
   },
-  "Qwen/Qwen3.5-0.8B": {
+  "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         }
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,44 +2298,32 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
+  "zai-org/GLM-5.1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00026
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
   },
-  "Qwen/Qwen3.5-35B-A3B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00022
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000001
         }
       }
     }
@@ -2355,14 +2343,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
         }
       }
     }
@@ -2375,6 +2366,84 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
         }
       }
     }
@@ -2402,75 +2471,6 @@
         },
         "response_token": {
           "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,17 +2298,14 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
+  "Qwen/Qwen3.5-27B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000026
         },
         "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
+          "price": 0.00026
         }
       }
     }
@@ -2321,6 +2318,18 @@
         },
         "response_token": {
           "price": 0.000005
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -2340,6 +2349,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2351,6 +2372,21 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
         }
       }
     }
@@ -2370,18 +2406,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
   "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2397,26 +2421,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
         }
       }
     }
   },
-  "Qwen/Qwen3.5-2B": {
+  "Qwen/Qwen3.5-9B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000004
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.00002
         }
       }
     }
@@ -2436,18 +2463,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
   "Wan-AI/Wan2.7-Image-Edit": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2456,21 +2471,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,14 +2298,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2322,17 +2337,83 @@
       }
     }
   },
-  "zai-org/GLM-5.1": {
+  "google/gemma-4-31B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.000038
         },
         "cache_read_input_token": {
-          "price": 0.0000260000006
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
+  "ByteDance/Seed-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-2B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000054
+        },
+        "response_token": {
+          "price": 0.00034
+        },
+        "cache_read_input_token": {
+          "price": 0.000027
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
         }
       }
     }
@@ -2364,21 +2445,6 @@
       }
     }
   },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2405,72 +2471,6 @@
         },
         "cache_read_input_token": {
           "price": 0.000001
-        }
-      }
-    }
-  },
-  "ByteDance/Seed-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000054
-        },
-        "response_token": {
-          "price": 0.00034
-        },
-        "cache_read_input_token": {
-          "price": 0.000027
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "Wan-AI/Wan2.7-Image-Edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,6 +2298,18 @@
       }
     }
   },
+  "Qwen/Qwen3.5-0.8B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000001
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2309,18 +2321,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-0.8B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000001
-        },
-        "response_token": {
-          "price": 0.000005
         }
       }
     }
@@ -2337,41 +2337,17 @@
       }
     }
   },
-  "Qwen/Qwen3.5-9B": {
+  "Qwen/Qwen3.5-397B-A17B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000054
         },
         "response_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-2B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
+          "price": 0.00034
         },
         "cache_read_input_token": {
-          "price": 0.000011
+          "price": 0.000027
         }
       }
     }
@@ -2403,17 +2379,17 @@
       }
     }
   },
-  "google/gemma-4-26B-A4B-it": {
+  "Qwen/Qwen3.5-35B-A3B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.00022
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000011
         }
       }
     }
@@ -2433,6 +2409,30 @@
       }
     }
   },
+  "Qwen/Qwen3.5-4B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "stepfun-ai/Step-3.5-Flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2448,29 +2448,29 @@
       }
     }
   },
-  "Qwen/Qwen3.5-397B-A17B": {
+  "google/gemma-4-26B-A4B-it": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000054
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00034
+          "price": 0.000035
         },
         "cache_read_input_token": {
-          "price": 0.000027
+          "price": 0.000001
         }
       }
     }
   },
-  "Qwen/Qwen3.5-4B": {
+  "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000002
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }

--- a/pricing/deepinfra.json
+++ b/pricing/deepinfra.json
@@ -2298,33 +2298,6 @@
       }
     }
   },
-  "Qwen/Qwen3.5-27B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000026
-        },
-        "response_token": {
-          "price": 0.00026
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-35B-A3B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.00022
-        },
-        "cache_read_input_token": {
-          "price": 0.000011
-        }
-      }
-    }
-  },
   "ByteDance/Seed-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2336,6 +2309,33 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "google/gemma-4-26B-A4B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    }
+  },
+  "Wan-AI/Wan2.7-Image-Edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2355,6 +2355,45 @@
       }
     }
   },
+  "Qwen/Qwen3.5-9B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-27B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00026
+        }
+      }
+    }
+  },
+  "google/gemma-4-31B-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.000038
+        },
+        "cache_read_input_token": {
+          "price": 0.00000199999995
+        }
+      }
+    }
+  },
   "Qwen/Qwen3.5-2B": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2367,14 +2406,44 @@
       }
     }
   },
-  "Wan-AI/Wan2.7-Image-Edit": {
+  "Qwen/Qwen3.5-4B": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "Qwen/Qwen3.5-35B-A3B": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.000011
+        }
+      }
+    }
+  },
+  "zai-org/GLM-5.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.0000260000006
         }
       }
     }
@@ -2402,75 +2471,6 @@
         },
         "response_token": {
           "price": 0.000005
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-4B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "google/gemma-4-26B-A4B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000008
-        },
-        "response_token": {
-          "price": 0.000035
-        },
-        "cache_read_input_token": {
-          "price": 0.000001
-        }
-      }
-    }
-  },
-  "zai-org/GLM-5.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.0000260000006
-        }
-      }
-    }
-  },
-  "google/gemma-4-31B-it": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000013
-        },
-        "response_token": {
-          "price": 0.000038
-        },
-        "cache_read_input_token": {
-          "price": 0.00000199999995
-        }
-      }
-    }
-  },
-  "Qwen/Qwen3.5-9B": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000004
-        },
-        "response_token": {
-          "price": 0.00002
         }
       }
     }


### PR DESCRIPTION
## 🔄 Models Update: deepinfra

### 📊 Summary

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 13 |
| 🔄 Prices updated | 1 |
| 📋 General configs added | 13 |

### ➕ New Models
- `Qwen/Qwen3.5-0.8B`
- `ByteDance/Seed-2.0-pro`
- `Wan-AI/Wan2.7-Image-Edit`
- `Qwen/Qwen3.5-397B-A17B`
- `zai-org/GLM-5.1`
- `Qwen/Qwen3.5-27B`
- `Qwen/Qwen3.5-35B-A3B`
- `google/gemma-4-31B-it`
- `Qwen/Qwen3.5-4B`
- `Qwen/Qwen3.5-9B`
- `stepfun-ai/Step-3.5-Flash`
- `google/gemma-4-26B-A4B-it`
- `Qwen/Qwen3.5-2B`

### 🔄 Updated Prices
- `meta-llama/Llama-3.2-11B-Vision-Instruct`

### 📋 New General Configs
- `Qwen/Qwen3.5-0.8B`
- `ByteDance/Seed-2.0-pro`
- `Wan-AI/Wan2.7-Image-Edit`
- `Qwen/Qwen3.5-397B-A17B`
- `zai-org/GLM-5.1`
- `Qwen/Qwen3.5-27B`
- `Qwen/Qwen3.5-35B-A3B`
- `google/gemma-4-31B-it`
- `Qwen/Qwen3.5-4B`
- `Qwen/Qwen3.5-9B`
- `stepfun-ai/Step-3.5-Flash`
- `google/gemma-4-26B-A4B-it`
- `Qwen/Qwen3.5-2B`


---
*Generated by Direct Converter on 2026-04-15*