### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1757,5 +1757,15 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "nano-banana-pro-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -924,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1943,7 +1943,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1977,7 +1977,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2463,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2494,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2581,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3174,7 +3174,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3214,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3238,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3283,102 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 4 |
| 🔄 Models updated (merged) | 23 |

### ➕ New Models
- `nano-banana-pro-preview-lte-128k`
- `nano-banana-pro-preview-gt-128k`
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.0-flash-lite-lte-128k`
- `gemini-2.0-flash-lite-gt-128k`
- `gemini-2.0-flash-lite-001-lte-128k`
- `gemini-2.0-flash-lite-001-gt-128k`
- `gemini-2.5-pro-lte-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-flash-lite-latest-lte-128k`
- `gemini-flash-lite-latest-gt-128k`
- `veo-2.0-generate-001-lte-128k`
- `veo-2.0-generate-001-gt-128k`
- `veo-3.0-generate-001-lte-128k`
- `veo-3.0-generate-001-gt-128k`
- `veo-3.0-fast-generate-001-lte-128k`
- `veo-3.0-fast-generate-001-gt-128k`
- `veo-3.1-generate-preview-lte-128k`
- `veo-3.1-generate-preview-gt-128k`
- `veo-3.1-fast-generate-preview-lte-128k`
- `veo-3.1-fast-generate-preview-gt-128k`


### Model → pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat pricing | input $0.15/1M, output $0.60/1M; batch 50%; web_search 3.5¢/call |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat pricing | same as lte (flat rate) |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash 001, flat pricing | same as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash 001, flat pricing | same as lte (flat rate) |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash Lite, flat pricing | input $0.075/1M, output $0.30/1M; batch 50%; web_search 3.5¢/call |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash Lite, flat pricing | same as lte (flat rate) |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash Lite 001, flat pricing | same as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash Lite 001, flat pricing | same as lte (flat rate) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash Lite, flat pricing | input $0.10/1M, output $0.40/1M, cache_read $0.01; batch 50%; web_search 3.5¢/call |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash Lite, flat pricing | same as lte (flat rate) |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat pricing | input $0.30/1M, output $2.50/1M, cache_read $0.03; batch 50%; web_search 3.5¢/call |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat pricing | same as lte (flat rate) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat pricing | input $0.30/1M, text output $2.50/1M, image_token $30/1M; batch: in $0.15, text out $1.25; web_search 3.5¢/call |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat pricing | same as lte (flat rate) |
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K context tier | input $1.25/1M, output $10/1M, cache_read $0.13; batch: in $0.625, out $5.00; web_search 3.5¢/call |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K context tier | input $2.50/1M, output $15/1M, cache_read $0.25; batch: in $1.25, out $7.50; web_search 3.5¢/call |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, flat pricing | input $0.50/1M, output $3.00/1M, cache_read $0.05; batch 50%; web_search 1.4¢/call ($14/1K) |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, flat pricing | same as lte (flat rate) |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K context tier | input $2.00/1M, output $12.00/1M, cache_read $0.20; batch: in $1.00, out $6.00; web_search 1.4¢/call |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K context tier | input $4.00/1M, output $18.00/1M, cache_read $0.40; batch: in $2.00, out $9.00; web_search 1.4¢/call |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview (Nano Banana Pro), flat pricing | input $2.00/1M, text output $12.00/1M, image_token $120/1M; batch: in $1.00, text out $6.00; web_search 1.4¢/call |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview (Nano Banana Pro), flat pricing | same as lte (flat rate) |
| nano-banana-pro-preview-lte-128k | Alias for gemini-3-pro-image-preview, flat pricing | same pricing as gemini-3-pro-image-preview |
| nano-banana-pro-preview-gt-128k | Alias for gemini-3-pro-image-preview, flat pricing | same as lte (flat rate) |
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K context tier | input $2.00/1M, output $12.00/1M, cache_read $0.20; batch: in $1.00, out $6.00; web_search 1.4¢/call |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K context tier | input $4.00/1M, output $18.00/1M, cache_read $0.40; batch: in $2.00, out $9.00; web_search 1.4¢/call |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview Customtools, ≤200K | same pricing as gemini-3.1-pro-preview |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview Customtools, >200K | same pricing as gemini-3.1-pro-preview gt tier |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash Lite Preview, flat pricing | input $0.25/1M, output $1.50/1M, cache_read $0.03; batch 50%; web_search 1.4¢/call |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash Lite Preview, flat pricing | same as lte (flat rate) |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview, flat pricing | input $0.50/1M, text output $3.00/1M, image_token $60/1M; batch: in $0.25, text out $1.50; web_search 1.4¢/call |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview, flat pricing | same as lte (flat rate) |
| gemini-pro-latest-lte-128k | *-latest alias → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview lte tier |
| gemini-pro-latest-gt-128k | *-latest alias → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview gt tier |
| gemini-flash-latest-lte-128k | *-latest alias → resolved to gemini-3-flash-preview | same pricing as gemini-3-flash-preview lte tier |
| gemini-flash-latest-gt-128k | *-latest alias → resolved to gemini-3-flash-preview | same pricing as gemini-3-flash-preview gt tier |
| gemini-flash-lite-latest-lte-128k | *-latest alias → resolved to gemini-3.1-flash-lite-preview | same pricing as gemini-3.1-flash-lite-preview lte tier |
| gemini-flash-lite-latest-gt-128k | *-latest alias → resolved to gemini-3.1-flash-lite-preview | same pricing as gemini-3.1-flash-lite-preview gt tier |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | input $0.15/1M, output 0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001, flat pricing | same as lte (flat rate) |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview | input $0.20/1M (text), output 0 |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview, flat pricing | same as lte (flat rate) |
| imagen-4.0-generate-001-lte-128k | Imagen 4.0 Generate | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4.0 Generate, flat pricing | same as lte |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4.0 Ultra Generate | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4.0 Ultra Generate, flat pricing | same as lte |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4.0 Fast Generate | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4.0 Fast Generate, flat pricing | same as lte |
| veo-2.0-generate-001-lte-128k | Veo 2.0 Generate | $0.50/sec → 50¢/s; default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2.0 Generate, flat pricing | same as lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0 Generate (video only) | $0.20/sec → 20¢/s; default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3.0 Generate, flat pricing | same as lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast Generate (video only, 720p) | $0.08/sec → 8¢/s; default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast Generate, flat pricing | same as lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Generate (video only) | $0.20/sec → 20¢/s; default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Generate, flat pricing | same as lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast Generate (video only, 720p) | $0.08/sec → 8¢/s; default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast Generate, flat pricing | same as lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite Generate (video only, 720p) | $0.03/sec → 3¢/s; default 8s, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite Generate, flat pricing | same as lte |

### Source notes

- Pricing sourced from Vertex AI Generative AI pricing page (`https://cloud.google.com/vertex-ai/generative-ai/pricing`) via `http_request` (firecrawl was unavailable due to insufficient credits).
- Vertex AI uses a 200K context threshold for tiered models; mapped to lte-128k (≤200K) and gt-128k (>200K) entries per skill convention.
- Thinking tokens: Vertex AI page shows "Text output (response and reasoning)" as a single combined line item — thinking is already priced into output tokens, so `thinking_token` is NOT added separately.
- Web search pricing: Gemini 2.x/2.5 models: $35/1K calls = 3.5¢/call. Gemini 3.x models: $14/1K calls = 1.4¢/call.
- Batch pricing: 50% of standard for all models where Batch section appears on the page.
- *-latest alias resolution: gemini-pro-latest → gemini-3.1-pro-preview; gemini-flash-latest → gemini-3-flash-preview; gemini-flash-lite-latest → gemini-3.1-flash-lite-preview (per skill SKILL.md alias table, verified as consistent with Vertex AI page showing 3.x as current generation).
- nano-banana-pro-preview: API model ID that maps to gemini-3-pro-image-preview (same model, different alias).
- Excluded models: gemini-*-tts, gemma-*, gemini-*-native-audio-*, gemini-*-live-*, gemini-*-computer-use-*, lyria-*, deep-research-*, gemini-robotics-*, aqa.
- Veo video_seconds: using video-only (non-audio) 720p rate as the default representative rate per model tier.

---
*Generated by Pricing Agent on 2026-04-09*