### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -576,7 +576,7 @@
         "image": {
           "default": {
             "default": {
-              "price": 2
+              "price": 1.6
             },
             "1024x1024": {
               "price": 2
@@ -590,7 +590,7 @@
           },
           "standard": {
             "default": {
-              "price": 2
+              "price": 1.6
             },
             "1024x1024": {
               "price": 2
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1339,6 +1339,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.6
         }
       }
     }
@@ -1383,6 +1386,9 @@
           "response_audio_token": {
             "price": 1.5
           }
+        },
+        "response_audio_token": {
+          "price": 0.0012
         }
       }
     }
@@ -1403,6 +1409,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0006
         }
       }
     }
@@ -1423,6 +1432,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0003
         }
       }
     }
@@ -1554,6 +1566,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       },
       "batch_config": {
@@ -1574,6 +1589,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       }
     }
@@ -1721,7 +1739,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1762,7 +1780,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2130,10 +2148,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
@@ -2164,10 +2182,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
@@ -2193,7 +2211,7 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
@@ -2259,16 +2277,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2286,16 +2304,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2611,10 +2629,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2692,7 +2710,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.0002
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2719,7 +2737,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.0002
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2747,6 +2765,9 @@
         },
         "request_audio_token": {
           "price": 0.0032
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2761,10 +2782,13 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
         }
       }
     }
@@ -2850,6 +2874,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3227,7 +3257,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.000008
@@ -3321,7 +3351,7 @@
           "price": 0.0008
         },
         "response_image_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "request_text_token": {
           "price": 0.0005
@@ -3340,6 +3370,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3478,7 +3514,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3508,7 +3544,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3569,6 +3605,9 @@
         },
         "response_audio_token": {
           "price": 0.0064
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -3590,6 +3629,9 @@
         },
         "response_audio_token": {
           "price": 0.002
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
         }
       }
     }
@@ -3611,6 +3653,9 @@
         },
         "response_audio_token": {
           "price": 0.002
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
         }
       }
     }
@@ -3748,7 +3793,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -3757,7 +3802,7 @@
           "price": 0.0008
         },
         "response_image_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "cache_read_image_input_token": {
           "price": 0.0002
@@ -3782,6 +3827,9 @@
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "response_image_token": {
+          "price": 0.0008
         }
       }
     }
@@ -3868,7 +3916,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0002
         },
         "request_audio_token": {
           "price": 0.0032
@@ -3898,7 +3946,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0
+          "price": 0.000125
         },
         "request_audio_token": {
           "price": 0.0032
@@ -3977,6 +4025,9 @@
         },
         "response_token": {
           "price": 0.018
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }
@@ -3989,6 +4040,9 @@
         },
         "response_token": {
           "price": 0.018
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 34 |


### 🔄 Updated Models
- `gpt-5.4-pro`
- `gpt-5.4-pro-2026-03-05`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `o4-mini-deep-research-2025-06-26`
- `o3-deep-research`
- `o3-deep-research-2025-06-26`
- `computer-use-preview`
- `computer-use-preview-2025-03-11`
- `gpt-realtime`
- `gpt-realtime-2025-08-28`
- `gpt-realtime-1.5`
- `gpt-realtime-mini`
- `gpt-realtime-mini-2025-10-06`
- `gpt-realtime-mini-2025-12-15`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-audio`
- `gpt-audio-2025-08-28`
- `gpt-audio-1.5`
- `gpt-audio-mini`
- `gpt-audio-mini-2025-10-06`
- `gpt-audio-mini-2025-12-15`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-4o-mini-tts`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `whisper-1`
- `gpt-image-1`
- ... and 4 more


## Model Coverage (128 models total)

| Batch | Family | Count |
|-------|--------|-------|
| 1 | GPT-5.4, GPT-5.3, GPT-5.2, GPT-5.1, GPT-5.0 (top) | 25 |
| 2 | GPT-5.0 (cont.), GPT-4.1, GPT-4o, Search Preview | 25 |
| 3 | O-series (o1/o3/o4), computer-use, GPT-4-turbo, GPT-4, GPT-3.5 | 25 |
| 4 | Realtime, Audio, TTS models | 25 |
| 5 | Transcribe, Whisper, TTS legacy, Image (gpt-image, DALL-E), Sora, Embeddings, Moderation, Legacy | 25 |
| 6 | GPT-3.5-turbo-16k, babbage-002, davinci-002 | 3 |

## Pricing Source
- Models list: OpenAI Models API (`get_openai_models`)
- Pricing data: LiteLLM `model_prices_and_context_window.json` (fallback — OpenAI pricing page blocked by Cloudflare)
- All Standard tier pricing

---
*Generated by Pricing Agent on 2026-04-07*