### PR TITLE
Add duplicate-key validation for model config JSONs

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -1,5 +1,11 @@
 name: Validate JSON
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'pricing/**'
+      - 'general/**'
   pull_request:
     branches:
       - main
@@ -43,3 +49,7 @@ jobs:
           if [ $ERRORS -gt 0 ]; then
             exit 1
           fi
+
+      - name: Check duplicate keys in configs
+        run: |
+          python3 scripts/check_duplicate_keys.py

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -1,11 +1,6 @@
 name: Validate JSON
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'pricing/**'
-      - 'general/**'
   pull_request:
     branches:
       - main

--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -1537,41 +1537,6 @@
         "skipValues": [null],
         "type": "string"
       },
-      {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
-      },
-
       { "key": "verbosity", "enum": ["low", "medium", "high", null], "defaultValue": null, "skipValues": [null] },
       {
         "key": "reasoning",
@@ -2057,40 +2022,6 @@
         ],
         "skipValues": [null],
         "type": "string"
-      },
-      {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
       }
     ],
 
@@ -2110,40 +2041,6 @@
     ],
     "params": [
       { "key": "max_completion_tokens", "defaultValue": 20000, "minValue": 1, "maxValue": 272000 },
-      {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
-      },
       {
         "key": "response_format",
         "defaultValue": null,

--- a/general/azure-openai.json
+++ b/general/azure-openai.json
@@ -2116,46 +2116,6 @@
         "type": "string"
       },
       {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [null]
-            }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
-      },
-
-      {
         "key": "verbosity",
         "enum": ["low", "medium", "high", null],
         "defaultValue": null,
@@ -2689,45 +2649,6 @@
         ],
         "skipValues": [null],
         "type": "string"
-      },
-      {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [null]
-            }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
       }
     ],
 
@@ -2751,45 +2672,6 @@
         "defaultValue": 20000,
         "minValue": 1,
         "maxValue": 272000
-      },
-      {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [null]
-            }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
       },
       {
         "key": "response_format",

--- a/general/open-ai.json
+++ b/general/open-ai.json
@@ -1559,41 +1559,6 @@
         "skipValues": [null],
         "type": "string"
       },
-      {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
-      },
-
       { "key": "verbosity", "enum": ["low", "medium", "high", null], "defaultValue": null, "skipValues": [null] },
       {
         "key": "reasoning",
@@ -1989,40 +1954,6 @@
         ],
         "skipValues": [null],
         "type": "string"
-      },
-      {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
       }
     ],
 
@@ -2042,40 +1973,6 @@
     ],
     "params": [
       { "key": "max_completion_tokens", "defaultValue": 20000, "minValue": 1, "maxValue": 272000 },
-      {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
-      },
       {
         "key": "response_format",
         "defaultValue": null,

--- a/general/openai.json
+++ b/general/openai.json
@@ -1559,41 +1559,6 @@
         "skipValues": [null],
         "type": "string"
       },
-      {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
-      },
-
       { "key": "verbosity", "enum": ["low", "medium", "high", null], "defaultValue": null, "skipValues": [null] },
       {
         "key": "reasoning",
@@ -1989,40 +1954,6 @@
         ],
         "skipValues": [null],
         "type": "string"
-      },
-      {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
       }
     ],
 
@@ -2042,40 +1973,6 @@
     ],
     "params": [
       { "key": "max_completion_tokens", "defaultValue": 20000, "minValue": 1, "maxValue": 272000 },
-      {
-        "key": "response_format",
-        "defaultValue": null,
-        "options": [
-          {
-            "value": null,
-            "name": "Text"
-          },
-          {
-            "value": "json_object",
-            "name": "JSON Object",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_object" }
-              }
-            }
-          },
-          {
-            "value": "json_schema",
-            "name": "JSON Schema",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
-              }
-            },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
-          }
-        ],
-        "skipValues": [null],
-        "type": "string"
-      },
       {
         "key": "response_format",
         "defaultValue": null,

--- a/pricing/anthropic.json
+++ b/pricing/anthropic.json
@@ -81,18 +81,6 @@
       }
     }
   },
-  "claude-2.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.001
-        },
-        "response_token": {
-          "price": 0.04
-        }
-      }
-    }
-  },
   "claude-3-5-sonnet-20241022": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/anthropic.json
+++ b/pricing/anthropic.json
@@ -81,6 +81,18 @@
       }
     }
   },
+  "claude-2.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.04
+        }
+      }
+    }
+  },
   "claude-3-5-sonnet-20241022": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/scripts/check_duplicate_keys.py
