### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1753,5 +1753,11 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -747,6 +747,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         },
         "cache_read_input_token": {
@@ -755,10 +758,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +770,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -778,6 +781,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         },
         "cache_read_input_token": {
@@ -786,10 +792,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +839,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -861,10 +870,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -921,10 +933,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -952,6 +967,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         },
         "cache_read_input_token": {
@@ -1157,6 +1175,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1191,6 +1212,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1399,6 +1423,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         },
         "cache_read_input_token": {
@@ -1430,6 +1457,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         },
         "cache_read_input_token": {
@@ -1532,6 +1562,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1563,6 +1596,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1597,6 +1633,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1631,6 +1670,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1685,6 +1727,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1719,6 +1764,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1883,6 +1931,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         },
         "cache_read_input_token": {
@@ -1914,6 +1965,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         },
         "cache_read_input_token": {
@@ -1943,7 +1997,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1951,12 +2005,15 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1977,7 +2034,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1985,12 +2042,15 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2084,6 +2144,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2118,6 +2181,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2285,6 +2351,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2316,6 +2385,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2347,6 +2419,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2378,6 +2453,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2409,6 +2487,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2440,6 +2521,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2463,7 +2547,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2471,12 +2555,15 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2494,7 +2581,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2502,12 +2589,15 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2533,6 +2623,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2564,6 +2657,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2581,10 +2677,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2595,15 +2691,18 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,10 +2711,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2626,15 +2725,18 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2650,10 +2752,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2678,10 +2783,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2820,7 +2928,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2951,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2974,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2997,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +3020,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +3043,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +3066,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +3089,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3112,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3135,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3043,7 +3151,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.015
         },
         "response_token": {
           "price": 0
@@ -3060,7 +3168,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.015
         },
         "response_token": {
           "price": 0
@@ -3174,7 +3282,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3322,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3346,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3391,40 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 48 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-2.5-pro-lte-128k`
- `gemini-2.5-pro-gt-128k`
- `gemini-2.5-flash-lte-128k`
- `gemini-2.5-flash-gt-128k`
- `gemini-2.5-flash-lite-lte-128k`
- `gemini-2.5-flash-lite-gt-128k`
- `gemini-2.5-flash-image-lte-128k`
- `gemini-2.5-flash-image-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-lite-001-lte-128k`
- `gemini-2.0-flash-lite-001-gt-128k`
- `gemini-2.0-flash-lite-lte-128k`
- `gemini-2.0-flash-lite-gt-128k`
- `gemini-3.1-pro-preview-lte-128k`
- `gemini-3.1-pro-preview-gt-128k`
- `gemini-3-pro-preview-lte-128k`
- `gemini-3-pro-preview-gt-128k`
- `gemini-3-flash-preview-lte-128k`
- `gemini-3-flash-preview-gt-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-3.1-flash-image-preview-lte-128k`
- `gemini-3.1-flash-image-preview-gt-128k`
- `gemini-3-pro-image-preview-lte-128k`
- `gemini-3-pro-image-preview-gt-128k`
- `gemini-3.1-pro-preview-customtools-lte-128k`
- `gemini-3.1-pro-preview-customtools-gt-128k`
- ... and 18 more


### Model to Pricing Page Mapping

| Model ID | Pricing Page Section | Notes |
|----------|----------------------|-------|
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K tokens | input $1.25/1M, output $10/1M, cache read $0.13; batch $0.625/$5; web_search/search: 3.5¢, enterprise_web_search: 4.5¢ |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K tokens | input $2.50/1M, output $15/1M, cache read $0.25; batch $1.25/$7.50 |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash (flat pricing) | input $0.30/1M, output $2.50/1M, cache read $0.03; batch $0.15/$1.25; web_search/search: 3.5¢ |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash (flat pricing) | same as lte — page shows flat pricing |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash-Lite (flat pricing) | input $0.10/1M, output $0.40/1M, cache read $0.01; batch $0.05/$0.20; web_search/search: 3.5¢ |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash-Lite (flat pricing) | same as lte — page shows flat pricing |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image (flat pricing) | input $0.30/1M, text output $2.50/1M, image output $30/1M; batch $0.15 in/$1.25 text out; web_search/search: 3.5¢ |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image (flat pricing) | same as lte — page shows flat pricing |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash (flat pricing) | input $0.15/1M, output $0.60/1M; batch $0.075/$0.30; web_search/search: 3.5¢ |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash (flat pricing) | same as lte — page shows flat pricing |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash alias → gemini-2.0-flash-001 | same pricing as gemini-2.0-flash-001 |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash alias → gemini-2.0-flash-001 | same pricing as gemini-2.0-flash-001 |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash Lite (flat pricing) | input $0.075/1M, output $0.30/1M; batch $0.0375/$0.15; web_search/search: 3.5¢ |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash Lite (flat pricing) | same as lte — page shows flat pricing |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash Lite alias → gemini-2.0-flash-lite-001 | same pricing as gemini-2.0-flash-lite-001 |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash Lite alias → gemini-2.0-flash-lite-001 | same pricing as gemini-2.0-flash-lite-001 |
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K tokens | input $2/1M, output $12/1M, cache read $0.2; batch $1/$6; web_search/search: 1.4¢, enterprise_web_search: 4.5¢ |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K tokens | input $4/1M, output $18/1M, cache read $0.4; batch $2/$9 |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K tokens | input $2/1M, output $12/1M, cache read $0.2; batch $1/$6; web_search/search: 1.4¢ |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K tokens | input $4/1M, output $18/1M, cache read $0.4; batch $2/$9 |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview (flat pricing) | input $0.50/1M, output $3/1M, cache read $0.05; batch $0.25/$1.50; web_search/search: 1.4¢ |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview (flat pricing) | same as lte — page shows flat pricing |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash Lite Preview (flat pricing) | input $0.25/1M, output $1.50/1M, cache read $0.03; batch $0.13/$0.75; web_search/search: 1.4¢ |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash Lite Preview (flat pricing) | same as lte — page shows flat pricing |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview (flat pricing) | input $0.50/1M, text output $3/1M, image output $60/1M; batch $0.25 in/$1.50 text out (batch image $30/1M); web_search/search: 1.4¢ |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview (flat pricing) | same as lte — page shows flat pricing |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview (flat pricing) | input $2/1M, text output $12/1M, image output $120/1M; batch $1 in/$6 text out; web_search/search: 1.4¢ |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview (flat pricing) | same as lte — page shows flat pricing |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview CustomTools — same pricing as gemini-3.1-pro-preview | ≤200K: $2/$12 |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview CustomTools — same pricing as gemini-3.1-pro-preview | >200K: $4/$18 |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4.0 Ultra Generate | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4.0 Ultra Generate | same as lte — per-image pricing |
| imagen-4.0-generate-001-lte-128k | Imagen 4.0 Generate | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4.0 Generate | same as lte — per-image pricing |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4.0 Fast Generate | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4.0 Fast Generate | same as lte — per-image pricing |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Generate Preview | $0.20/sec video, default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Generate Preview | same as lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast Generate Preview | $0.08/sec at 720p |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast Generate Preview | same as lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite Generate Preview | $0.03/sec at 720p |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite Generate Preview | same as lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0 Generate | $0.20/sec video, default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3.0 Generate | same as lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast Generate | $0.08/sec |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast Generate | same as lte |
| veo-2.0-generate-001-lte-128k | Veo 2.0 Generate | $0.50/sec |
| veo-2.0-generate-001-gt-128k | Veo 2.0 Generate | same as lte |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | $0.00015/1K tokens input; output 0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 | same as lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview | $0.20/1M tokens text input; per-image and per-video pricing also available |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview | same as lte |
| gemini-pro-latest-lte-128k | *-latest alias → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview ≤200K |
| gemini-pro-latest-gt-128k | *-latest alias → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview >200K |
| gemini-flash-latest-lte-128k | *-latest alias → resolved to gemini-3-flash-preview | same pricing as gemini-3-flash-preview |
| gemini-flash-latest-gt-128k | *-latest alias → resolved to gemini-3-flash-preview | same as lte |
| gemini-flash-lite-latest-lte-128k | *-latest alias → resolved to gemini-3.1-flash-lite-preview | same pricing as gemini-3.1-flash-lite-preview |
| gemini-flash-lite-latest-gt-128k | *-latest alias → resolved to gemini-3.1-flash-lite-preview | same as lte |

### Pricing Source
- Vertex AI Generative AI Pricing (Global): https://cloud.google.com/vertex-ai/generative-ai/pricing
- Gemini API models list: get_gemini_models API

### Notes
- Gemini 2.5 series web search: $35/1K grounded prompts → 3.5 cents each
- Gemini 3.x series web search: $14/1K queries → 1.4 cents each
- Enterprise web search (all generations): $45/1K → 4.5 cents each
- Context tiers: Vertex page shows 200K thresholds; lte-128k uses ≤200K rate, gt-128k uses >200K rate where tiered
- Models with flat pricing (no context tiers): Flash, Flash-Lite, Flash-Image, Imagen, Veo, Embedding — lte/gt entries identical
- gemini-2.0-flash and gemini-2.0-flash-lite are bare aliases without -001 suffix; priced same as their -001 canonical versions
- nano-banana-pro-preview: not found on pricing page; excluded per exclusion rules


---
*Generated by Pricing Agent on 2026-04-07*