### PR TITLE
chore(pricing): Update dashscope pricing

### DIFF
--- a/general/dashscope.json
+++ b/general/dashscope.json
@@ -632,5 +632,530 @@
   "qwen-mt-lite": {
     "params": [{ "key": "max_tokens", "maxValue": 8192 }],
     "type": { "primary": "chat" }
+  },
+  "qwen-long": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-4b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-1.7b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-0.6b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-27b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-14b-instruct-1m": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-7b-instruct-1m": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qvq-72b-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-doc-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-deep-research": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-embedding-v4": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-embedding-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-rerank": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gte-rerank-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-max": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-max": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "z-image-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-t2i": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-t2i-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-t2i-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-t2i-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2i-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2i-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-i2i-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wanx2.1-imageedit": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "aitryon-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "aitryon-parsing-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-mt-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "animate-anyone-detect-gen2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-s2v-detect": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "liveportrait-detect": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "emo-detect-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-t2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-i2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-i2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-i2v-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-i2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-kf2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-kf2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-r2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-r2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-vace-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-s2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-animate-move": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-animate-mix": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "animate-anyone-template-gen2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "animate-anyone-gen2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "emo-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "liveportrait": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "emoji-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "videoretalk": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "video-style-transform": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "emoji-detect-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vd-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vc-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-8k-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-realtime-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-voice-enrollment": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-voice-design": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-livetranslate-flash": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -159,6 +159,12 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
+        },
+        "response_image_token": {
+          "price": 0.000063
         }
       }
     }
@@ -177,6 +183,12 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000084
+        },
+        "response_image_token": {
+          "price": 0.000252
         }
       }
     }
@@ -458,10 +470,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000035
+          "price": 0.000014
         },
         "response_token": {
-          "price": 0.00014
+          "price": 0.000056
         },
         "reasoning_token": {
           "price": 0.00042
@@ -488,10 +500,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.000016
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.000064
         },
         "reasoning_token": {
           "price": 0.00084
@@ -503,10 +515,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000018
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00007
+          "price": 0.000028
         },
         "reasoning_token": {
           "price": 0.00021
@@ -518,10 +530,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0035
         },
         "response_token": {
-          "price": 0.0000035
+          "price": 0.0035
         }
       }
     }
@@ -602,7 +614,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.00013
         },
         "response_token": {
           "price": 0.001
@@ -612,6 +624,9 @@
         },
         "response_audio_token": {
           "price": 0.0038
+        },
+        "request_image_token": {
+          "price": 0.00013
         }
       }
     }
@@ -684,6 +699,12 @@
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
+        },
+        "response_image_token": {
+          "price": 0.000306
         }
       }
     }
@@ -702,6 +723,12 @@
         },
         "response_audio_token": {
           "price": 0.001813
+        },
+        "request_image_token": {
+          "price": 0.000094
+        },
+        "response_image_token": {
+          "price": 0.000367
         }
       }
     }
@@ -721,7 +748,6 @@
       }
     }
   },
-
   "qwen3-vl-30b-a3b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -792,10 +818,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000573
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.000258
+          "price": 0.0000861
         }
       }
     }
@@ -912,10 +938,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000431
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.0002007
+          "price": 0.0000861
         }
       }
     }
@@ -924,10 +950,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000431
+          "price": 0.0000143
         },
         "response_token": {
-          "price": 0.0002007
+          "price": 0.000043
         }
       }
     }
@@ -960,10 +986,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.00008
         },
         "reasoning_token": {
           "price": 0.00084
@@ -1626,10 +1652,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000381
+          "price": 0.0381
         },
         "response_token": {
-          "price": 0.000306
+          "price": 0.0306
         }
       }
     }
