### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -812,10 +812,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0015
         },
         "additional_units": {
           "web_search": {
@@ -824,9 +824,6 @@
           "file_search": {
             "price": 0.25
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000125
         }
       },
       "batch_config": {
@@ -1120,16 +1117,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.000125
         },
         "cache_read_audio_input_token": {
           "price": 0.00025
@@ -1147,16 +1144,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.000125
         },
         "cache_read_audio_input_token": {
           "price": 0.00025
@@ -1330,13 +1327,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 10
+          "price": 0.6
         },
         "response_token": {
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.0000006
         },
         "response_audio_token": {
           "price": 0
@@ -1360,6 +1357,11 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "per_million_characters": {
+            "price": 1500
+          }
         }
       }
     }
@@ -1372,6 +1374,11 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "per_million_characters": {
+            "price": 3000
+          }
         }
       }
     }
@@ -1409,10 +1416,10 @@
           "price": 0.00025
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "request_audio_token": {
-          "price": 0.0006
+          "price": 0.0003
         },
         "response_audio_token": {
           "price": 0
@@ -1432,10 +1439,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0
         },
         "request_audio_token": {
           "price": 0.0003
@@ -1583,7 +1590,7 @@
           "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 0.000075
         }
       },
       "batch_config": {
@@ -1606,7 +1613,7 @@
           "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 0.000075
         }
       }
     }
@@ -2295,7 +2302,7 @@
           "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
           "price": 0.002
@@ -2322,7 +2329,7 @@
           "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
           "price": 0.002
@@ -2412,7 +2419,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00003125
         },
         "additional_units": {
           "web_search": {
@@ -2438,7 +2445,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00003125
         },
         "additional_units": {
           "web_search": {
@@ -2466,10 +2473,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
@@ -2503,10 +2510,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
@@ -2529,10 +2536,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
@@ -2558,10 +2565,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
@@ -2585,7 +2592,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00003125
         },
         "additional_units": {
           "web_search": {
@@ -2664,10 +2671,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0015
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.012
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
@@ -2698,10 +2705,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0015
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.012
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
@@ -2724,10 +2731,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2739,10 +2746,10 @@
           "price": 0.0064
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2751,10 +2758,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2766,10 +2773,10 @@
           "price": 0.0064
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2784,10 +2791,10 @@
           "price": 0.001
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2896,10 +2903,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0
-        },
-        "cache_read_input_token": {
-          "price": 0.000125
+          "price": 0.004
         }
       }
     }
@@ -2935,10 +2939,10 @@
         },
         "additional_units": {
           "video_duration_seconds_720_1280": {
-            "price": 30
+            "price": 20
           },
           "video_duration_seconds_1280_720": {
-            "price": 30
+            "price": 20
           },
           "video_duration_seconds_1024_1792": {
             "price": 50
@@ -2954,16 +2958,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00015
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -2991,16 +2995,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00015
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -3017,16 +3021,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00015
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -3043,16 +3047,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00015
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -3069,16 +3073,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00015
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -3156,7 +3160,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 0.00004375
         },
         "additional_units": {
           "web_search": {
@@ -3193,7 +3197,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 0.00004375
         },
         "additional_units": {
           "web_search": {
@@ -3219,7 +3223,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 0.00004375
         },
         "additional_units": {
           "web_search": {
@@ -3236,10 +3240,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0021
+          "price": 0.003
         },
         "response_token": {
-          "price": 0.0168
+          "price": 0.018
         },
         "cache_write_input_token": {
           "price": 0
@@ -3267,10 +3271,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0021
+          "price": 0.003
         },
         "response_token": {
-          "price": 0.0168
+          "price": 0.018
         },
         "cache_write_input_token": {
           "price": 0
@@ -3290,16 +3294,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00015
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.0000375
         },
         "additional_units": {
           "web_search": {
@@ -3346,10 +3350,10 @@
           "price": 0.00025
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "request_audio_token": {
-          "price": 0.0006
+          "price": 0.0003
         }
       }
     }
@@ -3549,7 +3553,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 0.00004375
         },
         "additional_units": {
           "web_search": {
@@ -3575,7 +3579,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 0.00004375
         },
         "additional_units": {
           "web_search": {
@@ -3652,13 +3656,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.000125
         },
         "request_audio_token": {
           "price": 0.004
@@ -3685,10 +3689,10 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         }
       }
     }
@@ -3811,10 +3815,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0
         },
         "request_audio_token": {
           "price": 0.0003
@@ -3826,10 +3830,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0
         },
         "request_audio_token": {
           "price": 0.0003
@@ -3845,6 +3849,11 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "per_million_characters": {
+            "price": 1500
+          }
         }
       }
     }
@@ -3857,6 +3866,11 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "per_million_characters": {
+            "price": 3000
+          }
         }
       }
     }
@@ -3874,10 +3888,10 @@
           "price": 0.000125
         },
         "request_image_token": {
-          "price": 0.001
+          "price": 0.0008
         },
         "response_image_token": {
-          "price": 0.004
+          "price": 0.0032
         },
         "cache_read_image_input_token": {
           "price": 0.0002
@@ -3889,7 +3903,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0005
         },
         "response_token": {
           "price": 0
@@ -3902,9 +3916,6 @@
         },
         "cache_read_image_input_token": {
           "price": 0.000025
-        },
-        "response_image_token": {
-          "price": 0.0008
         }
       }
     }
@@ -3982,10 +3993,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
@@ -3994,10 +4005,10 @@
           "price": 0.00004
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "cache_read_audio_input_token": {
           "price": 0.00004
@@ -4024,10 +4035,10 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         }
       }
     }
