### PR TITLE
chore(pricing): Update dashscope pricing

### DIFF
--- a/general/dashscope.json
+++ b/general/dashscope.json
@@ -632,5 +632,321 @@
   "qwen-mt-lite": {
     "params": [{ "key": "max_tokens", "maxValue": 8192 }],
     "type": { "primary": "chat" }
+  },
+  "qwen3-max-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen-flash-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen-long": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-4b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-1.7b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-0.6b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-27b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen-doc-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-deep-research": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-embedding-v4": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "text-embedding-v3": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "qwen3-rerank": {
+    "type": {
+      "primary": "embedding"
+    },
+    "disablePlayground": true
+  },
+  "gte-rerank-v2": {
+    "type": {
+      "primary": "embedding"
+    },
+    "disablePlayground": true
+  },
+  "qwen3-omni-captioner": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen-image-2.0": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen-image-max": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen-image-plus": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen-image-edit-max": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-t2i": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-image": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "z-image-turbo": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wanx2.1-imageedit": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-t2v-720p": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-i2v-720p": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-r2v-720p": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-vace-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-s2v-720p": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "qwen3-asr-flash-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "paraformer-v2": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "paraformer-realtime-v2": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-flash": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "cosyvoice-v3-flash": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "qwen-tts": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
   }
 }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -152,13 +152,16 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0.000027
+          "price": 0.000007
         },
         "request_audio_token": {
           "price": 0.000444
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
         }
       }
     }
@@ -488,10 +491,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.000016
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.000064
         },
         "reasoning_token": {
           "price": 0.00084
@@ -518,10 +521,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0035
         },
         "response_token": {
-          "price": 0.0000035
+          "price": 0.0035
         }
       }
     }
@@ -677,13 +680,16 @@
           "price": 0.000043
         },
         "response_token": {
-          "price": 0.000166
+          "price": 0.000043
         },
         "request_audio_token": {
           "price": 0.000381
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
         }
       }
     }
@@ -721,7 +727,6 @@
       }
     }
   },
-
   "qwen3-vl-30b-a3b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -840,10 +845,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.000058
+          "price": 0.0000861
         }
       }
     }
@@ -852,10 +857,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.0000861
         }
       }
     }
@@ -960,10 +965,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.00008
         },
         "reasoning_token": {
           "price": 0.00084
@@ -1320,10 +1325,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000043
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000072
+          "price": 0.000016
         }
       }
     }
