### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,409 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemini-2.5-flash-exp-05-20": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemini-2.5-flash-image-generation": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "gemini-2.5-flash-preview-tts": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "gemini-2.5-pro-preview-tts": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "gemini-2.0-flash-live-001": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    },
+    "disablePlayground": true
+  },
+  "gemini-1.5-flash-8b-001": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "imagen-4.0-ultra-generate-exp-05-20": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "imagen-4.0-capability-preview-05-20": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "veo-3-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "veo-3-fast-generate-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "veo-2-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "textembedding-gecko@002": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "gemini-embedding-2-preview-06-30": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "gemini-3-flash-preview-06-05": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemini-3-flash-preview-06-05-image-generation": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "gemini-3-pro-preview-06-05": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemini-3-pro-preview-06-05-image-generation": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "gemini-3.1-pro-preview-06-05": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemini-3.1-flash-image-preview-06-05": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "gemini-3.1-flash-lite-preview-06-05": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemini-3.1-flash-preview-06-05": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "llama3-405b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama3-70b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama3-8b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama3-1-405b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama3-1-70b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama3-1-8b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama3-2-90b-vision-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "llama3-2-11b-vision-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "llama3-2-3b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama3-2-1b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama3-3-70b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama-4-scout-17b-16e-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "deepseek-r1-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-0528-full-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-32b-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-30b-a3b-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-235b-a22b-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-14b-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwq-32b-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-72b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2-5-coder-32b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2-5-vl-72b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "kimi-k2-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "moonshot-v1-32k-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "minimax-text-01-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4v-plus-0111-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "glm-4-long-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4-9b-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "jamba-1-5-large": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -351,6 +351,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -440,6 +443,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -550,7 +556,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -630,7 +636,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -866,6 +872,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -919,6 +928,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1176,6 +1188,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1266,10 +1281,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1277,15 +1292,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1294,10 +1315,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1305,15 +1326,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1322,23 +1349,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
-            "price": 0.01
+            "price": 0.0001
           },
           "input_video_plus": {
-            "price": 0.2
+            "price": 0.002
           },
           "input_video_standard": {
-            "price": 0.1
+            "price": 0.001
           },
           "input_video_essential": {
-            "price": 0.05
+            "price": 0.0005
           }
         }
       },
@@ -1445,7 +1472,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       },
       "batch_config": {
@@ -1602,7 +1635,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2199,7 +2232,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.015
         },
         "response_token": {
           "price": 0
@@ -2522,7 +2555,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2932,6 +2965,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
         }
       }
     }
