### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1753,5 +1753,10 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -917,14 +917,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1681,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
@@ -1943,20 +1943,20 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1977,20 +1977,20 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2463,20 +2463,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2494,20 +2494,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2581,29 +2581,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,29 +2612,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3051,7 +3051,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3068,7 +3071,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3174,7 +3180,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3220,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3244,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3289,40 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 42 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-3.1-pro-preview-lte-128k`
- `gemini-3.1-pro-preview-gt-128k`
- `gemini-3-pro-preview-lte-128k`
- `gemini-3-pro-preview-gt-128k`
- `gemini-3-flash-preview-lte-128k`
- `gemini-3-flash-preview-gt-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-3-pro-image-preview-lte-128k`
- `gemini-3-pro-image-preview-gt-128k`
- `gemini-3.1-flash-image-preview-lte-128k`
- `gemini-3.1-flash-image-preview-gt-128k`
- `gemini-pro-latest-lte-128k`
- `gemini-pro-latest-gt-128k`
- `gemini-flash-latest-lte-128k`
- `gemini-flash-latest-gt-128k`
- `gemini-flash-lite-latest-lte-128k`
- `gemini-flash-lite-latest-gt-128k`
- `gemini-2.5-pro-lte-128k`
- `gemini-2.5-pro-gt-128k`
- `gemini-2.5-flash-lte-128k`
- `gemini-2.5-flash-gt-128k`
- `gemini-2.5-flash-lite-lte-128k`
- `gemini-2.5-flash-lite-gt-128k`
- `gemini-2.5-flash-image-lte-128k`
- `gemini-2.5-flash-image-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- ... and 12 more


