### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1753,5 +1753,11 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -917,14 +917,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -948,10 +951,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1159,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1187,10 +1193,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1395,10 +1401,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1435,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1537,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1568,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1599,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1608,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1633,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1642,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1693,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1727,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1879,10 +1891,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1922,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1943,20 +1955,20 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1977,20 +1989,20 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2080,10 +2092,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2114,10 +2126,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2281,10 +2293,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2312,10 +2327,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2343,10 +2361,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2374,10 +2395,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2405,10 +2429,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2436,10 +2463,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2463,20 +2493,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2494,20 +2524,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2529,10 +2559,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2560,10 +2590,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2581,29 +2611,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,29 +2642,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2650,10 +2680,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2678,10 +2708,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -3004,7 +3034,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3057,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3174,7 +3204,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3244,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3268,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3313,40 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 38 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-3.1-pro-preview-lte-128k`
- `gemini-3.1-pro-preview-gt-128k`
- `gemini-3-pro-preview-lte-128k`
- `gemini-3-pro-preview-gt-128k`
- `gemini-3-flash-preview-lte-128k`
- `gemini-3-flash-preview-gt-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-3-pro-image-preview-lte-128k`
- `gemini-3-pro-image-preview-gt-128k`
- `gemini-3.1-flash-image-preview-lte-128k`
- `gemini-3.1-flash-image-preview-gt-128k`
- `gemini-2.5-pro-lte-128k`
- `gemini-2.5-pro-gt-128k`
- `gemini-2.5-flash-lte-128k`
- `gemini-2.5-flash-gt-128k`
- `gemini-2.5-flash-lite-lte-128k`
- `gemini-2.5-flash-lite-gt-128k`
- `gemini-2.5-flash-image-lte-128k`
- `gemini-2.5-flash-image-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.0-flash-lite-lte-128k`
- `gemini-2.0-flash-lite-gt-128k`
- `gemini-2.0-flash-lite-001-lte-128k`
- `gemini-2.0-flash-lite-001-gt-128k`
- `gemini-pro-latest-lte-128k`
- `gemini-pro-latest-gt-128k`
- ... and 8 more


### Pricing data source

Pricing sourced from the Vertex AI Generative AI pricing page (`https://cloud.google.com/vertex-ai/generative-ai/pricing`) as a fallback — the Gemini API pricing page (`https://ai.google.dev/gemini-api/docs/pricing`) was fetched but the raw HTML file exceeded the 72K token read limit and Firecrawl was out of credits. Vertex AI and Gemini API use the same underlying models with matching pricing.

Model list sourced from the Google Gemini API (`https://generativelanguage.googleapis.com/v1beta/models`).

---

