### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,190 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-flash-preview-tts": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-pro-preview-tts": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-flash-preview-native-audio-dialog": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-pro-preview-native-audio-dialog": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-flash-exp-native-audio-thinking-dialog": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-pro-exp-native-audio-dialog": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-flash-preview-native-audio-thinking-dialog": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-pro-preview-native-audio-thinking-dialog": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-flash-image-generation": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-pro-computer-use": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-pro-preview-computer-use": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-flash-preview-computer-use": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.0-pro-exp-02-05": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.0-flash-live-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-3-pro-preview-06-19": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-3-flash-preview-06-19": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-3-1-pro-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-3-1-flash-image-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-3-1-flash-lite-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-1.5-flash-8b-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "imagen-4.0-ultra-generate-exp-05-20": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama3-405b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama3-70b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama3-8b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama2-70b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "codellama-7b-hf": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "nllb": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-2-quantized": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama4": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama3_1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama3-2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama3-3": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -124,10 +124,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -135,6 +135,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -152,10 +155,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -163,6 +166,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -180,10 +186,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -191,6 +197,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -351,7 +360,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
         }
       },
       "finetune_config": {
@@ -432,7 +447,7 @@
           "price": 0.0000075
         },
         "response_token": {
-          "price": 0.000003
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -440,7 +455,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "finetune_config": {
@@ -453,7 +474,7 @@
           "price": 0.00000375
         },
         "response_token": {
-          "price": 0.0000015
+          "price": 0.000015
         }
       }
     }
@@ -510,7 +531,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -550,7 +571,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -630,7 +651,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -866,7 +887,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
         }
       },
       "finetune_config": {
@@ -911,7 +938,7 @@
           "price": 0.0000075
         },
         "response_token": {
-          "price": 0.000003
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -919,7 +946,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "finetune_config": {
@@ -932,7 +965,7 @@
           "price": 0.00000375
         },
         "response_token": {
-          "price": 0.0000015
+          "price": 0.000015
         }
       }
     }
@@ -952,6 +985,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -984,6 +1020,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -1145,6 +1184,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
         }
       },
       "batch_config": {
@@ -1176,6 +1218,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
         }
       },
       "batch_config": {
@@ -1266,10 +1311,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1277,15 +1322,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1294,10 +1345,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1305,15 +1356,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1322,10 +1379,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
@@ -1445,7 +1502,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000025
         }
       },
       "batch_config": {
@@ -1482,7 +1545,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "finetune_config": {
@@ -1602,7 +1665,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00003125
         }
       },
       "finetune_config": {
@@ -1641,7 +1704,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -2341,7 +2404,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2522,7 +2585,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2991,7 +3054,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3331,6 +3394,20 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
         }
       },
       "batch_config": {
@@ -3507,6 +3584,20 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
         }
       },
       "batch_config": {
@@ -3515,6 +3606,815 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-exp-03-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-preview-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-preview-native-audio-dialog": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-native-audio-dialog": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-exp-native-audio-thinking-dialog": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-exp-native-audio-dialog": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-preview-native-audio-thinking-dialog": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-native-audio-thinking-dialog": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.000125
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-computer-use": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-computer-use": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-preview-computer-use": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-thinking-exp-01-21": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-pro-exp-02-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-live-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-3-pro-preview-06-19": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "gemini-3-flash-preview-06-19": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.0000125
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-3-1-pro-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "gemini-3-1-flash-image-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-3-1-flash-lite-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        },
+        "cache_read_input_token": {
+          "price": 0.00000625
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-1.5-flash-8b-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00000375
+        },
+        "response_token": {
+          "price": 0.000015
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000001875
+        },
+        "response_token": {
+          "price": 0.0000075
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-ultra-generate-exp-05-20": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 6
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "llama3-405b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0016
+        }
+      }
+    }
+  },
+  "llama3-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000072
+        },
+        "response_token": {
+          "price": 0.000072
+        }
+      }
+    }
+  },
+  "llama3-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000072
+        },
+        "response_token": {
+          "price": 0.000072
+        }
+      }
+    }
+  },
+  "llama2-70b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "codellama-7b-hf": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "nllb": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-2-quantized": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3_1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 39 |
| 🔄 Models updated (merged) | 26 |