### Model → pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K | input $2/1M, output $12/1M, cache_read $0.20/1M, batch 50%, web_search $14/1K |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K | input $4/1M, output $18/1M, cache_read $0.40/1M, batch 50%, web_search $14/1K |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K | same pricing as 3.1-pro-preview ≤200K tier |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K | same pricing as 3.1-pro-preview >200K tier |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, flat pricing | input $0.50/1M, output $3/1M, cache_read $0.05/1M, batch 50%, web_search $14/1K |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, flat pricing | identical to lte (no context tier) |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash Lite Preview, flat pricing | input $0.25/1M, output $1.50/1M, cache_read $0.03/1M, batch ~50%, web_search $14/1K |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash Lite Preview, flat pricing | identical to lte (no context tier) |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview, flat pricing | input $2/1M, text output $12/1M, image_token $120/1M, batch 50%; output_price≠image_token |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview, flat pricing | identical to lte (flat pricing, no context tier) |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview, flat pricing | input $0.50/1M, text output $3/1M, image_token $60/1M, batch 50% |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview, flat pricing | identical to lte (flat pricing, no context tier) |
| gemini-pro-latest-lte-128k | *-latest → resolved to gemini-3.1-pro-preview (verified from pricing page) | same pricing as 3.1-pro-preview ≤200K |
| gemini-pro-latest-gt-128k | *-latest → resolved to gemini-3.1-pro-preview (verified from pricing page) | same pricing as 3.1-pro-preview >200K |
| gemini-flash-latest-lte-128k | *-latest → resolved to gemini-3-flash-preview (verified from pricing page) | same pricing as 3-flash-preview |
| gemini-flash-latest-gt-128k | *-latest → resolved to gemini-3-flash-preview (verified from pricing page) | identical to lte |
| gemini-flash-lite-latest-lte-128k | *-latest → resolved to gemini-3.1-flash-lite-preview (verified from pricing page) | same pricing as 3.1-flash-lite-preview |
| gemini-flash-lite-latest-gt-128k | *-latest → resolved to gemini-3.1-flash-lite-preview (verified from pricing page) | identical to lte |
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | input $1.25/1M, output $10/1M, cache_read $0.13/1M, batch 50%, web_search $35/1K |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | input $2.50/1M, output $15/1M, cache_read $0.25/1M, batch 50%, web_search $35/1K |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat pricing | input $0.30/1M, output $2.50/1M, cache_read $0.03/1M, batch 50%, web_search $35/1K |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat pricing | identical to lte (no context tier on page) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash Lite, flat pricing | input $0.10/1M, output $0.40/1M, cache_read $0.01/1M, batch 50%, web_search $35/1K |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash Lite, flat pricing | identical to lte |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat pricing | input $0.30/1M, text output $2.50/1M, image_token $30/1M, batch 50%; batch image output $15/1M |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat pricing | identical to lte |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat pricing | input $0.15/1M, output $0.60/1M, batch 50%, web_search $35/1K |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat pricing | identical to lte |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash 001 (versioned alias of gemini-2.0-flash) | same pricing as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash 001 (versioned alias) | identical to lte |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash Lite, flat pricing | input $0.075/1M, output $0.30/1M, batch 50% |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash Lite, flat pricing | identical to lte |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash Lite 001 (versioned alias) | same pricing as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash Lite 001 (versioned alias) | identical to lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4 Generate | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4 Generate | $0.04/image |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4 Ultra Generate | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4 Ultra Generate | $0.06/image |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4 Fast Generate | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4 Fast Generate | $0.02/image |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Generate Preview | $0.20/s video-only (1080p default), 8s default duration, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Generate Preview | identical to lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast Generate Preview | $0.10/s (1080p), 8s default, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast Generate Preview | identical to lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite Generate Preview | $0.05/s (1080p), 8s default, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite Generate Preview | identical to lte |
| veo-3.0-generate-001-lte-128k | Veo 3 Generate | $0.20/s video-only (1080p), 8s default, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3 Generate | identical to lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3 Fast Generate | $0.10/s (1080p), 8s default, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3 Fast Generate | identical to lte |
| veo-2.0-generate-001-lte-128k | Veo 2 Generate | $0.50/s video-only (720p), 8s default, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2 Generate | identical to lte |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | input $0.15/1M (online), batch $0.12/1M, output free |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 | identical to lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview (Unified Multimodal) | input text $0.20/1M; image/video/audio priced separately (per-image/frame/second not in token format) |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview | identical to lte |
| deep-research-pro-preview-12-2025-lte-128k | — | Price not found on pricing page; added with 0s |
| deep-research-pro-preview-12-2025-gt-128k | — | Price not found on pricing page; added with 0s |

### Data sources
- **Pricing page**: https://cloud.google.com/vertex-ai/generative-ai/pricing (Vertex AI, fetched fresh via http_request)
- **Models API**: get_gemini_models (50 models returned)

### Notes
- Pricing sourced from Vertex AI pricing page (cloud.google.com); Gemini Developer API page (ai.google.dev) was unavailable due to firecrawl credit exhaustion and file size limits
- Context tiers on Vertex AI page are ≤200K / >200K; mapped to -lte-128k / -gt-128k suffixes per skill convention
- Gemini 2.0 and Flash/Flash-Lite models have flat pricing (no context tiers) — lte and gt entries are identical
- *-latest aliases resolved from live pricing page: gemini-pro-latest → gemini-3.1-pro-preview; gemini-flash-latest → gemini-3-flash-preview; gemini-flash-lite-latest → gemini-3.1-flash-lite-preview
- Gemini image models: output_price = text output rate (inherited from base model); additional.image_token = separate image output rate
- Veo video_seconds values: Veo 2 = 50¢/s, Veo 3/3.1 standard = 20¢/s, Fast = 10¢/s, Lite = 5¢/s (1080p video-only defaults used)
- gemini-embedding-2-preview per-image/frame/audio pricing not captured in token format (requires separate additional keys not currently supported)
- deep-research-pro-preview-12-2025: no pricing found on page, submitted with 0s

---
*Generated by Pricing Agent on 2026-04-08*