@@ -4057,7 +4068,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 0.00004375
         },
         "additional_units": {
           "web_search": {
@@ -4080,7 +4091,7 @@
           "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000625
         },
         "additional_units": {
           "web_search": {
@@ -4103,7 +4114,7 @@
           "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000625
         },
         "additional_units": {
           "web_search": {
@@ -4132,9 +4143,6 @@
           "file_search": {
             "price": 0.25
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.0003
         }
       }
     }
@@ -4169,7 +4177,7 @@
           "price": 0.00045
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.00001875
         },
         "additional_units": {
           "web_search": {
@@ -4192,7 +4200,7 @@
           "price": 0.00045
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.00001875
         },
         "additional_units": {
           "web_search": {
@@ -4215,7 +4223,7 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -4238,7 +4246,7 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -4247,21 +4255,6 @@
           "file_search": {
             "price": 0.25
           }
-        }
-      }
-    }
-  },
-  "gpt-5.4-pro-2025-12-11": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.003
-        },
-        "response_token": {
-          "price": 0.018
-        },
-        "cache_read_input_token": {
-          "price": 0.0003
         }
       }
     }

--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -812,10 +812,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.001
         },
         "additional_units": {
           "web_search": {
@@ -824,6 +824,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       },
       "batch_config": {
@@ -1269,10 +1272,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1327,7 +1330,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.6
+          "price": 10
         },
         "response_token": {
           "price": 0
@@ -1395,7 +1398,7 @@
           "response_audio_token": {
             "price": 0.0012
           }
-        }     
+        }
       }
     }
   },
@@ -1409,7 +1412,7 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.0006
         },
         "response_audio_token": {
           "price": 0
@@ -1435,7 +1438,7 @@
           "price": 0.0005
         },
         "request_audio_token": {
-          "price": 0.3
+          "price": 0.0003
         },
         "response_audio_token": {
           "price": 0
@@ -1578,6 +1581,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -1598,6 +1604,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
         }
       }
     }
@@ -1745,7 +1754,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1786,7 +1795,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2217,13 +2226,13 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2283,16 +2292,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2310,16 +2319,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2643,10 +2652,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2793,10 +2802,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2881,6 +2890,15 @@
           "price": 0.000125
         },
         "cache_read_text_input_token": {
+          "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
           "price": 0.000125
         }
       }
@@ -3420,6 +3438,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3844,16 +3868,16 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
         },
         "request_image_token": {
-          "price": 0.0008
+          "price": 0.001
         },
         "response_image_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "cache_read_image_input_token": {
           "price": 0.0002
@@ -3878,6 +3902,9 @@
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "response_image_token": {
+          "price": 0.0008
         }
       }
     }
@@ -4105,6 +4132,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }
@@ -4217,6 +4247,21 @@
           "file_search": {
             "price": 0.25
           }
+        }
+      }
+    }
+  },
+  "gpt-5.4-pro-2025-12-11": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.003
+        },
+        "response_token": {
+          "price": 0.018
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 63 |


### 🔄 Updated Models
- `gpt-5.4-mini`
- `gpt-5.4-mini-2026-03-17`
- `gpt-5.4-nano`
- `gpt-5.4-nano-2026-03-17`
- `gpt-5.4`
- `gpt-5.4-2026-03-05`
- `gpt-5.3-chat-latest`
- `gpt-audio-1.5`
- `gpt-realtime-1.5`
- `gpt-5.3-codex`
- `gpt-5.2-codex`
- `chatgpt-image-latest`
- `gpt-4o-mini-transcribe-2025-03-20`
- `gpt-4o-mini-transcribe-2025-12-15`
- `gpt-5.2-chat-latest`
- `gpt-5.2-pro`
- `gpt-5.2-pro-2025-12-11`
- `gpt-5.2`
- `gpt-5.2-2025-12-11`
- `gpt-image-1.5`
- `gpt-5.1-codex-max`
- `gpt-5.1-codex-mini`
- `gpt-5.1-codex`
- `gpt-5.1`
- `gpt-5.1-2025-11-13`
- `gpt-5.1-chat-latest`
- `sora-2-pro`
- `gpt-audio-mini`
- `gpt-5-pro`
- `gpt-5-pro-2025-10-06`
- ... and 33 more


## Data Sources

- **Models API**: OpenAI Models API (128 models, ft:* excluded)
- **Pricing**: LiteLLM model_prices_and_context_window.json (fallback — OpenAI pricing page blocked by Cloudflare)

## Coverage

All 128 models from the OpenAI API processed across 6 batches:
- Batch 1 (25): gpt-5.4-mini/nano/pro, gpt-5.3, gpt-5.2-pro, audio/realtime/TTS/transcribe models
- Batch 2 (25): gpt-5.2, gpt-5.1, gpt-5-search-api, sora-2, gpt-realtime-mini, gpt-audio-mini, gpt-5-pro/codex/nano/mini
- Batch 3 (25): gpt-5, o4-mini-deep-research, o3-deep-research, o3-pro, gpt-4o-realtime-2025-06-03, gpt-image-1, gpt-4.1 family, o4-mini, o3
- Batch 4 (25): o4-mini/o3 versioned, gpt-4o-mini-tts, o1-pro, transcribe, search-preview, computer-use-preview, gpt-4o-2024-11-20, o3-mini, realtime-preview, o1, audio-preview
- Batch 5 (24): gpt-4o family, gpt-4-turbo, gpt-3.5-turbo variants, embeddings, TTS, DALL-E 2/3, legacy models
- Batch 6 (4): tts-1, gpt-3.5-turbo, whisper-1, text-embedding-ada-002

---
*Generated by Pricing Agent on 2026-04-10*