### ➕ New Models
- `gemini-2.5-pro-exp-03-25`
- `gemini-2.5-pro-preview-06-05`
- `gemini-2.5-flash-preview-tts`
- `gemini-2.5-pro-preview-tts`
- `gemini-2.5-flash-preview-native-audio-dialog`
- `gemini-2.5-pro-preview-native-audio-dialog`
- `gemini-2.5-flash-exp-native-audio-thinking-dialog`
- `gemini-2.5-pro-exp-native-audio-dialog`
- `gemini-2.5-flash-preview-native-audio-thinking-dialog`
- `gemini-2.5-pro-preview-native-audio-thinking-dialog`
- `gemini-2.5-flash-image-generation`
- `gemini-2.5-pro-computer-use`
- `gemini-2.5-pro-preview-computer-use`
- `gemini-2.5-flash-preview-computer-use`
- `gemini-2.0-flash-thinking-exp-01-21`
- `gemini-2.0-pro-exp-02-05`
- `gemini-2.0-flash-live-001`
- `gemini-3-pro-preview-06-19`
- `gemini-3-flash-preview-06-19`
- `gemini-3-1-pro-preview`
- ... and 19 more

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-2.5-flash`
- `gemini-2.5-flash-lite`
- `gemini-2.5-flash-preview-04-17`
- `gemini-2.5-pro-preview-03-25`
- `gemini-2.5-pro-preview-05-06`
- `gemini-2.5-flash-preview-05-20`
- `gemini-2.5-flash-lite-preview-06-17`
- `gemini-2.0-flash-001`
- `gemini-2.0-flash-exp`
- `gemini-2.0-flash-lite-preview-02-05`
- `gemini-1.5-pro-001`
- `gemini-1.5-pro-002`
- `gemini-1.5-flash-001`
- `gemini-1.5-flash-002`
- `gemini-1.0-pro-001`
- `gemini-1.0-pro-002`
- `gemini-1.0-pro-vision-001`
- `gemini-2.0-flash-preview-image-generation`
- `veo-3.1-fast-generate-001`
- `veo-3.0-fast-generate-preview`
- `text-embedding-004`
- `textembedding-gecko-multilingual@001`
- `textembedding-gecko@001`
- `multimodalembedding@001`
- `text-embedding-large-exp-03-07`


## Model-to-Pricing-Page Mapping

### Google – Gemini 2.5

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 Pro | API | Standard tier ≤200K: $1.25/$10; long-context >200K: $2.50/$15 (not split) |
| `gemini-2.5-flash` | Google – Gemini 2.5 Flash | API | $0.30/$2.50; cache $0.075 |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 Flash Lite | API | $0.10/$0.40 |
| `gemini-2.5-flash-preview-04-17` | Google – Gemini 2.5 Flash | API | Preview alias; same pricing as 2.5 Flash |
| `gemini-2.5-pro-preview-03-25` | Google – Gemini 2.5 Pro | API | Preview alias; same pricing as 2.5 Pro |
| `gemini-2.5-pro-preview-05-06` | Google – Gemini 2.5 Pro | API | Preview alias; same pricing as 2.5 Pro |
| `gemini-2.5-pro-exp-03-25` | Google – Gemini 2.5 Pro | API | Experimental alias; same pricing as 2.5 Pro |
| `gemini-2.5-flash-preview-05-20` | Google – Gemini 2.5 Flash | API | Preview alias; same pricing as 2.5 Flash |
| `gemini-2.5-flash-lite-preview-06-17` | Google – Gemini 2.5 Flash Lite | API | Preview alias; same pricing as 2.5 Flash Lite |
| `gemini-2.5-pro-preview-06-05` | Google – Gemini 2.5 Pro | API | Preview alias; same pricing as 2.5 Pro |
| `gemini-2.5-flash-preview-tts` | Google – Gemini 2.5 Flash | API | TTS variant; priced as 2.5 Flash |
| `gemini-2.5-pro-preview-tts` | Google – Gemini 2.5 Pro | API | TTS variant; priced as 2.5 Pro |
| `gemini-2.5-flash-preview-native-audio-dialog` | Google – Gemini 2.5 Flash | API | Native audio dialog; priced as 2.5 Flash |
| `gemini-2.5-pro-preview-native-audio-dialog` | Google – Gemini 2.5 Pro | API | Native audio dialog; priced as 2.5 Pro |
| `gemini-2.5-flash-exp-native-audio-thinking-dialog` | Google – Gemini 2.5 Flash | API | Experimental; priced as 2.5 Flash |
| `gemini-2.5-pro-exp-native-audio-dialog` | Google – Gemini 2.5 Pro | API | Experimental; priced as 2.5 Pro |
| `gemini-2.5-flash-preview-native-audio-thinking-dialog` | Google – Gemini 2.5 Flash | API | Preview; priced as 2.5 Flash |
| `gemini-2.5-pro-preview-native-audio-thinking-dialog` | Google – Gemini 2.5 Pro | API | Preview; priced as 2.5 Pro |
| `gemini-2.5-flash-image-generation` | Google – Gemini 2.5 Flash Image Generation | API | image_token $30/1M |
| `gemini-2.5-pro-computer-use` | Google – Gemini 2.5 Pro Computer Use | API | $1.25/$10 |
| `gemini-2.5-pro-preview-computer-use` | Google – Gemini 2.5 Pro Computer Use | API | Preview; same as computer-use row |
| `gemini-2.5-flash-preview-computer-use` | Google – Gemini 2.5 Flash | API | Preview; priced as 2.5 Flash |

### Google – Gemini 2.0 / 3.x

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.0-flash-001` | Google – Gemini 2.0 Flash | API | $0.15/$0.60; batch 50% off |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 Flash Lite | API | $0.075/$0.30 |
| `gemini-2.0-flash-exp` | Google – Gemini 2.0 Flash | API | Experimental alias |
| `gemini-2.0-flash-thinking-exp-01-21` | Google – Gemini 2.0 Flash | API | Thinking experimental; priced as 2.0 Flash |
| `gemini-2.0-flash-lite-preview-02-05` | Google – Gemini 2.0 Flash Lite | API | Preview alias |
| `gemini-2.0-pro-exp-02-05` | Google – Gemini 2.0 Flash | API | Pro experimental; priced as 2.0 Flash |
| `gemini-2.0-flash-live-001` | Google – Gemini Live | API | Excluded from generative pricing (Live streaming product); price 0 |
| `gemini-2.0-flash-preview-image-generation` | Google – Gemini 2.0 Flash Image Generation | API | image_token $30/1M |
| `gemini-2.0-flash-image-generation` | Google – Gemini 2.0 Flash Image Generation | API | image_token $30/1M |
| `gemini-3-pro-preview-06-19` | Google – Gemini 3 Pro Preview | API | $2/$12; cache $0.50; batch $1/$6 |
| `gemini-3-flash-preview-06-19` | Google – Gemini 3 Flash Preview | API | $0.50/$3.00; cache $0.125 |
| `gemini-3-1-pro-preview` | Google – Gemini 3.1 Pro Preview | API | $2/$12; same as Gemini 3 Pro |
| `gemini-3-1-flash-image-preview` | Google – Gemini 3.1 Flash Image Preview | API | image_token $60/1M |
| `gemini-3-1-flash-lite-preview` | Google – Gemini 3.1 Flash Lite Preview | API | $0.25/$1.50 |
| `gemini-1.5-pro-001` | Google – Gemini 1.5 Pro | API | $1.25/$5.00 ≤128K standard |
| `gemini-1.5-pro-002` | Google – Gemini 1.5 Pro | API | $1.25/$5.00 |
| `gemini-1.5-flash-001` | Google – Gemini 1.5 Flash | API | $0.075/$0.30 |
| `gemini-1.5-flash-002` | Google – Gemini 1.5 Flash | API | $0.075/$0.30 |
| `gemini-1.5-flash-8b-001` | Google – Gemini 1.5 Flash-8B | API | $0.0375/$0.15 |
| `gemini-1.0-pro-001` | Google – Gemini 1.0 Pro | API | $0.125/$0.375 |
| `gemini-1.0-pro-002` | Google – Gemini 1.0 Pro | API | $0.125/$0.375 |
| `gemini-1.0-pro-vision-001` | Google – Gemini 1.0 Pro Vision | API | $0.125/$0.375 |

