### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1339,6 +1339,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.6
         }
       }
     }
@@ -1383,6 +1386,9 @@
           "response_audio_token": {
             "price": 1.5
           }
+        },
+        "response_audio_token": {
+          "price": 0.0012
         }
       }
     }
@@ -1403,6 +1409,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0006
         }
       }
     }
@@ -1423,6 +1432,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0003
         }
       }
     }
@@ -1721,7 +1733,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1762,7 +1774,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2193,7 +2205,7 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
@@ -2259,16 +2271,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2286,16 +2298,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2361,7 +2373,7 @@
           "price": 0.0000375
         },
         "cache_read_input_token": {
-          "price": 0.0006
+          "price": 0.0000375
         }
       }
     }
@@ -2611,10 +2623,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2761,10 +2773,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2775,16 +2787,16 @@
         "image": {
           "default": {
             "default": {
-              "price": 16.7
+              "price": 1.1
             },
             "1024x1024": {
-              "price": 16.7
+              "price": 1.1
             },
             "1024x1536": {
-              "price": 25
+              "price": 1.6
             },
             "1536x1024": {
-              "price": 25
+              "price": 1.6
             }
           },
           "high": {
@@ -3146,10 +3158,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0021
+          "price": 0.0015
         },
         "response_token": {
-          "price": 0.0168
+          "price": 0.012
         },
         "cache_write_input_token": {
           "price": 0
@@ -3177,10 +3189,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0021
+          "price": 0.0015
         },
         "response_token": {
-          "price": 0.0168
+          "price": 0.012
         },
         "cache_write_input_token": {
           "price": 0
@@ -3262,58 +3274,58 @@
         "image": {
           "default": {
             "default": {
-              "price": 13.3
+              "price": 1.1
             },
             "1024x1024": {
-              "price": 13.3
+              "price": 1.1
             },
             "1024x1536": {
-              "price": 20
+              "price": 1.6
             },
             "1536x1024": {
-              "price": 20
+              "price": 1.6
             }
           },
           "high": {
             "default": {
-              "price": 13.3
+              "price": 16.7
             },
             "1024x1024": {
-              "price": 13.3
+              "price": 16.7
             },
             "1024x1536": {
-              "price": 20
+              "price": 25
             },
             "1536x1024": {
-              "price": 20
+              "price": 25
             }
           },
           "medium": {
             "default": {
-              "price": 3.4
+              "price": 4.2
             },
             "1024x1024": {
-              "price": 3.4
+              "price": 4.2
             },
             "1024x1536": {
-              "price": 5
+              "price": 6.3
             },
             "1536x1024": {
-              "price": 5
+              "price": 6.3
             }
           },
           "low": {
             "default": {
-              "price": 0.9
+              "price": 1.1
             },
             "1024x1024": {
-              "price": 0.9
+              "price": 1.1
             },
             "1024x1536": {
-              "price": 1.3
+              "price": 1.6
             },
             "1536x1024": {
-              "price": 1.3
+              "price": 1.6
             }
           }
         },
@@ -3761,6 +3773,64 @@
         },
         "cache_read_image_input_token": {
           "price": 0.0002
+        },
+        "image": {
+          "low": {
+            "default": {
+              "price": 1.1
+            },
+            "1024x1024": {
+              "price": 1.1
+            },
+            "1024x1536": {
+              "price": 1.6
+            },
+            "1536x1024": {
+              "price": 1.6
+            }
+          },
+          "medium": {
+            "default": {
+              "price": 4.2
+            },
+            "1024x1024": {
+              "price": 4.2
+            },
+            "1024x1536": {
+              "price": 6.3
+            },
+            "1536x1024": {
+              "price": 6.3
+            }
+          },
+          "high": {
+            "default": {
+              "price": 16.7
+            },
+            "1024x1024": {
+              "price": 16.7
+            },
+            "1024x1536": {
+              "price": 25
+            },
+            "1536x1024": {
+              "price": 25
+            }
+          },
+          "default": {
+            "default": {
+              "price": 1.1
+            },
+            "1024x1024": {
+              "price": 1.1
+            },
+            "1024x1536": {
+              "price": 1.6
+            },
+            "1536x1024": {
+              "price": 1.6
+            }
+          }
         }
       }
     }
@@ -3782,6 +3852,40 @@
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "image": {
+          "low": {
+            "default": {
+              "price": 0.2
+            },
+            "1024x1024": {
+              "price": 0.2
+            }
+          },
+          "medium": {
+            "default": {
+              "price": 0.75
+            },
+            "1024x1024": {
+              "price": 0.75
+            }
+          },
+          "high": {
+            "default": {
+              "price": 3
+            },
+            "1024x1024": {
+              "price": 3
+            }
+          },
+          "default": {
+            "default": {
+              "price": 0.2
+            },
+            "1024x1024": {
+              "price": 0.2
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 19 |


### 🔄 Updated Models
- `gpt-5.2-pro`
- `gpt-5.2-pro-2025-12-11`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `o4-mini-deep-research-2025-06-26`
- `codex-mini-latest`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-audio-mini`
- `gpt-4o-mini-tts`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `whisper-1`
- `gpt-image-1`
- `gpt-image-1.5`
- `gpt-image-1-mini`
- `chatgpt-image-latest`


## Data Sources

| Source | Type | URL |
|--------|------|-----|
| OpenAI Models API | API | `get_openai_models` tool |
| LiteLLM model prices database | Pricing reference | `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json` |

> Note: OpenAI's platform pricing page (https://platform.openai.com/docs/pricing) was inaccessible due to Cloudflare protection and insufficient Firecrawl credits. LiteLLM's publicly maintained pricing database was used as a fallback source.

## Model Coverage (129 models)

| Family | Count |
|--------|-------|
| GPT-5.4 (base, pro, mini, nano + dated) | 8 |
| GPT-5.3 (chat-latest, codex) | 2 |
| GPT-5.2 (base, pro, codex, chat-latest + dated) | 5 |
| GPT-5.1 (base, codex, codex-max, codex-mini, chat-latest + dated) | 6 |
| GPT-5 (base, search-api, pro, codex, mini, nano, chat-latest + dated) | 11 |
| GPT-4.1 (base, mini, nano + dated) | 6 |
| GPT-4o (base, search, + dated variants) | 9 |
| O-series (o1, o3, o4-mini, pro, mini, deep-research) | 16 |
| Audio/Realtime (gpt-4o-realtime, gpt-realtime, gpt-audio, etc.) | 22 |
| Transcription (gpt-4o-transcribe, gpt-4o-mini-transcribe, whisper) | 6 |
| TTS (tts-1, tts-1-hd, gpt-4o-mini-tts) | 7 |
| Image (gpt-image-1, dall-e-2/3, chatgpt-image-latest) | 6 |
| Video (sora-2, sora-2-pro) | 2 |
| Embeddings (text-embedding-3-large/small, ada-002) | 3 |
| Moderation (omni-moderation) | 2 |
| Computer Use | 2 |
| Codex-mini | 1 |
| Legacy (gpt-4-turbo, gpt-4, gpt-3.5, babbage, davinci) | 11 |

---
*Generated by Pricing Agent on 2026-04-08*