### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,20 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemini-2.0-flash-image-generation": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-embedding-2-preview-04-15": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -510,7 +510,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -630,7 +630,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -1211,7 +1211,7 @@
             "price": 1.4
           },
           "enterprise_web_search": {
-            "price": 1.4
+            "price": 4.5
           },
           "image_token": {
             "price": 0.012
@@ -1560,6 +1560,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         },
         "cache_read_input_token": {
@@ -1602,7 +1605,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2295,7 +2298,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2522,7 +2525,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2578,6 +2581,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2693,6 +2699,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2753,7 +2762,7 @@
           "price": 0.000025
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2761,12 +2770,15 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2792,6 +2804,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -3515,6 +3530,103 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-04-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.012
+          },
+          "input_video_standard": {
+            "price": 0.079
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 5 |
| 🔄 Models updated (merged) | 11 |

### ➕ New Models
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `gemini-2.0-flash-image-generation`
- `veo-3.1-lite-generate-001`
- `gemini-embedding-2-preview-04-15`

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-3-pro-preview`
- `gemini-3-flash-preview`
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-lite-preview`
- `gemini-3-pro-image-preview`
- `gemini-3.1-flash-image-preview`
- `veo-3.1-fast-generate-001`
- `veo-3.0-fast-generate-001`
- `textembedding-gecko@001`
- `textembedding-gecko-multilingual@001`


## Model-to-Pricing-Page Mapping

### Google – Gemini (text/multimodal)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Standard ≤200K: $1.25/$10; >200K: $2.50/$15 (used ≤200K rate) |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 | API | Maps to Gemini 2.5 Pro Computer Use; $1.25/$10 |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | $0.30/$2.50; cache $0.03; batch $0.15/$1.25 |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias → gemini-2.5-flash pricing |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | $0.10/$0.40; cache $0.01; batch $0.05/$0.20 |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias → gemini-2.5-flash-lite pricing |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no pricing row on page → price 0 |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no pricing row on page → price 0 |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | $0.15/$0.60; batch $0.075/$0.30 |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | $0.075/$0.30; batch $0.0375/$0.15 |
| `gemini-3-pro-preview` | Google – Gemini 3 | API | $2/$12; cache $0.20; batch $1/$6 |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | $0.50/$3; cache $0.05; batch $0.25/$1.50 |
| `gemini-3.1-pro-preview` | Google – Gemini 3.1 | API | $2/$12; cache $0.20; batch $1/$6 |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3.1 | API | $0.25/$1.50; cache $0.03; batch $0.13/$0.75 |

### Google – Gemini (image output)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | $0.30/$2.50; image_token $30/1M; batch $0.15/$1.25 |
| `gemini-2.0-flash-image-generation` | Google – Gemini 2.0 | API | $0.15/$0.60; image_token $30/1M |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API | $2/$12; image_token $120/1M; batch $1/$6 |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3.1 | API | $0.50/$3; image_token $60/1M; batch $0.25/$1.50 |

### Google – Imagen

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `imagen-4.0-ultra-generate-001` | Google – Imagen 4 Ultra | API | $0.06/image |
| `imagen-4.0-generate-001` | Google – Imagen 4 | API | $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4 Fast | API | $0.02/image |
| `imagen-3.0-generate-002` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-capability-001` | Google – Imagen 3 (capability) | API | Maps to Imagen 3 generate price: $0.04/image |
| `imagen-3.0-capability-002` | Google – Imagen 3 (capability) | API | Maps to Imagen 3 generate price: $0.04/image |

### Google – Veo

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | $0.20/s (720p/1080p video-only); default 8s/1 sample |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | $0.08/s (720p video-only); default 8s/1 sample |
| `veo-3.1-lite-generate-001` | Google – Veo 3.1 Lite | API | $0.03/s (720p video-only); default 8s/1 sample |
| `veo-3.0-generate-001` | Google – Veo 3 | API | $0.20/s video-only; default 8s/1 sample |
| `veo-3.0-fast-generate-001` | Google – Veo 3 Fast | API | $0.08/s (720p video-only); default 8s/1 sample |
| `veo-2.0-generate-001` | Google – Veo 2 | API | $0.50/s; default 8s/1 sample |

### Google – Embedding

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-embedding-001` | Google – Gemini Embedding | API | $0.00015/1K tokens |
| `gemini-embedding-2-preview-04-15` | Google – Gemini Embedding 2 Preview | API | $0.20/1M tokens text; per-image/video additional |
| `text-embedding-005` | Google – Text Embedding | API | $0.000025/1K chars (mapped as /1K tokens) |
| `text-multilingual-embedding-002` | Google – Text Multilingual Embedding | API | $0.000025/1K chars |
| `text-embedding-large-exp-03-07` | Google – Text Embedding Large | API – price not found | Experimental; no dedicated row → price 0 |
| `textembedding-gecko@001` | Google – Textembedding Gecko | API | Legacy; $0.000025/1K chars |
| `textembedding-gecko@003` | Google – Textembedding Gecko | API | Legacy; $0.000025/1K chars |
| `textembedding-gecko-multilingual@001` | Google – Textembedding Gecko Multilingual | API | Legacy; $0.000025/1K chars |
| `multimodalembedding@001` | Google – Multimodal Embedding | API | Text $0.0002/1K chars; image $0.0001; video tiers |

### Anthropic – Claude

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `claude-opus-4-6` | Anthropic – Claude Opus 4.6 | API | @default stripped; $5/$25; cache write $6.25 (5m), hit $0.50 |
| `claude-opus-4-5@20251101` | Anthropic – Claude Opus 4.5 | API | Pinned date kept; $5/$25; cache write $6.25 (5m), hit $0.50 |
| `claude-sonnet-4-6` | Anthropic – Claude Sonnet 4.6 | API | @default stripped; $3/$15; cache write $3.75 (5m), hit $0.30 |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude Sonnet 4.5 | API | Pinned date kept; $3/$15; cache write $3.75 (5m), hit $0.30 |
| `claude-haiku-4-5@20251001` | Anthropic – Claude Haiku 4.5 | API | $1/$5; cache write $1.25 (5m), hit $0.10 |
| `claude-opus-4-1@20250805` | Anthropic – Claude Opus 4.1 | API | $15/$75; cache write $18.75 (5m), hit $1.50 |
| `claude-sonnet-4@20250514` | Anthropic – Claude Sonnet 4 | API | $3/$15; cache write $3.75 (5m), hit $0.30 |
| `claude-opus-4@20250514` | Anthropic – Claude Opus 4 | API | $15/$75; cache write $18.75 (5m), hit $1.50 |

### OpenAI

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gpt-oss-120b-maas` | OpenAI – gpt-oss-120b | API | $0.09/$0.36; batch $0.045/$0.18 |
| `clip-vit-base-patch32` | OpenAI | API – excluded | Non-generative vision model |
| `openclip` | OpenAI | API – excluded | Non-generative |
| `whisper-large` | OpenAI | API – excluded | Audio transcription, not generative inference |
| `gpt-oss` | OpenAI | API – excluded | Self-deploy (has_deploy: true, no -maas suffix) |

### Meta – Llama

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `llama-3.3-70b-instruct-maas` | Meta – Llama 3.3 70B | API | $0.72/$0.72; batch $0.36/$0.36 |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama 4 Maverick | API | $0.35/$1.15; batch $0.175/$0.575 |
| All other meta models (llama2*, llama3*, llama4*, sam3, llama-guard, prompt-guard, codellama*, roberta*, xlm-roberta*, imagebind, nllb*, faster-r-cnn*, retinanet*, mask-r-cnn*, segment-anything*) | Meta | API – excluded | Self-deploy, guard models, or non-generative |

### Mistral AI

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `mistral-small-2503` | Mistral – Mistral Small 3.1 (25.03) | API | $0.10/$0.30 |
| `mistral-medium-3` | Mistral – Mistral Medium 3 | API | $0.40/$2.00 |
| `codestral-2` | Mistral – Codestral 2 | API | $0.30/$0.90 |
| `mistral` (mistral-ai publisher) | Mistral | API – excluded | Self-deploy |
| `mixtral` (mistral-ai publisher) | Mistral | API – excluded | Self-deploy |
| `codestral-2501-self-deploy` | Mistral | API – excluded | Self-deploy |
| `mistral-ocr-2505` | Mistral | API – excluded | OCR model |
| `ministral-3` | Mistral | API – excluded | Self-deploy |
| `mistral-large-3` | Mistral | API – excluded | Self-deploy |

### DeepSeek

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `deepseek-v3.1-maas` | DeepSeek – DeepSeek-V3.1 | API | $0.60/$1.70; cache hit $0.06; batch $0.30/$0.85 |
| `deepseek-v3.2-maas` | DeepSeek – DeepSeek-V3.2 | API | $0.56/$1.68; cache hit $0.056; batch $0.28/$0.84 |
| `deepseek-r1-0528-maas` | DeepSeek – DeepSeek-R1 (0528) | API | $1.35/$5.40; batch $0.675/$2.70 |
| `deepseek-v3`, `deepseek-v3-1`, `deepseek-v3-2`, `deepseek-r1` | DeepSeek | API – excluded | Self-deploy |
| `deepseek-ocr`, `deepseek-ocr-2`, `deepseek-ocr-maas` | DeepSeek | API – excluded | OCR models |

### MiniMax

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `minimax-m2-maas` | MiniMax – MiniMax-M2 | API | $0.30/$1.20; cache hit $0.03 |
| `minimax-m2` | MiniMax | API – excluded | Self-deploy |

### Moonshot / Kimi

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `kimi-k2-thinking-maas` | Kimi – Kimi-K2-Thinking | API | $0.60/$2.50; cache hit $0.06 |
| `kimi-k2`, `kimi-k2-5` | Kimi | API – excluded | Self-deploy |

### Qwen

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen – Qwen3-235B-A22B-Instruct-2507 | API | $0.22/$0.88; batch $0.11/$0.44 |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen – Qwen3-Coder-480B | API | $0.22/$1.80; cache hit $0.022; batch $0.11/$0.90 |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen – Qwen3-Next-80B-Instruct | API | $0.15/$1.20 |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen – Qwen3-Next-80B-Thinking | API | $0.15/$1.20 |
| All other qwen models (qwq, qwen3, qwen3-embedding, qwen3-5, qwen2, qwen3-coder-next, qwen3-coder, qwen-image, qwen3-next, qwen3-vl) | Qwen | API – excluded | Self-deploy or excluded by policy (qwen-image) |

### ZAI.org / GLM

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `glm-4.7-maas` | ZAI.org – GLM-4.7 | API | $0.60/$2.20 |
| `glm-5-maas` | ZAI.org – GLM-5 | API | $1.00/$3.20; cache hit $0.10 |
| `glm-4.7`, `glm-5`, `glm-ocr`, `glm-4.5` | ZAI.org | API – excluded | Self-deploy |
| `glm-image` | ZAI.org | API – excluded | Excluded by policy (image generation) |
| `glm-ocr` | ZAI.org | API – excluded | OCR model |

### AI21

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `jamba-large-1.6` | AI21 | API – excluded | Self-deploy only (has_deploy: true, no -maas suffix); no MaaS entry |

### Excluded from all publishers (global rules)

| Category | Models |
|----------|--------|
| Live/streaming | `gemini-live-2.5-flash-native-audio` |
| Music generation | `lyria-002`, `lyria-3-pro-preview`, `lyria-3-clip-preview` |
| Legacy image gen | `imagegeneration` |
| Virtual try-on | `virtual-try-on-001` |
| Non-generative CV/NLP | All object detection, segmentation, classification, OCR, translation-only models |
| Self-deploy | All models with `self-deploy` in name or `has_deploy: true` without `-maas` suffix |
| Guard/safety | `shieldgemma2`, `llama-guard`, `prompt-guard` |
| Audio transcription | `chirp-2`, `chirp-3`, `whisper-large` |

### Pricing-page-only models (on page but NOT in get_vertex_models)

| Model | Section | Notes |
|-------|---------|-------|
| xAI Grok models (grok-4.20, grok-4.1-fast-reasoning, grok-4.1-fast-non-reasoning) | xAI section | On pricing page; no get_vertex_models publisher queried for xAI; not added (API-only policy) |
| `gpt-oss-20b` | OpenAI section | On pricing page; no matching API model returned → not added |
| `llama-3.1-405b-instruct-maas` | Meta section | On pricing page ($5/$16); not returned by get_vertex_models → not added |
| `llama-4-scout-17b-16e-instruct-maas` | Meta section | On pricing page ($0.25/$0.70); not returned by get_vertex_models → not added |

---
*Generated by Pricing Agent on 2026-04-09*