### Google – Imagen

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `imagen-4.0-generate-001` | Google – Imagen 4.0 Generate | API | $0.04/image |
| `imagen-4.0-ultra-generate-exp-05-20` | Google – Imagen 4.0 Ultra | API | $0.06/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4.0 Fast | API | $0.02/image |
| `imagen-3.0-generate-001` | Google – Imagen 3.0 Generate | API | $0.04/image |
| `imagen-3.0-generate-002` | Google – Imagen 3.0 Generate | API | $0.04/image |
| `imagen-3.0-fast-generate-001` | Google – Imagen 3.0 Fast | API | $0.02/image |
| `imagen-3.0-capability-001` | Google – Imagen 3.0 (capability) | API | Maps to imagen-3.0-generate pricing: $0.04/image |
| `imagen-4.0-capability-001` | Google – Imagen 4.0 (capability) | API | Maps to imagen-4.0-generate pricing: $0.04/image |

### Google – Veo

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | $0.20/sec (720p/1080p video only) |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | $0.08/sec (720p video only) |
| `veo-3.1-lite-generate-preview` | Google – Veo 3.1 Lite | API | $0.03/sec (720p video only) |
| `veo-3.0-generate-preview` | Google – Veo 3.0 | API | $0.20/sec |
| `veo-3.0-fast-generate-preview` | Google – Veo 3.0 Fast | API | $0.08/sec (720p) |
| `veo-2.0-generate-001` | Google – Veo 2.0 | API | $0.50/sec |

