### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1383,6 +1383,9 @@
           "response_audio_token": {
             "price": 1.5
           }
+        },
+        "response_audio_token": {
+          "price": 0.0012
         }
       }
     }
@@ -1403,6 +1406,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0006
         }
       }
     }
@@ -1423,6 +1429,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0003
         }
       }
     }
@@ -2193,7 +2202,7 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
@@ -2265,10 +2274,10 @@
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2292,10 +2301,10 @@
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2611,10 +2620,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2761,10 +2770,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2850,6 +2859,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3340,6 +3355,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3428,6 +3449,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3748,7 +3775,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -3757,7 +3784,7 @@
           "price": 0.0008
         },
         "response_image_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "cache_read_image_input_token": {
           "price": 0.0002
@@ -3782,6 +3809,9 @@
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "response_image_token": {
+          "price": 0.0008
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 14 |


### 🔄 Updated Models
- `gpt-4o-audio-preview`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `gpt-4o-mini-tts`
- `gpt-audio-mini`
- `o4-mini-deep-research-2025-06-26`
- `gpt-image-1`
- `gpt-image-1-mini`
- `gpt-image-1.5`
- `gpt-image-1.5-2025-12-16`
- `chatgpt-image-latest`


## Data Sources

- **Models**: OpenAI Models API (`get_openai_models`) — 128 models retrieved (ft:* excluded)
- **Pricing**: LiteLLM model prices JSON (`https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`) — used as fallback since OpenAI pricing page (platform.openai.com/docs/pricing) was blocked by Cloudflare

## Model Families Covered

| Family | Count |
|--------|-------|
| GPT-5.4 (including pro, mini, nano) | 8 |
| GPT-5.3 / 5.2 / 5.1 (chat, codex, pro) | 17 |
| GPT-5 base (chat, codex, mini, nano, pro, search) | 14 |
| GPT-4.1 (mini, nano) | 6 |
| GPT-4o text + search | 9 |
| GPT-4o audio / realtime / transcribe / TTS | 18 |
| GPT Audio / Realtime families | 10 |
| O-series (o1, o3, o4-mini, pro, deep-research) | 16 |
| Computer Use | 2 |
| Codex | 1 |
| Image (gpt-image, chatgpt-image, dall-e) | 7 |
| Sora | 2 |
| TTS / Whisper | 5 |
| Embeddings | 3 |
| Moderation | 2 |
| Legacy (GPT-4, GPT-3.5, babbage, davinci) | 10 |
| **Total** | **130** |

---
*Generated by Pricing Agent on 2026-04-08*