### PR TITLE
chore: Update openrouter pricing and config

### DIFF
--- a/general/openrouter.json
+++ b/general/openrouter.json
@@ -5316,5 +5316,19 @@
       "primary": "embedding"
     },
     "disablePlayground": true
+  },
+  "openrouter/elephant-alpha": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
+      }
+    ]
   }
 }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -4288,7 +4288,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.000029
         },
         "response_token": {
           "price": 0.000095

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5308,10 +5308,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000126
+          "price": 0.0001395
         },
         "response_token": {
-          "price": 0.000396
+          "price": 0.00044
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -256,10 +256,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": undefined
         },
         "response_token": {
-          "price": 0.0012
+          "price": undefined
         }
       }
     }
@@ -520,10 +520,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": undefined
         },
         "response_token": {
-          "price": 0.0002
+          "price": undefined
         }
       }
     }
@@ -568,10 +568,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": undefined
         },
         "response_token": {
-          "price": 0.001
+          "price": undefined
         }
       }
     }
@@ -628,10 +628,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": undefined
         },
         "response_token": {
-          "price": 0.00025
+          "price": undefined
         }
       }
     }
@@ -3940,10 +3940,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": undefined
         },
         "response_token": {
-          "price": 0
+          "price": undefined
         }
       }
     }
@@ -4840,10 +4840,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": undefined
         },
         "response_token": {
-          "price": 0.0003
+          "price": undefined
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -3340,10 +3340,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000049
+          "price": 0.0000245
         },
         "response_token": {
-          "price": 0.0000049
+          "price": 0.0000245
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -1327,7 +1327,7 @@
           "price": 0.000003
         },
         "response_token": {
-          "price": 0.000011
+          "price": 0.000014
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5591,5 +5591,17 @@
         }
       }
     }
+  },
+  "openrouter/elephant-alpha": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
   }
 }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5332,7 +5332,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000012
         },
         "response_token": {
           "price": 0.00004

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -2428,10 +2428,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000035
         },
         "response_token": {
-          "price": 0.000011
+          "price": 0.000056
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5308,10 +5308,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001395
+          "price": 0.000095
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.000315
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5332,10 +5332,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000035
         }
       }
     }
@@ -5356,10 +5356,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000014
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000038
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5308,10 +5308,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001395
+          "price": 0.000126
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.000396
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -1864,7 +1864,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000045
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.000215
@@ -4672,10 +4672,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00008
         }
       }
     }


### PR DESCRIPTION
## 🔄 Models Update: openrouter

### 📊 Summary

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 1 |
| 🔄 Prices updated | 15 |
| 📋 General configs added | 1 |

### ➕ New Models
- `openrouter/elephant-alpha`

### 🔄 Updated Prices
- `z-ai/glm-5.1`
- `google/gemma-4-26b-a4b-it`
- `google/gemma-4-31b-it`
- `google/gemini-3.1-flash-image-preview`
- `qwen/qwen3-coder-next`
- `minimax/minimax-m2.1`
- `google/gemini-3-pro-image-preview`
- `openai/gpt-5-image-mini`
- `openai/gpt-5-image`
- `google/gemini-2.5-flash-image`
- `openai/gpt-oss-20b`
- `deepseek/deepseek-r1-0528`
- `mistralai/mistral-small-3.1-24b-instruct`
- `meta-llama/llama-3.2-11b-vision-instruct`
- `openrouter/auto`

### 📋 New General Configs
- `openrouter/elephant-alpha`


---
*Generated by Direct Converter on 2026-04-13*