### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,10 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -1322,23 +1322,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
-            "price": 0.01
+            "price": 0.0001
           },
           "input_video_plus": {
-            "price": 0.2
+            "price": 0.002
           },
           "input_video_standard": {
-            "price": 0.1
+            "price": 0.001
           },
           "input_video_essential": {
-            "price": 0.05
+            "price": 0.0005
           }
         }
       },
@@ -1560,6 +1560,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1602,7 +1605,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2522,7 +2525,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2577,6 +2580,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2693,6 +2699,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2761,6 +2770,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2791,6 +2803,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2944,6 +2959,17 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.012
+          },
+          "input_video_plus": {
+            "price": 0.079
+          },
+          "input_video_essential": {
+            "price": 0.016
+          }
         }
       }
     }
@@ -3515,6 +3541,47 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 3 |
| 🔄 Models updated (merged) | 9 |

### ➕ New Models
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `veo-3.1-lite-generate-001`

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-3-flash-preview`
- `gemini-3-pro-image-preview`
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-image-preview`
- `gemini-3.1-flash-lite-preview`
- `multimodalembedding@001`
- `veo-3.1-fast-generate-001`
- `gemini-embedding-2-preview`


## Model-to-Pricing-Page Mapping

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Standard ≤200K input price used; long-context >200K: $2.50/M in, $15/M out |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | Cache read $0.03/M |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | Cache read $0.01/M |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | Image output token $30/M |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 | API | Matched to Gemini 2.5 Pro pricing |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 | API | Alias for gemini-2.5-flash; same pricing |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 | API | Alias for gemini-2.5-flash-lite; same pricing |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API – price not found | TTS variant; no dedicated pricing row |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API – price not found | TTS variant; no dedicated pricing row |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | Batch config included |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | Batch config included |
| `gemini-3-pro-preview` | Google – Gemini 3 | API | Gemini 3 Pro Preview; web_search $14/1000 |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | Gemini 3 Flash Preview; web_search $14/1000 |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API | Image output token $120/M |
| `gemini-3.1-pro-preview` | Google – Gemini 3.1 | API | Gemini 3.1 Pro Preview |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3.1 | API | Image output token $60/M |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3.1 | API | Gemini 3.1 Flash-Lite Preview |
| `gemini-embedding-001` | Google – Embedding | API | $0.00015/1K tokens |
| `gemini-embedding-2-preview` | Google – Embedding | API | Text $0.2/M tokens; per-image/video additional units |
| `text-embedding-005` | Google – Embedding | API | $0.000025/1K chars |
| `text-multilingual-embedding-002` | Google – Embedding | API | $0.000025/1K chars |
| `text-embedding-large-exp-03-07` | Google – Embedding | API | No dedicated row; uses text embedding family pricing |
| `textembedding-gecko@003` | Google – Embedding | API | Legacy; $0.000025/1K chars |
| `multimodalembedding@001` | Google – Embedding | API | Text $0.0002/1K chars + per-image/video additional units |
| `imagen-4.0-generate-001` | Google – Imagen | API | $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen | API | $0.02/image |
| `imagen-4.0-ultra-generate-001` | Google – Imagen | API | $0.06/image |
| `imagen-3.0-generate-002` | Google – Imagen | API | $0.04/image |
| `imagen-3.0-capability-001` | Google – Imagen capability | API | Maps to imagen-3.0-generate pricing: $0.04/image |
| `imagen-3.0-capability-002` | Google – Imagen capability | API | Maps to imagen-3.0-generate pricing: $0.04/image |
| `veo-2.0-generate-001` | Google – Veo | API | $0.50/sec |
| `veo-3.0-generate-001` | Google – Veo | API | $0.20/sec video; $0.40/sec audio+video |
| `veo-3.0-fast-generate-001` | Google – Veo | API | $0.10/sec video; $0.15/sec audio+video |
| `veo-3.1-generate-001` | Google – Veo | API | $0.20/sec 720p/1080p; $0.40/sec 4K |
| `veo-3.1-fast-generate-001` | Google – Veo | API | $0.10/sec video; $0.15/sec audio+video |
| `veo-3.1-lite-generate-001` | Google – Veo | API | $0.03/sec 720p; $0.05/sec 1080p |
| `claude-opus-4-6` | Anthropic – Claude | API | @default stripped; input $5, output $25/M; cache write 5m $6.25/M |
| `claude-sonnet-4-6` | Anthropic – Claude | API | @default stripped; input $3, output $15/M; cache write 5m $3.75/M |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude | API | Pinned date kept; long-ctx: $6/$22.50/M |
| `claude-haiku-4-5@20251001` | Anthropic – Claude | API | Input $1, output $5/M |
| `claude-opus-4-5@20251101` | Anthropic – Claude | API | Input $5, output $25/M |
| `claude-opus-4-1@20250805` | Anthropic – Claude | API | Input $15, output $75/M |
| `claude-opus-4@20250514` | Anthropic – Claude | API | Input $15, output $75/M |
| `claude-sonnet-4@20250514` | Anthropic – Claude | API | Input $3, output $15/M |
| `gpt-oss-120b-maas` | OpenAI – Partner | API | Input $0.09, output $0.36/M; gpt-oss-20b on page but not in API → not added |
| `llama-3.3-70b-instruct-maas` | Meta – Llama | API | Input $0.72, output $0.72/M; batch config included |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama | API | Input $0.35, output $1.15/M; batch config included |
| `mistral-small-2503` | Mistral – Partner | API | Matched to Mistral Small 3.1 (25.03) on pricing page |
| `mistral-medium-3` | Mistral – Partner | API | Input $0.40, output $2/M |
| `codestral-2` | Mistral – Partner | API | Input $0.30, output $0.90/M |
| `deepseek-r1-0528-maas` | DeepSeek – Partner | API | DeepSeek-R1 (0528); batch config included |
| `deepseek-v3.1-maas` | DeepSeek – Partner | API | DeepSeek-V3.1; batch config included |
| `deepseek-v3.2-maas` | DeepSeek – Partner | API | DeepSeek-V3.2; batch config included |
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen – Partner | API | Qwen3-235B-A22B-Instruct-2507; batch config included |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen – Partner | API | Qwen3-Coder-480B; batch config included |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen – Partner | API | Qwen3-Next-80B-Instruct |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen – Partner | API | Qwen3-Next-80B-Thinking |
| `kimi-k2-thinking-maas` | Moonshot / Kimi – Partner | API | Kimi-K2-Thinking; input $0.60, output $2.50/M |
| `minimax-m2-maas` | MiniMax – Partner | API | MiniMax-M2; input $0.30, output $1.20/M |
| `glm-4.7-maas` | ZAI.org / GLM – Partner | API | GLM-4.7; input $0.60, output $2.20/M |
| `glm-5-maas` | ZAI.org / GLM – Partner | API | GLM-5; input $1, output $3.20/M |