@@ -1885,6 +1890,558 @@
         },
         "response_token": {
           "price": 0.0002294
+        }
+      }
+    }
+  },
+  "qwen3-max-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00012
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "qwen-flash-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-long": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "qwen3-4b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-1.7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-0.6b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00036
+        }
+      }
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00032
+        }
+      }
+    }
+  },
+  "qwen3.5-27b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00056
+        }
+      }
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00007
+        },
+        "response_token": {
+          "price": 0.00028
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.00014
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000175
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      }
+    }
+  },
+  "qwen-doc-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000087
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "qwen-deep-research": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0007742
+        },
+        "response_token": {
+          "price": 0.0023367
+        }
+      }
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000058
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "text-embedding-v4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000007
+        }
+      }
+    }
+  },
+  "text-embedding-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000007
+        }
+      }
+    }
+  },
+  "qwen3-rerank": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "gte-rerank-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000115
+        }
+      }
+    }
+  },
+  "qwen3-omni-captioner": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-2.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "wan2.6-t2i": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.6-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "z-image-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 1.5
+        }
+      }
+    }
+  },
+  "wanx2.1-imageedit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.007
+        },
+        "response_token": {
+          "price": 2.007
+        }
+      }
+    }
+  },
+  "wan2.6-t2v-720p": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-720p": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-r2v-720p": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.1-vace-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.2-s2v-720p": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 12.9018
+        },
+        "response_token": {
+          "price": 12.9018
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "paraformer-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "paraformer-realtime-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0026
+        },
+        "response_token": {
+          "price": 0.0026
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: dashscope

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 46 |
| 🔄 Models updated (merged) | 8 |

### ➕ New Models
- `qwen3-max-latest`
- `qwen-flash-latest`
- `qwen-long`
- `qwen3-4b`
- `qwen3-1.7b`
- `qwen3-0.6b`
- `qwen3.5-397b-a17b`
- `qwen3.5-122b-a10b`
- `qwen3.5-27b`
- `qwen3.5-35b-a3b`
- `qwen2.5-72b-instruct`
- `qwen2.5-32b-instruct`
- `qwen2.5-14b-instruct`
- `qwen2.5-7b-instruct`
- `qwen-doc-turbo`
- `qwen-deep-research`
- `tongyi-intent-detect-v3`
- `text-embedding-v4`
- `text-embedding-v3`
- `qwen3-rerank`
- ... and 26 more

### 🔄 Updated Models
- `qwen-vl-ocr-latest`
- `qwen3-32b`
- `qwen3-30b-a3b`
- `qwq-32b`
- `qwq-32b-preview`
- `qwen3-omni-flash`
- `qwen-omni-turbo`
- `qwen3-asr-flash`


## Model-to-pricing-page mapping

All prices sourced from https://www.alibabacloud.com/help/en/model-studio/models (`maxAge: 0`)

**Pricing priority applied:** International → Global → Chinese mainland (per skill rules)

| Family | Models | Region used |
|--------|--------|-------------|
| Flagship | qwen3-max, qwen3.5-plus, qwen3.5-flash | International |
| Commercial text | qwen-max, qwen-plus, qwen-flash, qwen-turbo, qwq-plus | International |
| Qwen-Long | qwen-long | Chinese mainland (mainland-only) |
| Open-source text | qwen3-235b-a22b through qwen2.5-7b-instruct | International / Global |
| qwq-32b | qwq-32b, qwq-32b-preview | Chinese mainland |
| Vision/VL | qwen3-vl-plus, qwen3-vl-flash, qvq-max, qwen-vl-max, qwen-vl-plus, qwen-vl-ocr | International |
| Omni | qwen3-omni-flash, qwen-omni-turbo, qwen3-omni-captioner | International |
| Coder | qwen3-coder-plus, qwen3-coder-flash, qwen-coder-plus, qwen-coder-turbo | International / mainland |
| Math | qwen-math-plus, qwen-math-turbo | Chinese mainland |
| Translation | qwen-mt-plus, qwen-mt-flash, qwen-mt-lite, qwen-mt-turbo | International |
| Domain | qwen-doc-turbo, qwen-deep-research, tongyi-intent-detect-v3 | Chinese mainland |
| Role-play | qwen-plus-character | International |
| Embedding | text-embedding-v4, text-embedding-v3 | International |
| Rerank | qwen3-rerank, gte-rerank-v2 | International / mainland |
| Third-party | deepseek-v3.2, kimi-k2.5, MiniMax-M2.5, glm-5 | International / mainland |
| Image gen | qwen-image-*, wan2.6-t2i, wan2.6-image, z-image-turbo, wanx2.1-imageedit | International / mainland |
| Video gen | wan2.6-t2v-720p, wan2.6-i2v-720p, wan2.6-r2v-720p, wan2.1-vace-plus, wan2.2-s2v-720p | International / mainland |
| TTS | qwen3-tts-instruct-flash, qwen3-tts-flash, qwen-tts, cosyvoice-v3-plus, cosyvoice-v3-flash | International / mainland |
| ASR | qwen3-asr-flash, qwen3-asr-flash-realtime, paraformer-v2, paraformer-realtime-v2, fun-asr, fun-asr-realtime | International / mainland |

**Tiered pricing note:** For models with tiered input pricing (e.g. qwen3-max, qwen-plus, qwen-flash), the lowest input tier rate is used as the default per skill instructions.

---
*Generated by Pricing Agent on 2026-04-08*