### Google – Embedding

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-embedding-001` | Google – Gemini Embedding | API | $0.00015/1K tokens |
| `text-embedding-005` | Google – Text Embedding | API | $0.000025/1K chars |
| `text-embedding-004` | Google – Text Embedding | API | $0.000025/1K chars |
| `text-multilingual-embedding-002` | Google – Text Multilingual Embedding | API | $0.000025/1K chars |
| `textembedding-gecko@003` | Google – Text Embedding (legacy) | API | $0.000025/1K chars |
| `textembedding-gecko-multilingual@001` | Google – Text Embedding (legacy multilingual) | API | $0.000025/1K chars |
| `textembedding-gecko@001` | Google – Text Embedding (legacy) | API | $0.000025/1K chars |
| `multimodalembedding@001` | Google – Multimodal Embedding | API | $0.0002/1K chars text |
| `text-embedding-large-exp-03-07` | Google – Text Embedding Large (experimental) | API | $0.00015/1K tokens; shares Gemini Embedding pricing |

### Anthropic – Claude

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `claude-opus-4-6` | Anthropic – Claude Opus 4.6 | API | @default stripped; $5/$25; cache write 5m $6.25; cache hit $0.50 |
| `claude-sonnet-4-6` | Anthropic – Claude Sonnet 4.6 | API | @default stripped; $3/$15; cache write 5m $3.75; cache hit $0.30 |
| `claude-opus-4-5@20251101` | Anthropic – Claude Opus 4.5 | API | $5/$25; cache write 5m $6.25; cache hit $0.50 |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude Sonnet 4.5 | API | $3/$15; cache write 5m $3.75; cache hit $0.30 |
| `claude-haiku-4-5@20251001` | Anthropic – Claude Haiku 4.5 | API | $1/$5; cache write 5m $1.25; cache hit $0.10 |
| `claude-opus-4-1@20250805` | Anthropic – Claude Opus 4.1 | API | $15/$75; cache write 5m $18.75; cache hit $1.50 |
| `claude-opus-4@20250514` | Anthropic – Claude Opus 4 | API | $15/$75; cache write 5m $18.75; cache hit $1.50 |
| `claude-sonnet-4@20250514` | Anthropic – Claude Sonnet 4 | API | $3/$15; cache write 5m $3.75; cache hit $0.30 |

### OpenAI

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gpt-oss-120b-maas` | OpenAI – GPT OSS 120B | API | $0.09/$0.36; batch $0.045/$0.18 |
| `clip-vit-base-patch32` | OpenAI | API – excluded | Non-generative (vision classification) |
| `openclip` | OpenAI | API – excluded | Non-generative (vision feature extraction) |
| `whisper-large` | OpenAI | API – excluded | Audio transcription (not generative inference) |
| `gpt-oss` | OpenAI | API – excluded | Self-deploy (has_deploy: true, no -maas suffix) |

### Meta – Llama

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `llama-3.3-70b-instruct-maas` | Meta – Llama 3.3 70B | API | $0.72/$0.72; batch $0.36/$0.36 |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama 4 Maverick | API | $0.35/$1.15; batch $0.175/$0.575 |
| `llama3-405b-instruct-maas` | Meta – Llama 3.1 405B | API | $5.00/$16.00 |
| `llama3-70b-instruct-maas` | Meta – Llama 3.3 70B | API | $0.72/$0.72 (matched Llama 3.3 70B row) |
| `llama3-8b-instruct-maas` | Meta – Llama | API – price not found | No dedicated 8B row found; price 0 |
| `llama2-70b` | Meta – Llama | API – price not found | Legacy; no pricing row |
| `codellama-7b-hf` | Meta – Code Llama | API – price not found | Legacy; no pricing row |
| `nllb` | Meta – NLLB | API – price not found | Translation model; no pricing row |
| `llama-2-quantized` | Meta – Llama | API – price not found | Legacy quantized; no pricing row |
| `llama3` | Meta – Llama | API – price not found | Bare name; no pricing row |
| `llama4` | Meta – Llama | API – price not found | Bare name; no pricing row |
| `llama3_1` | Meta – Llama | API – price not found | Bare name; no pricing row |
| `llama3-2` | Meta – Llama | API – price not found | Bare name; no pricing row |
| `llama3-3` | Meta – Llama | API – price not found | Bare name; no pricing row |

