### PR TITLE
chore(pricing): Update ai21 pricing

### DIFF
--- a/general/ai21.json
+++ b/general/ai21.json
@@ -95,5 +95,10 @@
     "type": {
       "primary": "chat"
     }
+  },
+  "jamba-large-1.6": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/ai21.json
+++ b/pricing/ai21.json
@@ -191,5 +191,41 @@
         }
       }
     }
+  },
+  "jamba-mini-1.7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "jamba-mini-1.6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "jamba-large-1.6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0008
+        }
+      }
+    }
   }
 }

--- a/pricing/ai21.json
+++ b/pricing/ai21.json
@@ -192,30 +192,6 @@
       }
     }
   },
-  "jamba-mini-1.7": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00004
-        }
-      }
-    }
-  },
-  "jamba-mini-1.6": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00004
-        }
-      }
-    }
-  },
   "jamba-large-1.6": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
## 🔄 Pricing Update: ai21

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 1 |
| 🔄 Models updated (merged) | 0 |

### ➕ New Models
- `jamba-large-1.6`



## Model → Pricing Page Mapping

| Model ID | Family | Input ($/MTok) | Output ($/MTok) |
|---|---|---|---|
| `jamba-mini` | Jamba Mini | $0.2 | $0.4 |
| `jamba-mini-2` | Jamba Mini | $0.2 | $0.4 |
| `jamba-mini-2-2026-01` | Jamba Mini | $0.2 | $0.4 |
| `jamba-large` | Jamba Large | $2 | $8 |
| `jamba-large-1.6` | Jamba Large | $2 | $8 |
| `jamba-large-1.6-2025-03` | Jamba Large | $2 | $8 |
| `jamba-large-1.7` | Jamba Large | $2 | $8 |
| `jamba-large-1.7-2025-07` | Jamba Large | $2 | $8 |

## Sources
- Docs: https://docs.ai21.com/docs/jamba-foundation-models
- Pricing: https://www.ai21.com/pricing/

---
*Generated by Pricing Agent on 2026-04-06*