## Excluded Models (notable)

| Model | Reason |
|-------|--------|
| `*-live-*` (e.g. gemini-live-2.5-flash-native-audio) | Gemini Live streaming – global exclude |
| `lyria-*`, `lyria-3-*` | Music generation – global exclude |
| `model-optimizer-*` | Meta-endpoint – global exclude |
| `whisper-large` | Audio transcription – global exclude |
| `clip-vit-base-patch32`, `openclip` | Non-generative (classification/embedding) – OpenAI publisher |
| `gpt-oss` | Self-deploy, no -maas suffix |
| `codestral-2501-self-deploy` | Self-deploy explicitly in name |
| `mistral-ocr-2505`, `deepseek-ocr*`, `glm-ocr` | OCR – global exclude |
| `llama-guard`, `prompt-guard`, `shieldgemma2` | Safety/guard models – global exclude |
| `glm-image`, `qwen-image` | Policy exception – excluded by design |
| `jamba-large-1.6` | AI21 – self-deploy only, no MaaS variant |
| `faster-r-cnn`, `retinanet`, `mask-r-cnn`, `segment-anything`, `sam3` | Non-generative CV – Meta publisher |
| `roberta-*`, `xlm-roberta-*` | Non-generative NLP – Meta publisher |
| All `has_deploy:true` without `-maas` | Self-deploy infrastructure models |

---
*Generated by Pricing Agent on 2026-04-08*