### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -576,7 +576,7 @@
         "image": {
           "default": {
             "default": {
-              "price": 2
+              "price": 1.8
             },
             "1024x1024": {
               "price": 2
@@ -590,7 +590,7 @@
           },
           "standard": {
             "default": {
-              "price": 2
+              "price": 1.8
             },
             "1024x1024": {
               "price": 2
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1383,6 +1383,9 @@
           "response_audio_token": {
             "price": 1.5
           }
+        },
+        "response_audio_token": {
+          "price": 0.0012
         }
       }
     }
@@ -1394,7 +1397,7 @@
           "price": 0.00025
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "additional_units": {
           "request_audio_token": {
@@ -1403,6 +1406,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0006
         }
       }
     }
@@ -1414,7 +1420,7 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0
         },
         "additional_units": {
           "request_audio_token": {
@@ -1423,6 +1429,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0003
         }
       }
     }
@@ -1554,6 +1563,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       },
       "batch_config": {
@@ -1574,6 +1586,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       }
     }
@@ -1721,7 +1736,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1762,7 +1777,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2130,10 +2145,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
@@ -2164,10 +2179,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
@@ -2190,10 +2205,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.00011
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.00044
         },
         "cache_write_input_token": {
           "price": 0
@@ -2216,10 +2231,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.00011
         },
         "response_token": {
-          "price": 0.0008
+          "price": 0.00044
         },
         "cache_write_input_token": {
           "price": 0
@@ -2259,16 +2274,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2286,16 +2301,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2611,10 +2626,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2683,25 +2698,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.00025
         },
         "cache_read_audio_input_token": {
-          "price": 0.0064
+          "price": 0.00025
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2710,25 +2725,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.00025
         },
         "cache_read_audio_input_token": {
-          "price": 0.0064
+          "price": 0.00025
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2743,10 +2758,10 @@
           "price": 0.001
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2755,16 +2770,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2831,7 +2846,7 @@
           }
         },
         "request_image_token": {
-          "price": 0.001
+          "price": 0.0005
         },
         "response_image_token": {
           "price": 0.004
@@ -2850,6 +2865,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3227,10 +3248,10 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.000008
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3248,10 +3269,10 @@
           "price": 0.00025
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "request_audio_token": {
-          "price": 0.0006
+          "price": 0.0008
         }
       }
     }
@@ -3318,7 +3339,7 @@
           }
         },
         "request_image_token": {
-          "price": 0.0008
+          "price": 0.0005
         },
         "response_image_token": {
           "price": 0.0032
@@ -3340,6 +3361,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3478,7 +3505,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3508,7 +3535,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3565,10 +3592,10 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         }
       }
     }
@@ -3577,10 +3604,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.00006
         },
         "cache_write_input_token": {
           "price": 0
@@ -3598,10 +3625,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.00006
         },
         "cache_write_input_token": {
           "price": 0
@@ -3694,7 +3721,7 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0
         },
         "request_audio_token": {
           "price": 0.0003
@@ -3709,7 +3736,7 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0
         },
         "request_audio_token": {
           "price": 0.0003
@@ -3748,7 +3775,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -3769,7 +3796,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.00015
         },
         "response_token": {
           "price": 0
@@ -3778,7 +3805,7 @@
           "price": 0.00002
         },
         "request_image_token": {
-          "price": 0.00025
+          "price": 0.00015
         },
         "cache_read_image_input_token": {
           "price": 0.000025
@@ -3859,25 +3886,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.00025
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "cache_read_audio_input_token": {
-          "price": 0.00004
+          "price": 0.00025
         },
         "request_image_token": {
           "price": 0.0005
@@ -3901,10 +3928,10 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         }
       }
     }
@@ -3977,6 +4004,9 @@
         },
         "response_token": {
           "price": 0.018
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }
@@ -3989,6 +4019,9 @@
         },
         "response_token": {
           "price": 0.018
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 37 |


### 🔄 Updated Models
- `gpt-5.4-pro`
- `gpt-5.4-pro-2026-03-05`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `o3-deep-research`
- `o3-deep-research-2025-06-26`
- `o4-mini-deep-research`
- `o4-mini-deep-research-2025-06-26`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-realtime`
- `gpt-realtime-2025-08-28`
- `gpt-realtime-1.5`
- `gpt-realtime-mini`
- `gpt-realtime-mini-2025-10-06`
- `gpt-realtime-mini-2025-12-15`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-audio`
- `gpt-audio-2025-08-28`
- `gpt-audio-1.5`
- `gpt-audio-mini`
- `gpt-audio-mini-2025-10-06`
- `gpt-audio-mini-2025-12-15`
- `gpt-4o-mini-tts`
- `gpt-4o-transcribe`
- `gpt-4o-transcribe-diarize`
- `gpt-4o-mini-transcribe`
- `gpt-4o-mini-transcribe-2025-03-20`
- `gpt-4o-mini-transcribe-2025-12-15`
- ... and 7 more


## Data Sources

| Source | Type | Notes |
|--------|------|-------|
| OpenAI Models API | API | 128 models fetched (ft:* excluded) |
| LiteLLM model_prices_and_context_window.json | Fallback pricing | Used because platform.openai.com/docs/pricing returned HTTP 403 (Cloudflare) |

## Model Coverage (128 total)

| Family | Models | Count |
|--------|--------|-------|
| GPT-5.x | gpt-5, gpt-5.1, gpt-5.2, gpt-5.3, gpt-5.4 + variants, codex, pro, mini, nano, search-api, chat-latest | 34 |
| GPT-4.x | gpt-4.1, gpt-4o, gpt-4-turbo, gpt-4 + variants | 16 |
| GPT-3.5 | gpt-3.5-turbo, gpt-3.5-turbo-instruct + variants | 6 |
| O-series | o1, o3, o4-mini, o3-mini, o1-pro, o3-pro, deep-research + variants | 16 |
| Audio/Realtime | gpt-4o-realtime, gpt-4o-mini-realtime, gpt-realtime, gpt-audio, gpt-4o-audio, gpt-4o-mini-audio + variants | 23 |
| TTS/Transcribe | gpt-4o-mini-tts, gpt-4o-transcribe, gpt-4o-mini-transcribe, tts-1, tts-1-hd, whisper-1 + variants | 11 |
| Image/Video | gpt-image-1, gpt-image-1.5, gpt-image-1-mini, chatgpt-image-latest, dall-e-2, dall-e-3, sora-2, sora-2-pro | 8 |
| Embeddings | text-embedding-3-large, text-embedding-3-small, text-embedding-ada-002 | 3 |
| Moderation | omni-moderation-latest, omni-moderation-2024-09-26 | 2 |
| Computer Use | computer-use-preview, computer-use-preview-2025-03-11 | 2 |
| Legacy | babbage-002, davinci-002 | 2 |

---
*Generated by Pricing Agent on 2026-04-08*