### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1327,7 +1327,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.6
+          "price": 0.01
         },
         "response_token": {
           "price": 0
@@ -1347,7 +1347,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0015
+          "price": 0.0000000015
         },
         "response_token": {
           "price": 0
@@ -1359,7 +1359,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.003
+          "price": 0.000000003
         },
         "response_token": {
           "price": 0
@@ -1371,7 +1371,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -1383,6 +1383,9 @@
           "response_audio_token": {
             "price": 1.5
           }
+        },
+        "response_audio_token": {
+          "price": 0.0012
         }
       }
     }
@@ -1403,6 +1406,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0006
         }
       }
     }
@@ -1423,6 +1429,9 @@
           "response_audio_token": {
             "price": 0
           }
+        },
+        "request_audio_token": {
+          "price": 0.0003
         }
       }
     }
@@ -1721,7 +1730,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1762,7 +1771,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2193,13 +2202,13 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2259,16 +2268,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2286,16 +2295,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2308,6 +2317,9 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2320,6 +2332,9 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2332,6 +2347,9 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       }
     }
@@ -2344,6 +2362,9 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       }
     }
@@ -2611,10 +2632,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2692,7 +2713,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.0004
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2719,7 +2740,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.0004
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2761,10 +2782,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2849,6 +2870,15 @@
           "price": 0.000125
         },
         "cache_read_text_input_token": {
+          "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
           "price": 0.000125
         }
       }
@@ -3230,7 +3260,7 @@
           "price": 0.000006
         },
         "cache_read_audio_input_token": {
-          "price": 0.000008
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3339,6 +3369,15 @@
           "price": 0.000125
         },
         "cache_read_text_input_token": {
+          "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
           "price": 0.000125
         }
       }
@@ -3661,7 +3700,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -3676,7 +3715,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -3721,7 +3760,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0015
+          "price": 0.0000000015
         },
         "response_token": {
           "price": 0
@@ -3733,7 +3772,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.003
+          "price": 0.000000003
         },
         "response_token": {
           "price": 0
@@ -3748,7 +3787,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -3757,7 +3796,7 @@
           "price": 0.0008
         },
         "response_image_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "cache_read_image_input_token": {
           "price": 0.0002
@@ -3775,13 +3814,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         },
         "request_image_token": {
           "price": 0.00025
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "response_image_token": {
+          "price": 0.0008
         }
       }
     }
@@ -3868,7 +3910,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0004
         },
         "request_audio_token": {
           "price": 0.0032
@@ -3977,6 +4019,9 @@
         },
         "response_token": {
           "price": 0.018
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }
@@ -3989,6 +4034,9 @@
         },
         "response_token": {
           "price": 0.018
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 32 |


### 🔄 Updated Models
- `gpt-5.4-pro`
- `gpt-5.4-pro-2026-03-05`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `gpt-4o-search-preview`
- `gpt-4o-search-preview-2025-03-11`
- `gpt-4o-mini-search-preview`
- `gpt-4o-mini-search-preview-2025-03-11`
- `o4-mini-deep-research-2025-06-26`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-realtime-preview`
- `gpt-audio-mini`
- `gpt-realtime`
- `gpt-realtime-2025-08-28`
- `gpt-realtime-1.5`
- `gpt-realtime-mini`
- `gpt-4o-mini-tts`
- `gpt-4o-mini-tts-2025-03-20`
- `gpt-4o-mini-tts-2025-12-15`
- `tts-1`
- `tts-1-1106`
- `tts-1-hd`
- `tts-1-hd-1106`
- `whisper-1`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `gpt-image-1`
- `gpt-image-1-mini`
- `gpt-image-1.5`
- `chatgpt-image-latest`
- ... and 2 more


## Data Sources

- **Models API**: `get_openai_models` tool — 128 models returned (fine-tuned models excluded)
- **Pricing Reference**: LiteLLM `model_prices_and_context_window.json` (used as fallback since OpenAI pricing page at `platform.openai.com/docs/pricing` returns HTTP 403 Cloudflare protection)

## Model Families Covered

| Family | Count |
|--------|-------|
| GPT-5.4.x (including pro, mini, nano) | 8 |
| GPT-5.3.x (chat-latest, codex) | 2 |
| GPT-5.2.x (including pro, codex) | 6 |
| GPT-5.1.x (including codex, codex-max, codex-mini) | 6 |
| GPT-5.x (including mini, nano, pro, codex, search-api, chat) | 11 |
| GPT-4.1.x (including mini, nano) | 6 |
| GPT-4o family (including dated variants) | 7 |
| GPT-4 Turbo / GPT-4 legacy | 4 |
| O-series (o1, o3, o4-mini, deep-research, pro) | 12 |
| Audio/Realtime (gpt-audio, gpt-realtime families) | 14 |
| GPT-4o Audio/Realtime (including dated variants) | 8 |
| TTS (tts-1, tts-1-hd, gpt-4o-mini-tts) | 7 |
| Transcription (whisper-1, gpt-4o-transcribe, gpt-4o-mini-transcribe) | 6 |
| Image (dall-e-2, dall-e-3, gpt-image-1, gpt-image-1-mini, gpt-image-1.5, chatgpt-image-latest) | 6 |
| Video (sora-2, sora-2-pro) | 2 |
| Embeddings | 3 |
| Moderation | 2 |
| Search preview (gpt-4o-search, gpt-4o-mini-search) | 4 |
| Computer use | 2 |
| Legacy (gpt-3.5-turbo, babbage-002, davinci-002) | 7 |
| **Total** | **128** |

---
*Generated by Pricing Agent on 2026-04-09*