### PR TITLE
chore(pricing): Update fireworks-ai pricing

### DIFF
--- a/general/fireworks-ai.json
+++ b/general/fireworks-ai.json
@@ -668,5 +668,85 @@
     "name": "qwen3-coder-480b-a35b-instruct",
     "params": [{ "key": "max_tokens", "maxValue": 32768 }],
     "type": { "primary": "chat", "supported": ["tools"] }
+  },
+  "deepseek-v3p1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3p2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4p7": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-5p1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-oss-120b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-oss-20b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-8b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3p6-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "flux-1-dev-fp8": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "flux-1-schnell-fp8": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "flux-kontext-pro": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "flux-kontext-max": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-embedding-8b": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -56,6 +56,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -112,10 +123,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -124,10 +135,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -136,10 +147,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -212,6 +223,17 @@
         },
         "response_token": {
           "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00016
         }
       }
     }
@@ -224,6 +246,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -236,6 +269,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -284,6 +328,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -308,6 +363,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -320,6 +386,330 @@
         },
         "response_token": {
           "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "deepseek-v3p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "deepseek-v3p2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "glm-4p7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "glm-5p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.000026
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00007
+        },
+        "response_token": {
+          "price": 0.00022
+        }
+      }
+    }
+  },
+  "gpt-oss-120b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.0000035
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "flux-1-dev-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.05
+          }
+        }
+      }
+    }
+  },
+  "flux-1-schnell-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.035
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 8
+            }
+          }
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: fireworks-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 16 |
| 🔄 Models updated (merged) | 7 |

### ➕ New Models
- `deepseek-v3p1`
- `deepseek-v3p2`
- `glm-4p7`
- `glm-5p1`
- `gpt-oss-120b`
- `gpt-oss-20b`
- `llama-v3p3-70b-instruct`
- `qwen3-8b`
- `qwen3p6-plus`
- `qwen3-vl-30b-a3b-instruct`
- `qwen3-vl-30b-a3b-thinking`
- `flux-1-dev-fp8`
- `flux-1-schnell-fp8`
- `flux-kontext-pro`
- `flux-kontext-max`
- `qwen3-embedding-8b`

### 🔄 Updated Models
- `glm-5`
- `kimi-k2-instruct-0905`
- `kimi-k2p5`
- `kimi-k2-thinking`
- `minimax-m2p1`
- `minimax-m2p5`
- `mixtral-8x22b-instruct`


## Model → Pricing Category Mapping

### Named Families (exact page values)
| Model ID | Display Name | Input | Output | Cache Read |
|---|---|---|---|---|
| deepseek-v3p1 | DeepSeek V3.1 | $0.56 | $1.68 | $0.28 |
| deepseek-v3p2 | DeepSeek v3.2 | $0.56 | $1.68 | $0.28 |
| glm-4p7 | GLM-4.7 | $0.60 | $2.20 | $0.30 |
| glm-5 | GLM-5 | $1.00 | $3.20 | $0.20 (explicit) |
| glm-5p1 | GLM 5.1 | $1.40 | $4.40 | $0.26 (explicit) |
| gpt-oss-120b | OpenAI gpt-oss-120b | $0.15 | $0.60 | $0.075 |
| gpt-oss-20b | OpenAI gpt-oss-20b | $0.07 | $0.30 | $0.035 |
| kimi-k2-instruct-0905 | Kimi K2 Instruct | $0.60 | $2.50 | $0.30 |
| kimi-k2p5 | Kimi K2.5 | $0.60 | $3.00 | $0.10 (explicit) |
| kimi-k2-thinking | Kimi K2 Thinking | $0.60 | $2.50 | $0.30 |
| minimax-m2p1 | MiniMax M2.1 | $0.30 | $1.20 | $0.03 (explicit) |
| minimax-m2p5 | MiniMax M2.5 | $0.30 | $1.20 | $0.03 (explicit) |
| qwen3-vl-30b-a3b-instruct | Qwen3 VL 30B A3B | $0.15 | $0.60 | $0.075 |
| qwen3-vl-30b-a3b-thinking | Qwen3 VL 30B A3B Thinking | $0.15 | $0.60 | $0.075 |

### Tier-Based (text/vision)
| Model ID | Tier | Input | Output | Cache Read |
|---|---|---|---|---|
| llama-v3p3-70b-instruct | >16B | $0.90 | $0.90 | $0.45 |
| mixtral-8x22b-instruct | MoE 56.1B–176B | $1.20 | $1.20 | $0.60 |
| qwen3-8b | 4B–16B | $0.20 | $0.20 | $0.10 |
| qwen3p6-plus | >16B | $0.90 | $0.90 | $0.45 |

### Image Models
| Model ID | Type | Price |
|---|---|---|
| flux-1-dev-fp8 | Per-step | $0.0005/step |
| flux-1-schnell-fp8 | Per-step | $0.00035/step |
| flux-kontext-pro | Per-image | $0.04/image |
| flux-kontext-max | Per-image | $0.08/image |

### Embedding Models
| Model ID | Input $/1M |
|---|---|
| qwen3-embedding-8b | $0.10 |

### Skipped
- qwen3-reranker-8b: Reranker model (excluded per skill rules)

---
*Generated by Pricing Agent on 2026-04-10*