### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1757,5 +1757,10 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -917,10 +917,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -948,10 +951,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1395,10 +1401,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1435,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1537,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1568,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1693,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1727,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2591,10 +2603,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2622,10 +2634,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2650,10 +2662,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2678,10 +2690,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3052,6 +3052,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3069,6 +3072,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3174,7 +3180,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3220,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3244,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3289,40 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 22 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-2.5-pro-lte-128k`
- `gemini-2.5-pro-gt-128k`
- `gemini-2.5-flash-lte-128k`
- `gemini-2.5-flash-gt-128k`
- `gemini-2.5-flash-lite-lte-128k`
- `gemini-2.5-flash-lite-gt-128k`
- `gemini-2.5-flash-image-lte-128k`
- `gemini-2.5-flash-image-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.0-flash-lite-lte-128k`
- `gemini-2.0-flash-lite-gt-128k`
- `gemini-2.0-flash-lite-001-lte-128k`
- `gemini-2.0-flash-lite-001-gt-128k`
- `veo-3.0-fast-generate-001-lte-128k`
- `veo-3.0-fast-generate-001-gt-128k`
- `veo-3.1-fast-generate-preview-lte-128k`
- `veo-3.1-fast-generate-preview-gt-128k`
- `gemini-embedding-001-lte-128k`
- `gemini-embedding-001-gt-128k`


### 📋 Model → pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | $1.25 in / $10 out / $0.125 cache read / thinking=0 / web_search $3.5/1K / batch $0.625/$5 |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | $2.50 in / $15 out / $0.25 cache read / batch $1.25/$7.50 |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, ≤200K | $0.30 in / $2.50 out / $0.03 cache read / thinking=0 / batch $0.15/$1.25 |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, >200K | flat pricing — same as lte tier |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash-Lite | $0.10 in / $0.40 out / $0.01 cache read / batch $0.05/$0.20 |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash-Lite | flat — same as lte |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image | $0.30 in / $2.50 text out / $30/1M image_token / batch $0.15/$1.25 text |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image | flat — same as lte |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash | $0.10 in / $0.40 out / $0.025 cache read / batch $0.05/$0.20 |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash | flat — same as lte |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash 001 | same pricing as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash 001 | flat — same as lte |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash-Lite | $0.075 in / $0.30 out / batch $0.0375/$0.15 |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash-Lite | flat — same as lte |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash-Lite 001 | same pricing as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash-Lite 001 | flat — same as lte |
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K | $2.00 in / $12 out / $0.20 cache read / web_search $14/1K / batch $1.00/$6.00 |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K | $4.00 in / $18 out / $0.40 cache read / batch $2.00/$9.00 |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview | $0.50 in / $3.00 out / $0.05 cache read / web_search $14/1K / batch $0.25/$1.50 |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview | flat — same as lte |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite Preview | $0.25 in / $1.50 out / $0.025 cache read / batch $0.125/$0.75 |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite Preview | flat — same as lte |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview | Not found on pricing page — set to 0 |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview | Not found on pricing page — set to 0 |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview (custom tools) | same pricing as gemini-3.1-pro-preview lte |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview (custom tools) | same pricing as gemini-3.1-pro-preview gt |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview | $0.50 in / $3.00 text out / $60/1M image_token / batch $0.25/$1.50 text; batch image $30/1M noted |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview | flat — same as lte |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview | $2.00 in / $12.00 text out / $120/1M image_token / batch $1.00/$6.00 text; batch image $60/1M noted |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview | flat — same as lte |
| gemini-pro-latest-lte-128k | *-latest → resolves to gemini-3.1-pro-preview (verified from pricing page) | same pricing as gemini-3.1-pro-preview lte |
| gemini-pro-latest-gt-128k | *-latest → resolves to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview gt |
| gemini-flash-latest-lte-128k | *-latest → resolves to gemini-3-flash-preview (verified from pricing page) | same pricing as gemini-3-flash-preview |
| gemini-flash-latest-gt-128k | *-latest → resolves to gemini-3-flash-preview | flat — same as lte |
| gemini-flash-lite-latest-lte-128k | *-latest → resolves to gemini-3.1-flash-lite-preview (verified from pricing page) | same pricing as gemini-3.1-flash-lite-preview |
| gemini-flash-lite-latest-gt-128k | *-latest → resolves to gemini-3.1-flash-lite-preview | flat — same as lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4.0 Standard | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4.0 Standard | $0.04/image |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4.0 Ultra | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4.0 Ultra | $0.06/image |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4.0 Fast | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4.0 Fast | $0.02/image |
| veo-2.0-generate-001-lte-128k | Veo 2.0 | $0.35/s → 35¢/s, default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2.0 | flat — same as lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0 Standard | $0.40/s → 40¢/s, default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3.0 Standard | flat — same as lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast | $0.10/s → 10¢/s, default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast | flat — same as lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Standard | $0.40/s → 40¢/s, default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Standard | flat — same as lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast | $0.10/s → 10¢/s, default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast | flat — same as lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite | $0.05/s → 5¢/s, default 8s, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite | flat — same as lte |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | $0.15/1M input, output 0, batch $0.075/1M |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 | flat — same as lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview | $0.20/1M text input, output 0; no batch available |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview | flat — same as lte |

---
*Generated by Pricing Agent on 2026-04-09*