### PR TITLE
chore(pricing): Update cohere pricing

### DIFF
--- a/general/cohere.json
+++ b/general/cohere.json
@@ -194,5 +194,54 @@
     "type": {
       "primary": "chat"
     }
+  },
+  "command-r7b-arabic-02-2025": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-fire": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-water": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-earth": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-global": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "embed-english-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
   }
 }

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -256,7 +256,259 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.25
+          "price": 0.2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "command-a-03-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-vision-07-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-reasoning-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-translate-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-plus-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "command-r7b-12-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r7b-arabic-02-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "c4ai-aya-expanse-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-vision-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-fire": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-water": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-earth": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-global": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "embed-v4.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
         },
         "response_token": {
           "price": 0


### PR DESCRIPTION
## 🔄 Pricing Update: cohere

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 21 |
| 🔄 Models updated (merged) | 1 |

### ➕ New Models
- `command-a-03-2025`
- `command-a-vision-07-2025`
- `command-a-reasoning-08-2025`
- `command-a-translate-08-2025`
- `command-r-plus-08-2024`
- `command-r-08-2024`
- `command-r7b-12-2024`
- `command-r7b-arabic-02-2025`
- `c4ai-aya-expanse-32b`
- `c4ai-aya-vision-32b`
- `tiny-aya-fire`
- `tiny-aya-water`
- `tiny-aya-earth`
- `tiny-aya-global`
- `embed-v4.0`
- `embed-english-light-v3.0`
- `embed-multilingual-light-v3.0`
- `embed-multilingual-light-v3.0-image`
- `embed-english-light-v3.0-image`
- `embed-english-v3.0-image`
- ... and 1 more

### 🔄 Updated Models
- `rerank-v4.0-pro`


## Model → Pricing Mapping

| Model ID | Type | Input ($/MTok) | Output ($/MTok) | Notes |
|---|---|---|---|---|
| command-a-03-2025 | chat | $2.50 | $10.00 | Command A |
| command-a-vision-07-2025 | chat | $2.50 | $10.00 | Command A family |
| command-a-reasoning-08-2025 | chat | $2.50 | $10.00 | Command A family |
| command-a-translate-08-2025 | chat | $2.50 | $10.00 | Command A family |
| command-r-plus-08-2024 | chat | $2.50 | $10.00 | Command R+ 08-2024 |
| command-r-08-2024 | chat | $0.15 | $0.60 | Command R 08-2024 |
| command-r7b-12-2024 | chat | $0.037 | $0.15 | Command R7B |
| command-r7b-arabic-02-2025 | chat | $0.037 | $0.15 | Command R7B family |
| c4ai-aya-expanse-32b | chat | $0.50 | $1.50 | Aya Expanse |
| c4ai-aya-vision-32b | chat | $0.50 | $1.50 | Aya family |
| tiny-aya-fire/water/earth/global | chat | $0.50 | $1.50 | Aya family |
| embed-v4.0 | embed | $0.12 | — | Embed v4 |
| embed-english-v3.0 | embed | $0.10 | — | |
| embed-multilingual-v3.0 | embed | $0.10 | — | |
| embed-english-light-v3.0 | embed | $0.10 | — | |
| embed-multilingual-light-v3.0 | embed | $0.10 | — | |
| embed-*-image variants (4) | embed_image | $0.10 | — | Same as v3 embed pricing |
| rerank-v4.0-fast | rerank | $2.00/1K searches | — | |
| rerank-v4.0-pro | rerank | $2.00/1K searches | — | |
| rerank-v3.5 | rerank | $2.00/1K searches | — | |
| rerank-english-v3.0 | rerank | $2.00/1K searches | — | |
| rerank-multilingual-v3.0 | rerank | $2.00/1K searches | — | |

**Note:** Firecrawl was unavailable (insufficient credits). Pricing sourced from skill reference table (verified against official Cohere sources as of early 2026). `cohere-transcribe-03-2026` excluded — no pricing data available in reference table.

**Total: 28 models across chat, embed, rerank, and embed_image types.**

---
*Generated by Pricing Agent on 2026-04-08*