### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,285 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemini-1.5-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-1.5-pro": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-flash-preview-native-audio": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "imagen-4.0-capability-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "imagetext@001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-embedding-2-preview-06-2025": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "translate-llm-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama-3.3-70b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama-4-maverick-17b-128e-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama-4-scout-17b-16e-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama3-405b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama3-70b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama3-8b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama3_1-405b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama3_1-70b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama3_1-8b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama3_2-90b-vision-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama-guard-3-8b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "meta-llama/llama3_2-11b-vision-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mistral-nemo@2407": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mistral-large@2407": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mistral-large@2411": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-ai/deepseek-v3.1-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-ai/deepseek-v3.2-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-ai/deepseek-r1-0528-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-ai/deepseek-r1-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-ai/deepseek-v2-chat-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-ai/deepseek-r1-zero-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-ai/deepseek-v3-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-ai/deepseek-r1-lite-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-ai/deepseek-v2.5-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-ai/deepseek-r1-distill-llama-70b-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "minimax/minimax-m2-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshotai/kimi-k2-thinking-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshotai/kimi-k1.5-thinking-preview-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshotai/kimi-k1.5-preview-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen/qwen3-next-80b-a3b-thinking-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen/qwen3-next-80b-a3b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen/qwen3-coder-480b-a35b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen/qwen3-235b-a22b-instruct-2507-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen/qwen2-72b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen/qwen2-vl-72b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen/qwq-32b-preview-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen/qwen2-5-72b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen/qwen2-5-coder-32b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen/qwen3-30b-a3b-instruct-2503-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen/qwen3-235b-a22b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "zai-org/glm-4.7-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "zai-org/glm-5-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "zai-org/glm-z1-plus-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "zai-org/glm-4v-flash-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "zai-org/glm-4v-plus-0111-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "zai-org/glm-z1-rumination-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "openai/gpt-oss-120b-maas": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -40,10 +40,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -51,6 +51,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -152,10 +155,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -163,6 +166,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -180,10 +186,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -191,6 +197,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -351,6 +360,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -432,7 +444,7 @@
           "price": 0.0000075
         },
         "response_token": {
-          "price": 0.000003
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -440,6 +452,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -510,7 +525,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -630,7 +645,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -866,6 +881,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -911,7 +929,7 @@
           "price": 0.0000075
         },
         "response_token": {
-          "price": 0.000003
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -919,6 +937,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1322,23 +1343,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
-            "price": 0.01
+            "price": 0.0001
           },
           "input_video_plus": {
-            "price": 0.2
+            "price": 0.002
           },
           "input_video_standard": {
-            "price": 0.1
+            "price": 0.001
           },
           "input_video_essential": {
-            "price": 0.05
+            "price": 0.0005
           }
         }
       },
@@ -1560,6 +1581,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1602,7 +1626,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2272,7 +2296,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2522,7 +2546,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2545,7 +2569,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2577,6 +2601,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2693,6 +2720,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2753,7 +2783,7 @@
           "price": 0.000025
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2761,12 +2791,15 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2791,6 +2824,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2932,6 +2968,17 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
         }
       }
     }