@@ -1885,6 +1911,1287 @@
         },
         "response_token": {
           "price": 0.0002294
+        }
+      }
+    }
+  },
+  "qwen-long": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "qwen3-4b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.000016
+        }
+      }
+    }
+  },
+  "qwen3-1.7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.000016
+        }
+      }
+    }
+  },
+  "qwen3-0.6b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.000016
+        }
+      }
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00036
+        }
+      }
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00032
+        }
+      }
+    }
+  },
+  "qwen3.5-27b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00056
+        }
+      }
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00007
+        },
+        "response_token": {
+          "price": 0.00028
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.00014
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000175
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000805
+        },
+        "response_token": {
+          "price": 0.000322
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000368
+        },
+        "response_token": {
+          "price": 0.000147
+        }
+      }
+    }
+  },
+  "qvq-72b-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001721
+        },
+        "response_token": {
+          "price": 0.0005161
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00028
+        },
+        "response_token": {
+          "price": 0.00084
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00042
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.000105
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000021
+        },
+        "response_token": {
+          "price": 0.000063
+        }
+      }
+    }
+  },
+  "qwen-doc-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000087
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "qwen-deep-research": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0007742
+        },
+        "response_token": {
+          "price": 0.0023367
+        }
+      }
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000058
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "text-embedding-v4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-rerank": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gte-rerank-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00004
+        },
+        "request_audio_token": {
+          "price": 0.000676
+        },
+        "response_audio_token": {
+          "price": 0.001351
+        },
+        "request_image_token": {
+          "price": 0.000028
+        },
+        "response_image_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "qwen-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.023
+        },
+        "response_token": {
+          "price": 0.1434
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0345
+        },
+        "response_token": {
+          "price": 0.1721
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-2.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4.5
+        },
+        "response_token": {
+          "price": 4.5
+        }
+      }
+    }
+  },
+  "z-image-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 1.5
+        }
+      }
+    }
+  },
+  "wan2.6-t2i": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.5-t2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.6-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.5-i2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wanx2.1-imageedit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.007
+        },
+        "response_token": {
+          "price": 2.007
+        }
+      }
+    }
+  },
+  "aitryon-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.1677
+        },
+        "response_token": {
+          "price": 7.1677
+        }
+      }
+    }
+  },
+  "aitryon-parsing-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "qwen-mt-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0431
+        },
+        "response_token": {
+          "price": 0.0431
+        }
+      }
+    }
+  },
+  "animate-anyone-detect-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "wan2.2-s2v-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "liveportrait-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "emo-detect-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "wan2.6-t2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.6
+        },
+        "response_token": {
+          "price": 3.6
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.6-i2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 1.5
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "wan2.1-i2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.6
+        },
+        "response_token": {
+          "price": 3.6
+        }
+      }
+    }
+  },
+  "wan2.1-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.2-kf2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 1.5
+        }
+      }
+    }
+  },
+  "wan2.1-kf2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-r2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.6-r2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.1-vace-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.2-s2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.1677
+        },
+        "response_token": {
+          "price": 7.1677
+        }
+      }
+    }
+  },
+  "wan2.2-animate-move": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 12
+        },
+        "response_token": {
+          "price": 12
+        }
+      }
+    }
+  },
+  "wan2.2-animate-mix": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 18
+        },
+        "response_token": {
+          "price": 18
+        }
+      }
+    }
+  },
+  "animate-anyone-template-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "animate-anyone-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "emo-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "liveportrait": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.2868
+        },
+        "response_token": {
+          "price": 0.2868
+        }
+      }
+    }
+  },
+  "emoji-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "videoretalk": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "video-style-transform": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.1677
+        },
+        "response_token": {
+          "price": 7.1677
+        }
+      }
+    }
+  },
+  "emoji-detect-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143
+        },
+        "response_token": {
+          "price": 0.00143
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143353
+        },
+        "response_token": {
+          "price": 0.00143353
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0026
+        },
+        "response_token": {
+          "price": 0.0026
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "paraformer-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "paraformer-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "paraformer-realtime-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "qwen-voice-enrollment": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1
+        },
+        "response_token": {
+          "price": 1
+        }
+      }
+    }
+  },
+  "qwen-voice-design": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 20
+        },
+        "response_token": {
+          "price": 20
+        }
+      }
+    }
+  },
+  "qwen3-livetranslate-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001577
+        },
+        "response_token": {
+          "price": 0.0001577
+        },
+        "request_audio_token": {
+          "price": 0.0001577
+        },
+        "response_audio_token": {
+          "price": 0.0006308
+        },
+        "request_image_token": {
+          "price": 0.0000631
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: dashscope

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 105 |
| 🔄 Models updated (merged) | 14 |

### ➕ New Models
- `qwen-long`
- `qwen3-4b`
- `qwen3-1.7b`
- `qwen3-0.6b`
- `qwen3.5-397b-a17b`
- `qwen3.5-122b-a10b`
- `qwen3.5-27b`
- `qwen3.5-35b-a3b`
- `qwen2.5-72b-instruct`
- `qwen2.5-32b-instruct`
- `qwen2.5-14b-instruct`
- `qwen2.5-7b-instruct`
- `qwen2.5-14b-instruct-1m`
- `qwen2.5-7b-instruct-1m`
- `qvq-72b-preview`
- `qwen2.5-vl-72b-instruct`
- `qwen2.5-vl-32b-instruct`
- `qwen2.5-vl-7b-instruct`
- `qwen2.5-vl-3b-instruct`
- `qwen-doc-turbo`
- ... and 85 more

### 🔄 Updated Models
- `qwen3-32b`
- `qwen3-30b-a3b`
- `qwen3-14b`
- `qwen3-8b`
- `glm-5`
- `qwen3-omni-flash`
- `qwen3-omni-flash-realtime`
- `qwen-omni-turbo`
- `qwen-omni-turbo-realtime`
- `qwen3-asr-flash`
- `qwen3-livetranslate-flash-realtime`
- `qwen3-omni-30b-a3b-captioner`
- `glm-4.7`
- `glm-4.6`


## Data Sources

| Source | URL |
|--------|-----|
| Models & Pricing page | https://www.alibabacloud.com/help/en/model-studio/models |

## Region Priority Applied
- **International** pricing used as priority 1 for all models where available
- **Global** pricing used as priority 2 where International not listed
- **Chinese Mainland / HK** used for models only available in those regions (e.g. qwen-long, qwen-math-*, qwen-doc-turbo, qwen-deep-research, tongyi-intent-detect-v3, deepseek-r1, MiniMax-M2.5, glm-*, qvq-72b-preview, paraformer-*)

## Pricing Notes
- Tiered input models: lowest tier used as default input price per skill instructions
- Thinking vs non-thinking: non-thinking rates used as default where separate
- TTS models: priced per 10K characters → converted via `per_million_characters`
- ASR models: priced per second → `per_second`
- Video models: priced per second → `per_second`
- Image generation models: priced per image → `per_image`
- Voice enrollment/design: priced per request → `per_request`
- qwen-deep-research: priced per 1K tokens → `per_thousand_tokens`
- Omni/audio models: mixed token pricing with `request_audio_price`, `response_audio_price`, `request_image_price`

## Model Count
161 models across all families: flagship, commercial text, open-source, multimodal/VL, coder, math, translation, data mining, deep research, embeddings, reranking, image generation, video generation, speech (TTS/ASR), and third-party (DeepSeek, Kimi, MiniMax, GLM).

---
*Generated by Pricing Agent on 2026-04-09*