+++ b/scripts/check_duplicate_keys.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+import argparse
+import glob
+import json
+import os
+import sys
+from collections import defaultdict
+from typing import Any, Dict, List, Tuple
+
+
+def gha_error(file_path: str, message: str) -> None:
+    safe_message = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    print(f"::error file={file_path}::{safe_message}")
+
+
+def parse_with_duplicate_key_detection(content: str) -> Tuple[Any, List[str]]:
+    duplicate_object_keys: List[str] = []
+
+    def object_pairs_hook(pairs: List[Tuple[str, Any]]) -> Dict[str, Any]:
+        obj: Dict[str, Any] = {}
+        seen = set()
+        for key, value in pairs:
+            if key in seen:
+                duplicate_object_keys.append(key)
+            seen.add(key)
+            obj[key] = value
+        return obj
+
+    parsed = json.loads(content, object_pairs_hook=object_pairs_hook)
+    return parsed, duplicate_object_keys
+
+
+def path_str(parts: List[str]) -> str:
+    if not parts:
+        return "$"
+    return "$." + ".".join(parts)
+
+
+def find_duplicate_param_keys(node: Any, parts: List[str], errors: List[str]) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            next_parts = parts + [key]
+            if key == "params" and isinstance(value, list):
+                occurrences: Dict[str, List[int]] = defaultdict(list)
+                for index, item in enumerate(value):
+                    if isinstance(item, dict):
+                        param_key = item.get("key")
+                        if isinstance(param_key, str):
+                            occurrences[param_key].append(index)
+
+                for param_key, indexes in occurrences.items():
+                    if len(indexes) > 1:
+                        errors.append(
+                            f'Duplicate params key "{param_key}" in array at {path_str(next_parts)} '
+                            f"(indexes: {', '.join(map(str, indexes))})"
+                        )
+
+            find_duplicate_param_keys(value, next_parts, errors)
+    elif isinstance(node, list):
+        for index, item in enumerate(node):
+            find_duplicate_param_keys(item, parts + [f"[{index}]"], errors)
+
+
+def collect_json_files(patterns: List[str]) -> List[str]:
+    files: List[str] = []
+    for pattern in patterns:
+        files.extend(glob.glob(pattern))
+    return sorted(set([f for f in files if os.path.isfile(f)]))
+
+
+def validate_file(file_path: str) -> int:
+    errors = 0
+
+    try:
+        with open(file_path, "r", encoding="utf-8") as file:
+            content = file.read()
+    except OSError as exc:
+        gha_error(file_path, f"Unable to read file: {exc}")
+        return 1
+
+    try:
+        parsed, duplicate_object_keys = parse_with_duplicate_key_detection(content)
+    except json.JSONDecodeError as exc:
+        gha_error(file_path, f"Invalid JSON: {exc}")
+        return 1
+
+    for key in sorted(set(duplicate_object_keys)):
+        gha_error(file_path, f'Duplicate JSON object key "{key}" found')
+        errors += 1
+
+    params_key_errors: List[str] = []
+    find_duplicate_param_keys(parsed, [], params_key_errors)
+    for message in params_key_errors:
+        gha_error(file_path, message)
+        errors += 1
+
+    if errors == 0:
+        print(f"OK: {file_path}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check JSON files for duplicate object keys and duplicate params[].key entries."
+    )
+    parser.add_argument(
+        "patterns",
+        nargs="*",
+        default=["general/*.json", "pricing/*.json"],
+        help="Glob patterns for files to validate",
+    )
+    args = parser.parse_args()
+
+    files = collect_json_files(args.patterns)
+    if not files:
+        print("No files matched the provided patterns.")
+        return 0
+
+    print(f"Checking {len(files)} file(s) for duplicate keys...")
+    total_errors = 0
+    for file_path in files:
+        total_errors += validate_file(file_path)
+
+    if total_errors > 0:
+        print(f"Found {total_errors} duplicate-key error(s).")
+        return 1
+
+    print("No duplicate keys found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_duplicate_keys.py
+++ b/scripts/check_duplicate_keys.py
@@ -12,11 +12,13 @@ from typing import Any, Dict, List, Optional, Tuple
 
 def gha_error(file_path: str, message: str, line: Optional[int] = None) -> None:
     safe_message = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    # Keep file path in message body too, since some GitHub views truncate annotation metadata.
+    message_with_file = f"{file_path}: {safe_message}"
     if line is not None and line > 0:
-        print(f"::error file={file_path},line={line}::{safe_message}")
+        print(f"::error file={file_path},line={line}::{message_with_file}")
         return
 
-    print(f"::error file={file_path}::{safe_message}")
+    print(f"::error file={file_path}::{message_with_file}")
 
 
 def parse_with_duplicate_key_detection(content: str) -> Tuple[Any, List[str]]:

--- a/scripts/check_duplicate_keys.py
+++ b/scripts/check_duplicate_keys.py
@@ -4,13 +4,18 @@ import argparse
 import glob
 import json
 import os
+import re
 import sys
 from collections import defaultdict
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
-def gha_error(file_path: str, message: str) -> None:
+def gha_error(file_path: str, message: str, line: Optional[int] = None) -> None:
     safe_message = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    if line is not None and line > 0:
+        print(f"::error file={file_path},line={line}::{safe_message}")
+        return
+
     print(f"::error file={file_path}::{safe_message}")
 
 
@@ -35,6 +40,94 @@ def path_str(parts: List[str]) -> str:
     if not parts:
         return "$"
     return "$." + ".".join(parts)
+
+
+def index_to_line(content: str, char_index: int) -> int:
+    return content.count("\n", 0, char_index) + 1
+
+
+def find_matching_closer(content: str, start_index: int, opener: str, closer: str) -> Optional[int]:
+    if start_index < 0 or start_index >= len(content) or content[start_index] != opener:
+        return None
+
+    depth = 0
+    in_string = False
+    escaped = False
+
+    for index in range(start_index, len(content)):
+        char = content[index]
+
+        if escaped:
+            escaped = False
+            continue
+
+        if char == "\\":
+            escaped = True
+            continue
+
+        if char == '"':
+            in_string = not in_string
+            continue
+
+        if in_string:
+            continue
+
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return index
+
+    return None
+
+
+def find_json_key_lines(content: str, key: str) -> List[int]:
+    pattern = re.compile(rf'"{re.escape(key)}"\s*:')
+    return [index_to_line(content, match.start()) for match in pattern.finditer(content)]
+
+
+def find_param_key_lines(content: str, path_parts: List[str], param_key: str) -> List[int]:
+    if not path_parts or path_parts[-1] != "params":
+        return []
+
+    current_start = 0
+    current_end = len(content)
+
+    # Walk all object keys before "params" to narrow down to the target model/object block.
+    for key in path_parts[:-1]:
+        key_pattern = re.compile(rf'"{re.escape(key)}"\s*:\s*')
+        key_match = key_pattern.search(content, current_start, current_end)
+        if not key_match:
+            return []
+
+        # Move to first non-space token after the colon.
+        value_start = key_match.end()
+        while value_start < len(content) and content[value_start] in (" ", "\t", "\r", "\n"):
+            value_start += 1
+
+        if value_start >= len(content) or content[value_start] != "{":
+            return []
+
+        value_end = find_matching_closer(content, value_start, "{", "}")
+        if value_end is None:
+            return []
+
+        current_start = value_start + 1
+        current_end = value_end
+
+    params_pattern = re.compile(r'"params"\s*:\s*\[')
+    params_match = params_pattern.search(content, current_start, current_end)
+    if not params_match:
+        return []
+
+    array_start = params_match.end() - 1
+    array_end = find_matching_closer(content, array_start, "[", "]")
+    if array_end is None:
+        return []
+
+    key_pattern = re.compile(rf'"key"\s*:\s*"{re.escape(param_key)}"')
+    return [index_to_line(content, match.start()) for match in key_pattern.finditer(content, array_start, array_end + 1)]
 
 
 def find_duplicate_param_keys(node: Any, parts: List[str], errors: List[str]) -> None:
@@ -86,13 +179,41 @@ def validate_file(file_path: str) -> int:
         return 1
 
     for key in sorted(set(duplicate_object_keys)):
-        gha_error(file_path, f'Duplicate JSON object key "{key}" found')
+        key_lines = find_json_key_lines(content, key)
+        line_hint = key_lines[0] if key_lines else None
+        if key_lines:
+            gha_error(
+                file_path,
+                f'Duplicate JSON object key "{key}" found (occurrences at lines: {", ".join(map(str, key_lines[:12]))})',
+                line=line_hint,
+            )
+        else:
+            gha_error(file_path, f'Duplicate JSON object key "{key}" found')
         errors += 1
 
     params_key_errors: List[str] = []
     find_duplicate_param_keys(parsed, [], params_key_errors)
     for message in params_key_errors:
-        gha_error(file_path, message)
+        match = re.match(r'^Duplicate params key "([^"]+)" in array at (\$\.[^ ]+)', message)
+        if not match:
+            gha_error(file_path, message)
+            errors += 1
+            continue
+
+        param_key = match.group(1)
+        param_path = match.group(2)
+        path_parts = param_path.removeprefix("$.").split(".")
+        line_numbers = find_param_key_lines(content, path_parts, param_key)
+        line_hint = line_numbers[0] if line_numbers else None
+
+        if line_numbers:
+            gha_error(
+                file_path,
+                f'{message}; lines: {", ".join(map(str, line_numbers))}',
+                line=line_hint,
+            )
+        else:
+            gha_error(file_path, message)
         errors += 1
 
     if errors == 0:


### PR DESCRIPTION
## Summary
- add a new validation script at `scripts/check_duplicate_keys.py` to catch:
  - duplicate JSON object keys at any nesting level (e.g. duplicate model IDs like `"gpt-4"`)
  - duplicate `params[].key` values within the same `params` array (e.g. two `"max_tokens"` entries)
- update `.github/workflows/validate-json.yml` to run on both `push` and `pull_request` to `main` for `pricing/**` and `general/**`
- add a new workflow step to run `python3 scripts/check_duplicate_keys.py` after existing `jq` syntax checks

## Why
`jq empty` only validates JSON syntax and does not fail when duplicate object keys exist.  
This change prevents silent config overrides and conflicting param definitions from being merged.

## Test plan
- run locally from `models/`:
  - `python3 scripts/check_duplicate_keys.py`
- verify workflow behavior:
  - passes when no duplicate keys are present
  - fails with GitHub Actions `::error` annotations when duplicates are found

## Notes
- current repo data already contains some duplicate `params[].key` entries (e.g. `response_format` in certain `gpt-5*` sections), so CI may fail until those are cleaned up.