@@ -2991,7 +3038,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3331,6 +3378,17 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
         }
       },
       "batch_config": {
@@ -3515,6 +3573,885 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-thinking-exp-01-21": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-1.5-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-1.5-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.0005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-preview-native-audio": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-capability-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagetext@001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 0.15
+            }
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-06-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.00012
+          },
+          "input_video_plus": {
+            "price": 0.00079
+          },
+          "input_video_standard": {
+            "price": 0.00079
+          },
+          "input_video_essential": {
+            "price": 0.00016
+          }
+        }
+      }
+    }
+  },
+  "translate-llm-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama-3.3-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000072
+        },
+        "response_token": {
+          "price": 0.000072
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000036
+        },
+        "response_token": {
+          "price": 0.000036
+        }
+      }
+    }
+  },
+  "meta-llama/llama-4-maverick-17b-128e-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.000115
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000175
+        },
+        "response_token": {
+          "price": 0.0000575
+        }
+      }
+    }
+  },
+  "meta-llama/llama-4-scout-17b-16e-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama3-405b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama3-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama3-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama3_1-405b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama3_1-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama3_1-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama3_2-90b-vision-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama-guard-3-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "meta-llama/llama3_2-11b-vision-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-nemo@2407": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-large@2407": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-large@2411": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-ai/deepseek-v3.1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00017
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000085
+        }
+      }
+    }
+  },
+  "deepseek-ai/deepseek-v3.2-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.0000056
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "deepseek-ai/deepseek-r1-0528-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000135
+        },
+        "response_token": {
+          "price": 0.00054
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000675
+        },
+        "response_token": {
+          "price": 0.00027
+        }
+      }
+    }
+  },
+  "deepseek-ai/deepseek-r1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-ai/deepseek-v2-chat-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-ai/deepseek-r1-zero-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-ai/deepseek-v3-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-ai/deepseek-r1-lite-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-ai/deepseek-v2.5-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-ai/deepseek-r1-distill-llama-70b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "minimax/minimax-m2-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      }
+    }
+  },
+  "moonshotai/kimi-k2-thinking-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "moonshotai/kimi-k1.5-thinking-preview-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "moonshotai/kimi-k1.5-preview-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen/qwen3-next-80b-a3b-thinking-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen/qwen3-next-80b-a3b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen/qwen3-coder-480b-a35b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00018
+        },
+        "cache_read_input_token": {
+          "price": 0.0000022
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "qwen/qwen3-235b-a22b-instruct-2507-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.000088
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000044
+        }
+      }
+    }
+  },
+  "qwen/qwen2-72b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen/qwen2-vl-72b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen/qwq-32b-preview-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen/qwen2-5-72b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen/qwen2-5-coder-32b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen/qwen3-30b-a3b-instruct-2503-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen/qwen3-235b-a22b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "zai-org/glm-4.7-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        }
+      }
+    }
+  },
+  "zai-org/glm-5-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "zai-org/glm-z1-plus-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "zai-org/glm-4v-flash-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "zai-org/glm-4v-plus-0111-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "zai-org/glm-z1-rumination-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "openai/gpt-oss-120b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000009
+        },
+        "response_token": {
+          "price": 0.000036
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000045
+        },
+        "response_token": {
+          "price": 0.000018
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 59 |
| 🔄 Models updated (merged) | 22 |

### ➕ New Models
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `gemini-2.0-flash-thinking-exp-01-21`
- `gemini-1.5-flash`
- `gemini-1.5-pro`
- `gemini-2.0-flash-image-generation`
- `gemini-2.5-flash-preview-native-audio`
- `imagen-4.0-capability-preview`
- `imagetext@001`
- `veo-3.1-lite-generate-001`
- `gemini-embedding-2-preview-06-2025`
- `translate-llm-001`
- `meta-llama/llama-3.3-70b-instruct-maas`
- `meta-llama/llama-4-maverick-17b-128e-instruct-maas`
- `meta-llama/llama-4-scout-17b-16e-instruct-maas`
- `meta-llama/llama3-405b-instruct-maas`
- `meta-llama/llama3-70b-instruct-maas`
- `meta-llama/llama3-8b-instruct-maas`
- `meta-llama/llama3_1-405b-instruct-maas`
- `meta-llama/llama3_1-70b-instruct-maas`
- ... and 39 more

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-2.5-computer-use-preview-10-2025`
- `gemini-2.0-flash-exp`
- `gemini-3-flash-preview`
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-lite-preview`
- `gemini-1.5-flash-001`
- `gemini-1.5-flash-002`
- `gemini-1.5-pro-001`
- `gemini-1.5-pro-002`
- `gemini-1.0-pro-001`
- `gemini-1.0-pro-002`
- `gemini-1.0-pro`
- `gemini-3-pro-image-preview`
- `gemini-3.1-flash-image-preview`
- `veo-3.0-generate-001`
- `veo-3.1-generate-001`
- `veo-3.1-fast-generate-001`
- `text-embedding-large-exp-03-07`
- `multimodalembedding@001`
- `textembedding-gecko@001`
- `textembedding-gecko-multilingual@001`


## Model-to-Pricing-Page Mapping

### Google – Gemini (text/multimodal)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Standard $1.25/$10 ≤200K; long-context $2.50/$15 >200K noted; batch $0.625/$5 |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | $0.30/$2.50; cache $0.03; batch $0.15/$1.25 |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | $0.10/$0.40; batch $0.05/$0.20 |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias → uses gemini-2.5-flash pricing |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias → uses gemini-2.5-flash-lite pricing |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 | API | Maps to Gemini 2.5 Pro Computer Use pricing |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no dedicated pricing row found |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no dedicated pricing row found |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | Image output model; $0.30/$2.50 + image_token $30/1M |
| `gemini-2.5-flash-preview-native-audio` | Google – Gemini 2.5 | API – price not found | Native audio preview; uses 2.5 Flash pricing as base |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | $0.15/$0.60; batch $0.075/$0.30 |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | $0.075/$0.30; batch $0.0375/$0.15 |
| `gemini-2.0-flash-exp` | Google – Gemini 2.0 | API | Experimental; uses 2.0 Flash pricing |
| `gemini-2.0-flash-thinking-exp-01-21` | Google – Gemini 2.0 | API | Thinking experimental; uses 2.0 Flash pricing |
| `gemini-2.0-flash-image-generation` | Google – Gemini 2.0 | API | Image generation variant; $0.15/$0.60 + image_token $30/1M |
| `gemini-3-pro-preview` | Google – Gemini 3 | API | $2.00/$12.00; cache $0.20; batch $1.00/$6.00; search $1.4 cents/search |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | $0.50/$3.00; cache $0.05; batch $0.25/$1.50; search $1.4 cents/search |
| `gemini-3.1-pro-preview` | Google – Gemini 3.1 | API | $2.00/$12.00; cache $0.20; batch $1.00/$6.00; search $1.4 cents/search |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3.1 | API | $0.25/$1.50; cache $0.03; batch $0.13/$0.75; search $1.4 cents/search |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3.1 | API | $0.50/$3.00 + image_token $60/1M; batch $0.25/$1.50; search $1.4 cents/search |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API | $2.00/$12.00 + image_token $120/1M |
| `gemini-1.5-flash-001` | Google – Gemini 1.5 | API | $0.075/$0.30 (≤128K tier) |
| `gemini-1.5-flash-002` | Google – Gemini 1.5 | API | $0.075/$0.30 (≤128K tier) |
| `gemini-1.5-flash` | Google – Gemini 1.5 | API | $0.075/$0.30 (≤128K tier) |
| `gemini-1.5-pro-001` | Google – Gemini 1.5 | API | $1.25/$5.00 (≤128K tier) |
| `gemini-1.5-pro-002` | Google – Gemini 1.5 | API | $1.25/$5.00 (≤128K tier) |
| `gemini-1.5-pro` | Google – Gemini 1.5 | API | $1.25/$5.00 (≤128K tier) |
| `gemini-1.0-pro-001` | Google – Gemini 1.0 | API | $0.125/$0.375 |
| `gemini-1.0-pro-002` | Google – Gemini 1.0 | API | $0.125/$0.375 |
| `gemini-1.0-pro` | Google – Gemini 1.0 | API | $0.125/$0.375 |

### Google – Imagen

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `imagen-4.0-generate-001` | Google – Imagen 4 | API | $0.04/image |
| `imagen-4.0-ultra-generate-001` | Google – Imagen 4 Ultra | API | $0.06/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4 Fast | API | $0.02/image |
| `imagen-3.0-generate-002` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-generate-001` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-fast-generate-001` | Google – Imagen 3 Fast | API | $0.02/image |
| `imagen-3.0-capability-001` | Google – Imagen 3 (capability) | API | Uses imagen-3.0-generate pricing: $0.04/image |
| `imagen-3.0-capability-002` | Google – Imagen 3 (capability) | API | Uses imagen-3.0-generate pricing: $0.04/image |
| `imagen-4.0-capability-preview` | Google – Imagen 4 (capability) | API | Uses imagen-4.0-generate pricing: $0.04/image |
| `imagetext@001` | Google – Imagen Visual Captioning | API | $0.0015/image |

### Google – Veo

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `veo-2.0-generate-001` | Google – Veo 2 | API | $0.50/sec |
| `veo-3.0-generate-001` | Google – Veo 3 | API | $0.40/sec (video+audio, 720p/1080p) |
| `veo-3.0-fast-generate-001` | Google – Veo 3 Fast | API | $0.10/sec (720p) |
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | $0.40/sec (video+audio, 720p/1080p) |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | $0.10/sec (720p) |
| `veo-3.1-lite-generate-001` | Google – Veo 3.1 Lite | API | $0.05/sec (720p) |

### Google – Embedding

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-embedding-001` | Google – Gemini Embedding | API | $0.00015/1K tokens |
| `gemini-embedding-2-preview-06-2025` | Google – Gemini Embedding 2 Preview | API | $0.2/1M tokens; image $0.00012/image; video $0.00079/frame |
| `text-embedding-005` | Google – Text Embedding | API | $0.000025/1K tokens |
| `text-multilingual-embedding-002` | Google – Text Multilingual Embedding | API | $0.000025/1K tokens |
| `text-embedding-large-exp-03-07` | Google – Text Embedding Large | API | $0.00015/1K tokens (experimental) |
| `textembedding-gecko@001` | Google – Legacy Embedding | API | $0.000025/1K tokens |
| `textembedding-gecko@003` | Google – Legacy Embedding | API | $0.000025/1K tokens |
| `textembedding-gecko-multilingual@001` | Google – Legacy Embedding | API | $0.000025/1K tokens |
| `multimodalembedding@001` | Google – Multimodal Embedding | API | $0.0002/1K chars; image $0.0001/image; video plus $0.002/sec |

### Google – Other

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `translate-llm-001` | Google – Translation LLM | API – price not found | Translation model; pricing page shows $/char but unclear model mapping |

### Google – Excluded

| Model ID | Reason |
|----------|--------|
| `*-live-*` (gemini-live-*) | Gemini Live streaming — separate product |
| `lyria-*` | Music generation — excluded per global rules |
| `model-optimizer-*` | Dynamic routing meta-endpoint |
| `virtual-try-on-001` | Product-specific retail model |
| `imagegeneration` | Legacy, superseded |
| `chirp-2`, `chirp-3` | Audio transcription, not generative inference |
| `gemma*`, `paligemma*`, `codegemma*` etc. | Self-deploy (has_deploy: true, no -maas) |
| `gemini-*-live-*` | Gemini Live — excluded |
| Non-generative CV/NLP models | Object detection, classification, segmentation, etc. |

### Anthropic – Claude

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `claude-opus-4-6` | Anthropic – Claude (Partner) | API | @default stripped; $5/$25; cache write 5m $6.25; cache read $0.50; batch $2.50/$12.50 |
| `claude-sonnet-4-6` | Anthropic – Claude (Partner) | API | @default stripped; $3/$15; cache write 5m $3.75; cache read $0.30; batch $1.50/$7.50 |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude (Partner) | API | Pinned @date kept; $3/$15 (≤200K); $6/$22.50 (>200K) noted; cache write 5m $3.75 |
| `claude-haiku-4-5@20251001` | Anthropic – Claude (Partner) | API | $1/$5; cache write 5m $1.25; cache read $0.10; batch $0.50/$2.50 |
| `claude-opus-4-5@20251101` | Anthropic – Claude (Partner) | API | $5/$25; cache write 5m $6.25; cache read $0.50; batch $2.50/$12.50 |
| `claude-opus-4-1@20250805` | Anthropic – Claude (Partner) | API | $15/$75; cache write 5m $18.75; cache read $1.50; batch $7.50/$37.50 |
| `claude-opus-4@20250514` | Anthropic – Claude (Partner) | API | $15/$75; cache write 5m $18.75; cache read $1.50; batch $7.50/$37.50 |
| `claude-sonnet-4@20250514` | Anthropic – Claude (Partner) | API | $3/$15; cache write 5m $3.75; cache read $0.30; batch $1.50/$7.50 |

### Meta – Llama

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `meta-llama/llama-3.3-70b-instruct-maas` | Meta – Llama 3.3 70B | API | $0.72/$0.72; batch $0.36/$0.36 |
| `meta-llama/llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama 4 Maverick | API | $0.35/$1.15; batch $0.175/$0.575 |
| `meta-llama/llama-4-scout-17b-16e-instruct-maas` | Meta – Llama 4 Scout | API – price not found | No pricing row found |
| `meta-llama/llama3-405b-instruct-maas` | Meta – Llama 3 405B | API – price not found | Legacy; no pricing row |
| `meta-llama/llama3-70b-instruct-maas` | Meta – Llama 3 70B | API – price not found | Legacy; no pricing row |
| `meta-llama/llama3-8b-instruct-maas` | Meta – Llama 3 8B | API – price not found | Legacy; no pricing row |
| `meta-llama/llama3_1-405b-instruct-maas` | Meta – Llama 3.1 405B | API – price not found | Legacy; no pricing row |
| `meta-llama/llama3_1-70b-instruct-maas` | Meta – Llama 3.1 70B | API – price not found | Legacy; no pricing row |
| `meta-llama/llama3_1-8b-instruct-maas` | Meta – Llama 3.1 8B | API – price not found | Legacy; no pricing row |
| `meta-llama/llama3_2-90b-vision-instruct-maas` | Meta – Llama 3.2 90B | API – price not found | Legacy; no pricing row |
| `meta-llama/llama3_2-11b-vision-instruct-maas` | Meta – Llama 3.2 11B | API – price not found | Legacy; no pricing row |
| `meta-llama/llama-guard-3-8b-instruct-maas` | Meta – Llama Guard | API | Guard model — included with price 0 (has -maas suffix) |

### Mistral

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `mistral-small-2503` | Mistral – Small 3.1 | API | $0.10/$0.30 |
| `mistral-medium-3` | Mistral – Medium 3 | API | $0.40/$2.00 |
| `codestral-2` | Mistral – Codestral 2 | API | $0.30/$0.90 |
| `mistral-nemo@2407` | Mistral – Nemo | API – price not found | Legacy; no pricing row |
| `mistral-large@2407` | Mistral – Large | API – price not found | Legacy; no pricing row |
| `mistral-large@2411` | Mistral – Large 2411 | API – price not found | Legacy; no pricing row |
| `mistral-ocr-2505` | Mistral | Excluded | OCR model — excluded by OCR rule |

### DeepSeek

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `deepseek-ai/deepseek-v3.1-maas` | DeepSeek – V3.1 | API | $0.60/$1.70; cache read $0.06; batch $0.30/$0.85 |
| `deepseek-ai/deepseek-v3.2-maas` | DeepSeek – V3.2 | API | $0.56/$1.68; cache read $0.056; batch $0.28/$0.84 |
| `deepseek-ai/deepseek-r1-0528-maas` | DeepSeek – R1 (0528) | API | $1.35/$5.40; batch $0.675/$2.70 |
| `deepseek-ai/deepseek-r1-maas` | DeepSeek – R1 | API – price not found | Legacy; no pricing row |
| `deepseek-ai/deepseek-v2-chat-maas` | DeepSeek – V2 | API – price not found | Legacy; no pricing row |
| `deepseek-ai/deepseek-r1-zero-maas` | DeepSeek – R1 Zero | API – price not found | No pricing row |
| `deepseek-ai/deepseek-v3-maas` | DeepSeek – V3 | API – price not found | Legacy; no pricing row |
| `deepseek-ai/deepseek-r1-lite-maas` | DeepSeek – R1 Lite | API – price not found | No pricing row |
| `deepseek-ai/deepseek-v2.5-maas` | DeepSeek – V2.5 | API – price not found | Legacy; no pricing row |
| `deepseek-ai/deepseek-r1-distill-llama-70b-maas` | DeepSeek – R1 Distill | API – price not found | No pricing row |
| `deepseek-ai/deepseek-ocr-maas` | DeepSeek | Excluded | OCR model — excluded by OCR rule |

### MiniMax

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `minimax/minimax-m2-maas` | MiniMax – M2 | API | $0.30/$1.20; cache read $0.03 |

### Moonshot / Kimi

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `moonshotai/kimi-k2-thinking-maas` | Moonshot – Kimi-K2-Thinking | API | $0.60/$2.50; cache read $0.06 |
| `moonshotai/kimi-k1.5-thinking-preview-maas` | Moonshot – Kimi K1.5 Thinking | API – price not found | Preview; no pricing row |
| `moonshotai/kimi-k1.5-preview-maas` | Moonshot – Kimi K1.5 | API – price not found | Preview; no pricing row |

### Qwen

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `qwen/qwen3-next-80b-a3b-thinking-maas` | Qwen – Qwen3-Next-80B Thinking | API | $0.15/$1.20 |
| `qwen/qwen3-next-80b-a3b-instruct-maas` | Qwen – Qwen3-Next-80B Instruct | API | $0.15/$1.20 |
| `qwen/qwen3-coder-480b-a35b-instruct-maas` | Qwen – Qwen3 Coder 480B | API | $0.22/$1.80; cache $0.022; batch $0.11/$0.90 |
| `qwen/qwen3-235b-a22b-instruct-2507-maas` | Qwen – Qwen3-235B-2507 | API | $0.22/$0.88; batch $0.11/$0.44 |
| `qwen/qwen2-72b-instruct-maas` | Qwen – Qwen2 72B | API – price not found | Legacy; no pricing row |
| `qwen/qwen2-vl-72b-instruct-maas` | Qwen – Qwen2-VL | API – price not found | Legacy; no pricing row |
| `qwen/qwq-32b-preview-maas` | Qwen – QwQ-32B | API – price not found | Preview; no pricing row |
| `qwen/qwen2-5-72b-instruct-maas` | Qwen – Qwen2.5 72B | API – price not found | Legacy; no pricing row |
| `qwen/qwen2-5-coder-32b-instruct-maas` | Qwen – Qwen2.5 Coder 32B | API – price not found | Legacy; no pricing row |
| `qwen/qwen3-30b-a3b-instruct-2503-maas` | Qwen – Qwen3-30B | API – price not found | No pricing row found |
| `qwen/qwen3-235b-a22b-instruct-maas` | Qwen – Qwen3-235B | API – price not found | No pricing row found |
| `qwen-image` | Qwen | Excluded | Image model — excluded by policy |

### ZAI.org / GLM

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `zai-org/glm-4.7-maas` | ZAI.org – GLM-4.7 | API | $0.60/$2.20 |
| `zai-org/glm-5-maas` | ZAI.org – GLM-5 | API | $1.00/$3.20; cache read $0.10 |
| `zai-org/glm-z1-plus-maas` | ZAI.org – GLM-Z1 Plus | API – price not found | No pricing row |
| `zai-org/glm-4v-flash-maas` | ZAI.org – GLM-4V Flash | API – price not found | No pricing row |
| `zai-org/glm-4v-plus-0111-maas` | ZAI.org – GLM-4V Plus | API – price not found | No pricing row |
| `zai-org/glm-z1-rumination-maas` | ZAI.org – GLM-Z1 Rumination | API – price not found | No pricing row |
| `glm-image` | ZAI.org | Excluded | Image model — excluded by policy |

### OpenAI (on Vertex)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `openai/gpt-oss-120b-maas` | OpenAI – GPT OSS 120B | API | $0.09/$0.36; batch $0.045/$0.18 |

### AI21

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `ai21-jamba-1.6-large` | AI21 | Excluded | Self-deploy (has_deploy: true, no -maas) |

### Pricing page only (not in get_vertex_models — not added to output)

| Pricing page row | Publisher | Notes |
|-----------------|-----------|-------|
| xAI Grok models | xAI | Appear on pricing page but NOT returned by get_vertex_models |
| Lyria 3 Pro, Lyria 3, Lyria 2 | Google | Music generation — excluded by global rules |

---
*Generated by Pricing Agent on 2026-04-09*