### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,11 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -1322,23 +1322,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
-            "price": 0.01
+            "price": 0.0001
           },
           "input_video_plus": {
-            "price": 0.2
+            "price": 0.002
           },
           "input_video_standard": {
-            "price": 0.1
+            "price": 0.001
           },
           "input_video_essential": {
-            "price": 0.05
+            "price": 0.0005
           }
         }
       },
@@ -1560,6 +1560,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1602,7 +1605,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2522,7 +2525,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2577,6 +2580,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2693,6 +2699,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2761,12 +2770,15 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2791,6 +2803,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2932,6 +2947,17 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
         }
       }
     }
@@ -2944,6 +2970,20 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.012
+          },
+          "input_video_plus": {
+            "price": 0.079
+          },
+          "input_video_standard": {
+            "price": 0.079
+          },
+          "input_video_essential": {
+            "price": 0.016
+          }
         }
       }
     }
@@ -3515,6 +3555,57 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 3 |
| 🔄 Models updated (merged) | 10 |

### ➕ New Models
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `veo-3.1-lite-generate-001`

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-2.5-computer-use-preview-10-2025`
- `gemini-3-pro-image-preview`
- `gemini-3-flash-preview`
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-image-preview`
- `gemini-3.1-flash-lite-preview`
- `multimodalembedding@001`
- `veo-3.1-fast-generate-001`
- `gemini-embedding-2-preview`


## Model-to-Pricing-Page Mapping

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Standard ≤200K rate used; cache_read, batch included |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | cache_read, batch included |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 | API | Maps to Gemini 2.5 Flash pricing |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | cache_read, batch included |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 | API | Maps to Gemini 2.5 Flash Lite pricing |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | image_token additional included |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API | Price not found; TTS model — added with price 0 |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API | Price not found; TTS model — added with price 0 |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 | API | Maps to Gemini 2.5 Pro Computer Use pricing |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | batch included |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | batch included |
| `gemini-3-pro-preview` | Google – Gemini 3 | API | Standard ≤200K rate; batch included; web_search $1.4/1000 |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API | image_token additional; batch included |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | batch included |
| `gemini-3.1-pro-preview` | Google – Gemini 3.1 | API | Maps to Gemini 3.1 Pro pricing; batch included |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3.1 | API | image_token additional; batch included |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3.1 | API | batch included |
| `gemini-embedding-001` | Google – Embedding | API | $/1K tokens; output free |
| `text-embedding-005` | Google – Embedding | API | $/1K chars (per_thousand_tokens) |
| `text-embedding-large-exp-03-07` | Google – Embedding | API | Shares pricing with text-embedding-005 |
| `text-multilingual-embedding-002` | Google – Embedding | API | $/1K chars |
| `textembedding-gecko@003` | Google – Embedding | API | Legacy; $/1K chars |
| `multimodalembedding@001` | Google – Multimodal Embedding | API | Text $/1K chars + per-image/video additional |
| `imagen-4.0-ultra-generate-001` | Google – Imagen | API | $0.06/image |
| `imagen-4.0-generate-001` | Google – Imagen | API | $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen | API | $0.02/image |
| `imagen-3.0-generate-002` | Google – Imagen | API | $0.04/image |
| `imagen-3.0-capability-001` | Google – Imagen | API | Capability model; uses imagen-3.0-generate pricing ($0.04/image) |
| `imagen-3.0-capability-002` | Google – Imagen | API | Capability model; uses imagen-3.0-generate pricing ($0.04/image) |
| `veo-2.0-generate-001` | Google – Veo | API | $0.50/sec; 8s default duration |
| `veo-3.0-generate-001` | Google – Veo | API | $0.20/sec video; 8s default duration |
| `veo-3.0-fast-generate-001` | Google – Veo | API | $0.10/sec; 8s default duration |
| `veo-3.1-generate-001` | Google – Veo | API | $0.20/sec video 720p/1080p; 8s default duration |
| `veo-3.1-fast-generate-001` | Google – Veo | API | $0.10/sec; 8s default duration |
| `veo-3.1-lite-generate-001` | Google – Veo | API | $0.03/sec 720p; 8s default duration |
| `gemini-embedding-2-preview` | Google – Multimodal Embedding | API | Text $/1M tokens + per-image/video/audio additional |
| `claude-opus-4-6` | Anthropic – Claude | API | @default stripped; cache_write (5m), cache_read, batch included |
| `claude-sonnet-4-6` | Anthropic – Claude | API | @default stripped; cache_write (5m), cache_read, batch included |
| `claude-opus-4-1@20250805` | Anthropic – Claude | API | Pinned version; cache_write (5m), cache_read, batch included |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude | API | Pinned version; uses ≤200K rate; cache_write (5m), cache_read, batch included |
| `claude-haiku-4-5@20251001` | Anthropic – Claude | API | Pinned version; cache_write (5m), cache_read, batch included |
| `claude-opus-4-5@20251101` | Anthropic – Claude | API | Pinned version; cache_write (5m), cache_read, batch included |
| `claude-sonnet-4@20250514` | Anthropic – Claude | API | Pinned version; cache_write (5m), cache_read, batch included |
| `claude-opus-4@20250514` | Anthropic – Claude | API | Pinned version; cache_write (5m), cache_read, batch included |
| `gpt-oss-120b-maas` | OpenAI – Partner | API | MaaS model; batch included |
| `llama-3.3-70b-instruct-maas` | Meta – Llama | API | Matches Llama 3.3 70B; batch included |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama | API | Matches Llama 4 Maverick; batch included |
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen – Partner | API | Matches Qwen3-235B-A22B-Instruct-2507; batch included |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen – Partner | API | Matches Qwen3-Coder-480B; batch included |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen – Partner | API | Matches Qwen3-Next-80B-Instruct |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen – Partner | API | Matches Qwen3-Next-80B-Thinking |
| `mistral-small-2503` | Mistral – Partner | API | Matches Mistral Small 3.1 (25.03) |
| `mistral-medium-3` | Mistral – Partner | API | Matches Mistral Medium 3 |
| `codestral-2` | Mistral – Partner | API | Matches Codestral 2 |
| `deepseek-r1-0528-maas` | DeepSeek – Partner | API | Matches DeepSeek-R1 (0528) |
| `deepseek-v3.1-maas` | DeepSeek – Partner | API | Matches DeepSeek-V3.1; batch included |
| `deepseek-v3.2-maas` | DeepSeek – Partner | API | Matches DeepSeek-V3.2; batch included |
| `kimi-k2-thinking-maas` | Moonshot (Kimi) – Partner | API | Matches Kimi-K2-Thinking |
| `minimax-m2-maas` | MiniMax – Partner | API | Matches MiniMax-M2 |
| `glm-4.7-maas` | ZAI.org (GLM) – Partner | API | Matches GLM-4.7 |
| `glm-5-maas` | ZAI.org (GLM) – Partner | API | Matches GLM-5 |

