### PR TITLE
chore(pricing): Update fireworks-ai pricing

### DIFF
--- a/general/fireworks-ai.json
+++ b/general/fireworks-ai.json
@@ -648,5 +648,111 @@
     "name": "qwen3-embedding-8b",
     "type": { "primary": "embedding" },
     "disablePlayground": true
+  },
+  "deepseek-v3p1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3p2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4p7": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-5": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-5p1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-oss-120b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-oss-20b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "minimax-m2p1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "minimax-m2p5": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-8b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3p6-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "flux-1-dev-fp8": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "flux-1-schnell-fp8": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "flux-kontext-pro": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "flux-kontext-max": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "qwen3-embedding-8b": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
   }
 }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -126,7 +126,7 @@
           "price": 0.0000008
         },
         "response_token": {
-          "price": 0.0000008
+          "price": 0
         }
       }
     }
@@ -481,29 +481,6 @@
       }
     }
   },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
   "minimax-m2p1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -543,52 +520,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "qwen3p6-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00012
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.00006
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00006
         },
         "response_token": {
           "price": 0.00006
@@ -638,6 +569,75 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00005
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000025
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -56,6 +56,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -112,10 +123,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -124,10 +135,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -136,10 +147,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -236,6 +247,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -260,6 +282,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -272,6 +305,399 @@
         },
         "response_token": {
           "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "deepseek-v3p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "deepseek-v3p2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "glm-4p7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "glm-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00016
+        }
+      }
+    }
+  },
+  "glm-5p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00016
+        }
+      }
+    }
+  },
+  "gpt-oss-120b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.0000035
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "minimax-m2p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "minimax-m2p5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00012
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "flux-1-dev-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.05
+          }
+        }
+      }
+    }
+  },
+  "flux-1-schnell-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.035
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 8
+            }
+          }
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: fireworks-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 19 |
| 🔄 Models updated (merged) | 5 |

### ➕ New Models
- `deepseek-v3p1`
- `deepseek-v3p2`
- `glm-4p7`
- `glm-5`
- `glm-5p1`
- `gpt-oss-120b`
- `gpt-oss-20b`
- `minimax-m2p1`
- `minimax-m2p5`
- `qwen3-vl-30b-a3b-instruct`
- `qwen3-vl-30b-a3b-thinking`
- `llama-v3p3-70b-instruct`
- `qwen3-8b`
- `qwen3p6-plus`
- `flux-1-dev-fp8`
- `flux-1-schnell-fp8`
- `flux-kontext-pro`
- `flux-kontext-max`
- `qwen3-embedding-8b`

### 🔄 Updated Models
- `kimi-k2-instruct-0905`
- `kimi-k2-thinking`
- `kimi-k2p5`
- `mixtral-8x22b-instruct`
- `nomic-ai/nomic-embed-text-v1.5`


## Data Sources

- **Models API**: `get_fireworks_models` — 24 serverless models
- **Pricing reference**: LiteLLM pricing DB (https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json) — cross-referenced with fireworks.ai/pricing page tier structure

## Model → Pricing Category Mapping

### Named Families
| Model | Input | Output | Cache Read |
|---|---|---|---|
| deepseek-v3p1, deepseek-v3p2 | $0.56 | $1.68 | $0.28 |
| glm-4p7 | $0.60 | $2.20 | $0.30 |
| glm-5, glm-5p1 | $1.00 | $3.20 | $0.20 |
| gpt-oss-120b | $0.15 | $0.60 | $0.075 |
| gpt-oss-20b | $0.07 | $0.30 | $0.035 |
| kimi-k2-instruct-0905, kimi-k2-thinking | $0.60 | $2.50 | $0.30 |
| kimi-k2p5 | $0.60 | $3.00 | $0.10 |
| minimax-m2p1, minimax-m2p5 | $0.30 | $1.20 | $0.03 |
| qwen3-vl-30b-a3b-instruct/thinking | $0.15 | $0.60 | $0.075 |

### Tier-Based
| Model | Tier | Input | Output |
|---|---|---|---|
| qwen3-8b | 4B–16B | $0.20 | $0.20 |
| llama-v3p3-70b-instruct | >16B | $0.90 | $0.90 |
| mixtral-8x22b-instruct | MoE 56.1–176B | $1.20 | $1.20 |
| qwen3p6-plus | MoE 0–56B | $0.50 | $0.50 |

### Image (per-step)
| Model | Price/step |
|---|---|
| flux-1-dev-fp8 | $0.0005 |
| flux-1-schnell-fp8 | $0.00035 |

### Image (per-image)
| Model | Price/image |
|---|---|
| flux-kontext-pro | $0.04 |
| flux-kontext-max | $0.08 |

### Embeddings
| Model | Input $/MTok |
|---|---|
| qwen3-embedding-8b | $0.10 |
| nomic-ai/nomic-embed-text-v1.5 | $0.008 |

### Skipped
- qwen3-reranker-8b (reranker — excluded per skill rules)

**Batch pricing**: 50% of serverless input and output for all text/vision models.
**Cache pricing**: 50% of input (read only, no cache_write) for all text/vision models, except named-family overrides (glm-5/5p1: $0.20, kimi-k2p5: $0.10, minimax: $0.03).

---
*Generated by Pricing Agent on 2026-04-07*