### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/general/openai.json
+++ b/general/openai.json
@@ -2957,5 +2957,85 @@
     ],
 
     "type": { "primary": "chat", "supported": ["tools", "image"] }
+  },
+  "sora": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-moderation-007": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-mini-realtime-preview-2025-06-03": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4.5-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-2025-01-31": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-mini-2025-01-31": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-2025-05-07": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-mini-2025-07-18": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "o3-mini-2025-07-23": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "o1-2025-04-16": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-realtime-preview-2025-01-23": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-mini-realtime-preview-2025-01-23": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-image-1-2025-04-23": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "codex-mini-2025-05-08": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-mini-2025-05-07": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4.1-2026-04-14": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -824,6 +824,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00025
         }
       },
       "batch_config": {
@@ -1067,16 +1070,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.00011
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.00044
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00015
+          "price": 0.000055
         },
         "additional_units": {
           "file_search": {
@@ -1102,13 +1105,13 @@
           "price": 0.00025
         },
         "cache_read_audio_input_token": {
-          "price": 0.002
+          "price": 0.00025
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         }
       }
     }
@@ -1269,10 +1272,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1295,10 +1298,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1339,6 +1342,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.6
         }
       }
     }
@@ -1351,6 +1357,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.0015
         }
       }
     }
@@ -1363,6 +1372,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.003
         }
       }
     }
@@ -1383,6 +1395,9 @@
           "response_audio_token": {
             "price": 1.5
           }
+        },
+        "response_audio_token": {
+          "price": 0.0012
         }
       }
     }
@@ -1394,7 +1409,7 @@
           "price": 0.00025
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "additional_units": {
           "request_audio_token": {
@@ -1403,6 +1418,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0006
         }
       }
     }
@@ -1414,7 +1432,7 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0
         },
         "additional_units": {
           "request_audio_token": {
@@ -1423,6 +1441,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0003
         }
       }
     }
@@ -1554,6 +1575,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       },
       "batch_config": {
@@ -1574,6 +1598,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       }
     }
@@ -1721,7 +1748,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1762,7 +1789,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2193,7 +2220,7 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
@@ -2259,16 +2286,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2286,16 +2313,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2361,7 +2388,7 @@
           "price": 0.0000375
         },
         "cache_read_input_token": {
-          "price": 0.0006
+          "price": 0.0000375
         }
       }
     }
@@ -2442,7 +2469,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000625
         },
         "additional_units": {
           "web_search": {
@@ -2505,7 +2532,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000005
+          "price": 0.00000125
         }
       },
       "batch_config": {
@@ -2611,10 +2638,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2850,6 +2877,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.004
         }
       }
     }
@@ -2865,10 +2898,16 @@
         },
         "additional_units": {
           "video_duration_seconds_720_1280": {
-            "price": 10
+            "price": 7
           },
           "video_duration_seconds_1280_720": {
             "price": 10
+          },
+          "video_duration_seconds_480_854": {
+            "price": 3
+          },
+          "video_duration_seconds_1080_1920": {
+            "price": 15
           }
         }
       }
@@ -3725,6 +3764,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.0015
         }
       }
     }
@@ -3737,6 +3779,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.003
         }
       }
     }