**Excluded Meta models:**
- `llama-guard-*`, `prompt-guard` — guard models
- `sam3`, `faster-r-cnn`, `retinanet`, `mask-r-cnn`, `segment-anything-*` — non-generative CV
- `xlm-roberta-large`, `roberta-large` — non-generative NLP
- `imagebind` — multimodal understanding (not generative)

### Mistral AI

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `mistral-small-2503` | Mistral – Mistral Small 3.1 | API | $0.10/$0.30 |
| `mistral-medium-3` | Mistral – Mistral Medium 3 | API | $0.40/$2.00 |
| `codestral-2` | Mistral – Codestral 2 | API | $0.30/$0.90 |

**Excluded Mistral models:**
- `mistral` (mistral-ai publisher) — self-deploy
- `mixtral` (mistral-ai publisher) — self-deploy
- `mistral-ocr-2505` — OCR model (excluded by OCR rule)
- `ministral-3` — self-deploy (has_deploy: true)
- `mistral-large-3` — self-deploy (has_deploy: true)
- `codestral-2501-self-deploy` — self-deploy (name contains "self-deploy")

### DeepSeek

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `deepseek-r1-0528-maas` | DeepSeek – DeepSeek R1 (0528) | API | $1.35/$5.40; batch $0.675/$2.70 |
| `deepseek-v3.1-maas` | DeepSeek – DeepSeek V3.1 | API | $0.60/$1.70; cache $0.06; batch $0.30/$0.85 |
| `deepseek-v3.2-maas` | DeepSeek – DeepSeek V3.2 | API | $0.56/$1.68; cache $0.056; batch $0.28/$0.84 |

**Excluded DeepSeek models:**
- `deepseek-r1`, `deepseek-v3`, `deepseek-v3-1`, `deepseek-v3-2` — self-deploy
- `deepseek-ocr`, `deepseek-ocr-2`, `deepseek-ocr-maas` — OCR models

### Qwen

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen – Qwen3 235B | API | $0.22/$0.88; batch $0.11/$0.44 |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen – Qwen3 Coder 480B | API | $0.22/$1.80; cache $0.022; batch $0.11/$0.90 |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen – Qwen3 Next 80B Instruct | API | $0.15/$1.20 |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen – Qwen3 Next 80B Thinking | API | $0.15/$1.20 |

**Excluded Qwen models:**
- `qwen-image` — policy exception (image generation excluded from Vertex AI pricing)
- `qwq`, `qwen3`, `qwen3-embedding`, `qwen3-5`, `qwen2`, `qwen3-coder-next`, `qwen3-coder`, `qwen3-next`, `qwen3-vl` — self-deploy (has_deploy: true, no -maas)

### MiniMax

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `minimax-m2-maas` | MiniMax – MiniMax M2 | API | $0.30/$1.20; cache $0.03 |

**Excluded:** `minimax-m2` — self-deploy

### Kimi / Moonshot

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `kimi-k2-thinking-maas` | Kimi – Kimi K2 Thinking | API | $0.60/$2.50; cache $0.06 |

**Excluded:** `kimi-k2-5`, `kimi-k2` — self-deploy

### ZAI.org / GLM

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `glm-4.7-maas` | ZAI.org – GLM-4.7 | API | $0.60/$2.20 |
| `glm-5-maas` | ZAI.org – GLM-5 | API | $1.00/$3.20; cache $0.10 |

**Excluded:**
- `glm-4.7`, `glm-5`, `glm-4.5` — self-deploy
- `glm-ocr` — OCR model
- `glm-image` — policy exception (image generation excluded from Vertex AI pricing)

### AI21

**Excluded:** `jamba-large-1.6` — self-deploy (has_deploy: true, no -maas suffix)

---

## Data Sources
- Vertex AI Generative AI Pricing (Global tab): https://cloud.google.com/vertex-ai/generative-ai/pricing#global
- Claude on Vertex AI docs: https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai
- get_vertex_models API (all publishers)

---
*Generated by Pricing Agent on 2026-04-09*