### Model → pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro, ≤200K | input $2/1M, output $12/1M, cache read $0.2/1M, batch $1/$6 |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro, >200K | input $4/1M, output $18/1M, cache read $0.4/1M, batch $2/$9 |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro, ≤200K | input $2/1M, output $12/1M, cache read $0.2/1M, batch $1/$6 |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro, >200K | input $4/1M, output $18/1M, cache read $0.4/1M, batch $2/$9 |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash, flat rate | input $0.50/1M, output $3/1M, cache read $0.05/1M, batch $0.25/$1.5 |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash, flat rate | identical to lte — no context tier on page |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite, flat rate | input $0.25/1M, output $1.50/1M, cache read $0.03/1M, batch $0.13/$0.75 |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite, flat rate | identical to lte — no context tier on page |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image, flat rate | input $2/1M, text output $12/1M, image output $120/1M, batch $1/$6; no context tier |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image, flat rate | identical to lte — no context tier on page |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image, flat rate | input $0.50/1M, text output $3/1M, image output $60/1M, batch $0.25/$1.5 |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image, flat rate | identical to lte — no context tier on page |
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | input $1.25/1M, output $10/1M, cache read $0.13/1M, batch $0.625/$5 |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | input $2.50/1M, output $15/1M, cache read $0.25/1M, batch $1.25/$7.5 |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat rate | input $0.30/1M, output $2.50/1M, cache read $0.03/1M, batch $0.15/$1.25 |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat rate | identical to lte — no context tier on page |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash-Lite, flat rate | input $0.10/1M, output $0.40/1M, cache read $0.01/1M, batch $0.05/$0.20 |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash-Lite, flat rate | identical to lte — no context tier on page |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat rate | input $0.30/1M, text output $2.50/1M, image output $30/1M, batch $0.15/$1.25; batch image $15/1M |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat rate | identical to lte — no context tier on page |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat rate | input $0.15/1M, output $0.60/1M, batch $0.075/$0.30 |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat rate | identical to lte — no context tier on page |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash 001, flat rate | same pricing as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash 001, flat rate | identical to lte |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash-Lite, flat rate | input $0.075/1M, output $0.30/1M, batch $0.0375/$0.15 |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash-Lite, flat rate | identical to lte |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash-Lite 001, flat rate | same pricing as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash-Lite 001, flat rate | identical to lte |
| gemini-pro-latest-lte-128k | *-latest → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview lte tier |
| gemini-pro-latest-gt-128k | *-latest → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview gt tier |
| gemini-flash-latest-lte-128k | *-latest → resolved to gemini-3-flash-preview | same pricing as gemini-3-flash-preview |
| gemini-flash-latest-gt-128k | *-latest → resolved to gemini-3-flash-preview | identical to lte |
| gemini-flash-lite-latest-lte-128k | *-latest → resolved to gemini-3.1-flash-lite-preview | same pricing as gemini-3.1-flash-lite-preview |
| gemini-flash-lite-latest-gt-128k | *-latest → resolved to gemini-3.1-flash-lite-preview | identical to lte |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro (custom tools variant), ≤200K | same pricing as gemini-3.1-pro-preview lte |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro (custom tools variant), >200K | same pricing as gemini-3.1-pro-preview gt |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4.0 Ultra Generate | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4.0 Ultra Generate | $0.06/image — flat, identical lte/gt |
| imagen-4.0-generate-001-lte-128k | Imagen 4.0 Generate | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4.0 Generate | $0.04/image — flat, identical lte/gt |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4.0 Fast Generate | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4.0 Fast Generate | $0.02/image — flat, identical lte/gt |
| veo-3.1-generate-preview-lte-128k | Veo 3.1, video+audio 720p/1080p | $0.40/s → 40¢/s; default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1, flat rate | identical to lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast, video+audio | $0.15/s → 15¢/s; default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast, flat rate | identical to lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite, video+audio 720p | $0.05/s → 5¢/s; default 8s, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite, flat rate | identical to lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0, video+audio | $0.40/s → 40¢/s; default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3.0, flat rate | identical to lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast, video+audio | $0.15/s → 15¢/s; default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast, flat rate | identical to lte |
| veo-2.0-generate-001-lte-128k | Veo 2.0, flat rate | $0.50/s → 50¢/s; default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2.0, flat rate | identical to lte |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | input $0.15/1M tokens (online), output 0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001, flat rate | identical to lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview | price not found on page; set to 0 |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview, flat rate | identical to lte |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Custom Tools | same pricing as gemini-3.1-pro-preview |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Custom Tools gt | same pricing as gemini-3.1-pro-preview gt |

---

### Excluded models (with reasons)

| Model ID | Reason |
|----------|--------|
| gemini-2.5-flash-preview-tts | TTS — excluded per scope rules |
| gemini-2.5-pro-preview-tts | TTS — excluded per scope rules |
| gemma-3-*, gemma-3n-*, gemma-4-* | Gemma family — excluded per scope rules |
| gemini-2.5-computer-use-preview-10-2025 | computer-use variant — excluded per scope rules |
| aqa | AQA — excluded per scope rules |
| gemini-robotics-er-1.5-preview | Robotics — excluded per scope rules |
| gemini-2.5-flash-native-audio-* | native-audio — excluded per scope rules |
| gemini-3.1-flash-live-preview | live variant — excluded per scope rules |
| deep-research-pro-preview-12-2025 | does not match gemini-*, imagen-*, veo-*, or embedding-* patterns |

---
*Generated by Pricing Agent on 2026-04-08*