@@ -4049,6 +4094,284 @@
         },
         "cache_read_input_token": {
           "price": 0.000002
+        }
+      }
+    }
+  },
+  "gpt-3.5-turbo-0301": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "sora": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_duration_seconds_480_854": {
+            "price": 3
+          },
+          "video_duration_seconds_720_1280": {
+            "price": 7
+          },
+          "video_duration_seconds_1080_1920": {
+            "price": 15
+          }
+        }
+      }
+    }
+  },
+  "text-moderation-007": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gpt-4o-mini-realtime-preview-2025-06-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        },
+        "request_audio_token": {
+          "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.002
+        },
+        "cache_read_audio_input_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-4.5-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0075
+        },
+        "response_token": {
+          "price": 0.015
+        },
+        "cache_read_input_token": {
+          "price": 0.00375
+        }
+      }
+    }
+  },
+  "gpt-4o-2025-01-31": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
+        }
+      }
+    }
+  },
+  "gpt-4o-mini-2025-01-31": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      }
+    }
+  },
+  "gpt-4o-2025-05-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
+        }
+      }
+    }
+  },
+  "gpt-4o-mini-2025-07-18": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      }
+    }
+  },
+  "o3-mini-2025-07-23": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00011
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.000055
+        }
+      }
+    }
+  },
+  "o1-2025-04-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0015
+        },
+        "response_token": {
+          "price": 0.006
+        },
+        "cache_read_input_token": {
+          "price": 0.00075
+        }
+      }
+    }
+  },
+  "gpt-4o-realtime-preview-2025-01-23": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.002
+        },
+        "cache_read_input_token": {
+          "price": 0.00025
+        },
+        "request_audio_token": {
+          "price": 0.004
+        },
+        "response_audio_token": {
+          "price": 0.008
+        },
+        "cache_read_audio_input_token": {
+          "price": 0.00025
+        }
+      }
+    }
+  },
+  "gpt-4o-mini-realtime-preview-2025-01-23": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        },
+        "request_audio_token": {
+          "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.002
+        },
+        "cache_read_audio_input_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-image-1-2025-04-23": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.004
+        },
+        "request_image_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "codex-mini-2025-05-08": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.0006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000375
+        }
+      }
+    }
+  },
+  "gpt-4o-mini-2025-05-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      }
+    }
+  },
+  "gpt-4.1-2026-04-14": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0008
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 17 |
| 🔄 Models updated (merged) | 26 |

### ➕ New Models
- `gpt-3.5-turbo-0301`
- `sora`
- `text-moderation-007`
- `gpt-4o-mini-realtime-preview-2025-06-03`
- `gpt-4.5-preview`
- `gpt-4o-2025-01-31`
- `gpt-4o-mini-2025-01-31`
- `gpt-4o-2025-05-07`
- `gpt-4o-mini-2025-07-18`
- `o3-mini-2025-07-23`
- `o1-2025-04-16`
- `gpt-4o-realtime-preview-2025-01-23`
- `gpt-4o-mini-realtime-preview-2025-01-23`
- `gpt-image-1-2025-04-23`
- `codex-mini-2025-05-08`
- `gpt-4o-mini-2025-05-07`
- `gpt-4.1-2026-04-14`

### 🔄 Updated Models
- `gpt-5-mini`
- `gpt-5-nano`
- `codex-mini-latest`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `gpt-4o-2024-05-13`
- `o1-mini-2024-09-12`
- `o4-mini-deep-research-2025-06-26`
- `gpt-4o-realtime-preview-2024-10-01`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-4o-audio-preview`
- `gpt-4o-audio-preview-2024-10-01`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-4o-mini-tts`
- `tts-1`
- `tts-1-hd`
- `tts-1-1106`
- `tts-1-hd-1106`
- `whisper-1`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `computer-use-preview`
- `computer-use-preview-2025-03-11`
- `gpt-image-1`
- `sora-2`


## Data Sources

| Model Family | Pricing Source |
|---|---|
| All models | LiteLLM `model_prices_and_context_window.json` (proxy for OpenAI pricing page, since platform.openai.com/docs/pricing returned 403) |
| Model list | OpenAI Models API (`get_openai_models`) |

## Model Coverage (128 models total)

| Batch | Family | Count |
|---|---|---|
| 1 | GPT-5.x, GPT-5.1.x, GPT-5.2.x, GPT-5.4.x, codex-mini, GPT-4.1.x, GPT-4o | 25 |
| 2 | GPT-4o variants, GPT-4-turbo, GPT-4, O4-mini, O3, O3-pro, O3-mini | 25 |
| 3 | O3-mini, O1, O1-pro, O1-preview, O1-mini, deep-research, GPT-3.5, babbage/davinci, search-preview | 25 |
| 4 | Search-preview variants, Realtime, Audio, TTS, Whisper, Transcribe, computer-use, gpt-image-1, DALL-E 3 | 25 |
| 5 | DALL-E 2, Sora, Embeddings, Moderation, additional dated variants | 19 |
| 6 | Remaining dated variants (GPT-4o, GPT-4.1, O-series, Realtime, Audio, codex-mini) | 11 |

---
*Generated by Pricing Agent on 2026-04-09*