## Excluded Models

| Model ID | Publisher | Reason |
|----------|-----------|--------|
| `*-live-*` | Google | Gemini Live streaming — separate product |
| `lyria-*` | Google | Music generation — excluded per rules |
| `model-optimizer-*` | Google | Dynamic routing meta-endpoint |
| `imagegeneration` | Google | Legacy model, superseded |
| `virtual-try-on-001` | Google | Product-specific retail model |
| `pretrained-ocr` | Google | OCR model |
| Non-generative CV/NLP (faster-r-cnn, retinanet, mask-r-cnn, segment-anything, roberta, xlm-roberta, nllb, imagebind) | Meta | Non-generative ML models |
| Self-deploy models without -maas (codestral-2501-self-deploy, mistral-large-3, ministral-3, etc.) | Mistral/all | Self-deploy: has_deploy=true, no -maas suffix |
| `llama-guard`, `prompt-guard` | Meta | Safety/guard models |
| `qwen-image` | Qwen | Explicit global exception — excluded from Vertex AI pricing |
| `glm-image` | ZAI.org | Explicit global exception — excluded from Vertex AI pricing |
| `jamba-large-1.6` | AI21 | Self-deploy (has_deploy=true, no -maas suffix) |
| `whisper-large`, `whisper-1` | OpenAI | Audio transcription — not generative inference |
| `clip-vit-base-patch32`, `openclip` | OpenAI | Non-generative (vision classification, feature extraction) |
| `deepseek-ocr-*`, `glm-ocr`, `mistral-ocr-*` | DeepSeek/ZAI/Mistral | OCR models — excluded per global rules |
| `sam3` | Meta | Non-generative (segmentation) |

---
*Generated by Pricing Agent on 2026-04-07*