@@ -3331,6 +3367,17 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
         }
       },
       "batch_config": {
@@ -3515,6 +3562,984 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-exp-05-20": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-exp-03-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-thinking-exp-01-21": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-preview-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-live-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-1.5-flash-8b-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-ultra-generate-exp-05-20": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 6
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-capability-preview-05-20": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 20
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3-fast-generate-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 8
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-2-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 50
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "textembedding-gecko@002": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-06-30": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-3-flash-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-3-flash-preview-06-05-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-3-pro-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-3-pro-preview-06-05-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-3.1-pro-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-lite-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-405b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-1-405b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-1-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-1-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-2-90b-vision-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-2-11b-vision-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-2-3b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-2-1b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-3-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-4-scout-17b-16e-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r1-0528-full-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-32b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-14b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwq-32b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-72b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-coder-32b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-vl-72b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "kimi-k2-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "moonshot-v1-32k-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "minimax-text-01-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4v-plus-0111-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-long-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-9b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "jamba-1-5-large": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 60 |
| 🔄 Models updated (merged) | 16 |

### ➕ New Models
- `gemini-2.5-pro-preview-06-05`
- `gemini-2.5-flash-exp-05-20`
- `gemini-2.5-pro-exp-03-25`
- `gemini-2.5-flash-image-generation`
- `gemini-2.0-flash-thinking-exp-01-21`
- `gemini-2.0-flash-image-generation`
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `gemini-2.5-flash-preview-tts`
- `gemini-2.5-pro-preview-tts`
- `gemini-2.0-flash-live-001`
- `gemini-1.5-flash-8b-001`
- `imagen-4.0-ultra-generate-exp-05-20`
- `imagen-4.0-capability-001`
- `imagen-4.0-capability-preview-05-20`
- `veo-3.1-lite-generate-preview`
- `veo-3-generate-001`
- `veo-3-fast-generate-preview`
- `veo-2-generate-001`
- `textembedding-gecko@002`
- ... and 40 more

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-2.5-flash-preview-04-17`
- `gemini-2.5-flash-lite-preview-06-17`
- `gemini-2.5-pro-preview-05-06`
- `gemini-2.5-flash-preview-05-20`
- `gemini-2.5-computer-use-preview-10-2025`
- `gemini-2.0-flash-exp`
- `gemini-1.5-flash-001`
- `gemini-1.5-flash-002`
- `gemini-1.5-pro-001`
- `gemini-1.5-pro-002`
- `veo-3.1-fast-generate-001`
- `gemini-embedding-001`
- `text-embedding-004`
- `textembedding-gecko-multilingual@001`
- `multimodalembedding@001`


## Model-to-Pricing-Page Mapping

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Standard $1.25/$10, batch $0.625/$5, cache $0.13 |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | Standard $0.30/$2.50, batch $0.15/$1.25, cache $0.03 |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | Standard $0.10/$0.40, batch $0.05/$0.20, cache $0.01 |
| `gemini-2.5-flash-preview-04-17` | Google – Gemini 2.5 | API | Alias → gemini-2.5-flash pricing |
| `gemini-2.5-flash-lite-preview-06-17` | Google – Gemini 2.5 | API | Alias → gemini-2.5-flash-lite pricing |
| `gemini-2.5-pro-preview-06-05` | Google – Gemini 2.5 | API | Alias → gemini-2.5-pro pricing |
| `gemini-2.5-pro-preview-05-06` | Google – Gemini 2.5 | API | Alias → gemini-2.5-pro pricing |
| `gemini-2.5-flash-preview-05-20` | Google – Gemini 2.5 | API | Alias → gemini-2.5-flash pricing |
| `gemini-2.5-flash-exp-05-20` | Google – Gemini 2.5 | API | Experimental alias → gemini-2.5-flash pricing (no batch) |
| `gemini-2.5-pro-exp-03-25` | Google – Gemini 2.5 | API | Experimental alias → gemini-2.5-pro pricing (no batch) |
| `gemini-2.5-flash-image-generation` | Google – Gemini 2.5 | API | $0.30/$2.50 + image_token $30/1M |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 | API | Computer Use → gemini-2.5-pro pricing |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API | TTS → gemini-2.5-pro pricing |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API | TTS → gemini-2.5-flash pricing |
| `gemini-2.5-flash-preview-tts` | Google – Gemini 2.5 | API | TTS preview → gemini-2.5-flash pricing |
| `gemini-2.5-pro-preview-tts` | Google – Gemini 2.5 | API | TTS preview → gemini-2.5-pro pricing |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | $0.15/$0.60, batch $0.075/$0.30 |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | $0.075/$0.30, batch $0.0375/$0.15 |
| `gemini-2.0-flash-exp` | Google – Gemini 2.0 | API | Experimental alias → gemini-2.0-flash pricing |
| `gemini-2.0-flash-thinking-exp-01-21` | Google – Gemini 2.0 | API | Thinking exp → gemini-2.0-flash pricing |
| `gemini-2.0-flash-image-generation` | Google – Gemini 2.0 | API | $0.15/$0.60 + image_token $30/1M |
| `gemini-2.0-flash-live-001` | Google – Gemini Live | API | Excluded (*-live-*); price 0 |
| `gemini-1.5-flash-001` | Google – Gemini 1.5 | API | Character-based; price 0 (legacy) |
| `gemini-1.5-flash-002` | Google – Gemini 1.5 | API | Character-based; price 0 (legacy) |
| `gemini-1.5-pro-001` | Google – Gemini 1.5 | API | Character-based; price 0 (legacy) |
| `gemini-1.5-pro-002` | Google – Gemini 1.5 | API | Character-based; price 0 (legacy) |
| `gemini-1.5-flash-8b-001` | Google – Gemini 1.5 | API | Character-based; price 0 (legacy) |
| `gemini-1.0-pro-001` | Google – Gemini 1.0 | API | Legacy; price 0 |
| `gemini-1.0-pro-002` | Google – Gemini 1.0 | API | Legacy; price 0 |
| `gemini-1.0-pro-vision-001` | Google – Gemini 1.0 | API | Legacy; price 0 |
| `imagen-4.0-generate-001` | Google – Imagen 4 | API | $0.04/image |
| `imagen-4.0-ultra-generate-exp-05-20` | Google – Imagen 4 Ultra | API | $0.06/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4 Fast | API | $0.02/image |
| `imagen-3.0-generate-001` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-generate-002` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-fast-generate-001` | Google – Imagen 3 Fast | API | $0.02/image |
| `imagen-3.0-capability-001` | Google – Imagen 3 | API | Capability model → imagen-3.0-generate pricing $0.04/image |
| `imagen-4.0-capability-001` | Google – Imagen 4 | API | Capability model → imagen-4.0-generate pricing $0.04/image |
| `imagen-4.0-capability-preview-05-20` | Google – Imagen 4 | API | Capability preview → $0.04/image |
| `imagen-4.0-generate-preview-05-20` | Google – Imagen 4 | API | Generate preview → $0.04/image |
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | $0.20/sec (video-only 720p/1080p), 8s default |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | $0.08/sec (720p video-only), 8s default |
| `veo-3.1-lite-generate-preview` | Google – Veo 3.1 Lite | API | $0.03/sec (720p video-only), 8s default |
| `veo-3-generate-001` | Google – Veo 3 | API | $0.20/sec (video-only), 8s default |
| `veo-3-fast-generate-preview` | Google – Veo 3 Fast | API | $0.08/sec (720p video-only), 8s default |
| `veo-2-generate-001` | Google – Veo 2 | API | $0.50/sec, 8s default |
| `gemini-embedding-001` | Google – Gemini Embedding | API | $0.15/1K tokens |
| `text-embedding-005` | Google – Text Embedding | API | $0.000025/1K tokens |
| `text-embedding-004` | Google – Text Embedding | API | $0.000025/1K tokens |
| `text-multilingual-embedding-002` | Google – Text Embedding | API | $0.000025/1K tokens |
| `textembedding-gecko@003` | Google – Text Embedding | API | $0.000025/1K tokens (legacy) |
| `textembedding-gecko-multilingual@001` | Google – Text Embedding | API | $0.000025/1K tokens (legacy) |
| `textembedding-gecko@002` | Google – Text Embedding | API | Legacy; price 0 |
| `textembedding-gecko@001` | Google – Text Embedding | API | Legacy; price 0 |
| `multimodalembedding@001` | Google – Multimodal Embedding | API | $0.0002/1K chars + per-image/video additional |
| `gemini-embedding-2-preview-06-30` | Google – Gemini Embedding 2 | API | $0.20/1M tokens (preview) |
| `text-embedding-large-exp-03-07` | Google – Text Embedding Large | API | $0.000025/1K tokens (experimental) |
| `gemini-3-flash-preview-06-05` | Google – Gemini 3 Flash | API | $0.50/$3.00 |
| `gemini-3-flash-preview-06-05-image-generation` | Google – Gemini 3 Flash Image | API | $0.50/$3.00 + image_token $60/1M |
| `gemini-3-pro-preview-06-05` | Google – Gemini 3 Pro | API | $2.00/$12.00 |
| `gemini-3-pro-preview-06-05-image-generation` | Google – Gemini 3 Pro Image | API | $2.00/$12.00 + image_token $120/1M |
| `gemini-3.1-pro-preview-06-05` | Google – Gemini 3.1 Pro | API | $2.00/$12.00 |
| `gemini-3.1-flash-image-preview-06-05` | Google – Gemini 3.1 Flash Image | API | $0.50/$3.00 + image_token $60/1M |
| `gemini-3.1-flash-lite-preview-06-05` | Google – Gemini 3.1 Flash Lite | API | $0.25/$1.50 |
| `gemini-3.1-flash-preview-06-05` | Google – Gemini 3.1 Flash | API | $0.50/$3.00 |
| `claude-opus-4-6` | Anthropic – Claude | API | $5/$25, cache write $6.25, hit $0.50 (@default stripped) |
| `claude-sonnet-4-6` | Anthropic – Claude | API | $3/$15, cache write $3.75, hit $0.30 (@default stripped) |
| `claude-opus-4-5@20251101` | Anthropic – Claude | API | $5/$25, cache write $6.25, hit $0.50 |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude | API | $3/$15, cache write $3.75, hit $0.30 |
| `claude-haiku-4-5@20251001` | Anthropic – Claude | API | $1/$5, cache write $1.25, hit $0.10 |
| `claude-opus-4-1@20250805` | Anthropic – Claude | API | $15/$75, cache write $18.75, hit $1.50 |
| `claude-opus-4@20250514` | Anthropic – Claude | API | $15/$75 (no cache listed) |
| `claude-sonnet-4@20250514` | Anthropic – Claude | API | $3/$15, cache write $3.75, hit $0.30 |
| `gpt-oss-120b-maas` | OpenAI / Partner | API | $0.09/$0.36, batch $0.045/$0.18 |
| `llama-3.3-70b-instruct-maas` | Meta / Llama | API | $0.72/$0.72, batch $0.36/$0.36 |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta / Llama 4 | API | $0.35/$1.15, batch $0.175/$0.575 |
| `llama-4-scout-17b-16e-instruct-maas` | Meta / Llama 4 | API – price not found | No pricing row; price 0 |
| `llama3-405b-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama3-70b-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama3-8b-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama3-1-405b-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama3-1-70b-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama3-1-8b-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama3-2-90b-vision-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama3-2-11b-vision-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama3-2-3b-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama3-2-1b-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama3-3-70b-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama-3.1-405b-instruct-maas` | Meta / Llama | API – price not found | Legacy; price 0 |
| `llama-4-scout-17b-16e-maas` | Meta / Llama 4 Scout | API – price not found | No pricing row; price 0 |
| `mistral-small-2503` | Mistral / Partner | API | Mistral Small 3.1 $0.10/$0.30 |
| `mistral-medium-3` | Mistral / Partner | API | Mistral Medium 3 $0.40/$2.00 |
| `codestral-2` | Mistral / Partner | API | Codestral 2 $0.30/$0.90 |
| `deepseek-r1-0528-maas` | DeepSeek / Partner | API | DeepSeek-R1(0528) $1.35/$5.40, batch $0.675/$2.70 |
| `deepseek-v3.1-maas` | DeepSeek / Partner | API | DeepSeek-V3.1 $0.60/$1.70, cache $0.06, batch $0.30/$0.85 |
| `deepseek-v3.2-maas` | DeepSeek / Partner | API | DeepSeek-V3.2 $0.56/$1.68, cache $0.056, batch $0.28/$0.84 |
| `deepseek-r1-maas` | DeepSeek / Partner | API – price not found | Legacy R1; price 0 |
| `deepseek-v3-maas` | DeepSeek / Partner | API – price not found | Legacy V3; price 0 |
| `deepseek-r1-0528-full-maas` | DeepSeek / Partner | API – price not found | No pricing row; price 0 |
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen / Partner | API | Qwen3-235B-A22B $0.22/$0.88, batch $0.11/$0.44 |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen / Partner | API | Qwen3-Coder-480B $0.22/$1.80, cache $0.022, batch $0.11/$0.90 |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen / Partner | API | Qwen3-Next-80B-A3B $0.15/$1.20 |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen / Partner | API | Qwen3-Next-80B-A3B Thinking $0.15/$1.20 |
| `qwen3-32b-maas` | Qwen / Partner | API – price not found | Legacy; price 0 |
| `qwen3-30b-a3b-maas` | Qwen / Partner | API – price not found | Legacy; price 0 |
| `qwen3-235b-a22b-maas` | Qwen / Partner | API – price not found | Legacy; price 0 |
| `qwen3-14b-maas` | Qwen / Partner | API – price not found | Legacy; price 0 |
| `qwq-32b-maas` | Qwen / Partner | API – price not found | No pricing row; price 0 |
| `qwen2-5-72b-instruct-maas` | Qwen / Partner | API – price not found | Legacy; price 0 |
| `qwen2-5-coder-32b-instruct-maas` | Qwen / Partner | API – price not found | Legacy; price 0 |
| `qwen2-5-vl-72b-instruct-maas` | Qwen / Partner | API – price not found | Legacy; price 0 |
| `kimi-k2-thinking-maas` | Kimi / MoonshotAI | API | Kimi-K2-Thinking $0.60/$2.50, cache $0.06 |
| `kimi-k2-maas` | Kimi / MoonshotAI | API – price not found | No pricing row; price 0 |
| `moonshot-v1-32k-maas` | Kimi / MoonshotAI | API – price not found | Legacy; price 0 |
| `minimax-m2-maas` | MiniMax / Partner | API | MiniMax-M2 $0.30/$1.20, cache $0.03 |
| `minimax-text-01-maas` | MiniMax / Partner | API – price not found | Legacy; price 0 |
| `glm-4.7-maas` | ZAI.org / GLM | API | GLM-4.7 $0.60/$2.20 |
| `glm-5-maas` | ZAI.org / GLM | API | GLM-5 $1.00/$3.20, cache $0.10 |
| `glm-4v-plus-0111-maas` | ZAI.org / GLM | API – price not found | No pricing row; price 0 |
| `glm-4-long-maas` | ZAI.org / GLM | API – price not found | Legacy; price 0 |
| `glm-4-9b-maas` | ZAI.org / GLM | API – price not found | Legacy; price 0 |
| `jamba-1-5-large` | AI21 / Partner | API – price not found | No pricing row; price 0 |

## Excluded Models (not added to pricing)

| Model ID | Publisher | Reason |
|----------|-----------|--------|
| `*-live-*` models | Google | Gemini Live streaming — excluded by policy |
| `lyria-*` | Google | Music generation — no inference endpoint |
| `model-optimizer-*` | Google | Meta-endpoint — dynamic routing |
| `imagegeneration@*` | Google | Legacy superseded by imagen-3.0+ |
| `virtual-try-on-*` | Google | Retail-specific product model |
| `shieldgemma2` | Google | Safety model |
| Non-generative models (gemma self-deploy, CV, PaLM, Codey, etc.) | Google | Non-generative / fine-tuning-only |
| `clip-vit-base-patch32`, `openclip` | OpenAI | Non-generative (vision classification) |
| `whisper-large` | OpenAI | Audio transcription, not generative inference |
| `gpt-oss` | OpenAI | Self-deploy (has_deploy:true, no -maas) |
| `*guard*` models | Meta | Safety/guard models excluded by policy |
| `mistral-ai` publisher models (ministral-3, mistral-large-3) | Mistral | Self-deploy (has_deploy:true, no -maas) |
| `codestral-2501-self-deploy` | Mistral | Self-deploy (has_deploy:true, no -maas) |
| `mistral-ocr-2505` | Mistral | OCR model — excluded by policy |
| `deepseek-ocr-maas` | DeepSeek | OCR model — excluded by policy |
| `glm-image` | ZAI.org | Explicit exception — excluded from Vertex AI pricing |
| `qwen-image` | Qwen | Explicit exception — excluded from Vertex AI pricing |


---
*Generated by Pricing Agent on 2026-04-08*