### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1757,5 +1757,10 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -917,14 +917,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.0000315
         }
       },
       "batch_config": {
@@ -948,14 +948,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.000063
         }
       },
       "batch_config": {
@@ -1140,32 +1140,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -1174,32 +1174,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -1395,14 +1395,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00005
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1426,14 +1429,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00005
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1525,13 +1531,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1562,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1593,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1602,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1627,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1636,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1677,14 +1683,14 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1711,14 +1717,14 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1872,29 +1878,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -1903,29 +1909,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -1934,32 +1940,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000025
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000006
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.00000125
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.0000075
         }
       }
     }
@@ -1968,32 +1974,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000025
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000006
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.00000125
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.0000075
         }
       }
     }
@@ -2067,32 +2073,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -2101,32 +2107,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -2271,29 +2277,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2302,29 +2311,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -2395,29 +2407,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2426,29 +2441,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -2457,29 +2475,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000025
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000006
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.00000125
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.0000075
         }
       }
     }
@@ -2488,20 +2506,51 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0.000015
+        },
+        "cache_read_input_token": {
+          "price": 0.0000006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.35
+          },
+          "search": {
+            "price": 0.35
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00000125
+        },
+        "response_token": {
+          "price": 0.0000075
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.000025
         },
         "response_token": {
           "price": 0.00015
         },
-        "cache_read_input_token": {
-          "price": 0.0000025
-        },
         "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2515,64 +2564,33 @@
       }
     }
   },
-  "gemini-3.1-flash-image-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.006
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "gemini-3.1-flash-image-preview-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2591,10 +2609,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2622,10 +2640,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2820,7 +2838,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2861,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2884,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 12
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2907,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 12
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2930,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2953,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2976,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 12
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2999,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 12
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3022,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3045,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3043,7 +3061,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3060,7 +3078,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3174,7 +3192,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,12 +3232,12 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3231,14 +3249,14 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3301,40 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 10
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 10
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 44 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-2.5-pro-lte-128k`
- `gemini-2.5-pro-gt-128k`
- `gemini-2.5-flash-lte-128k`
- `gemini-2.5-flash-gt-128k`
- `gemini-2.5-flash-lite-lte-128k`
- `gemini-2.5-flash-lite-gt-128k`
- `gemini-2.5-flash-image-lte-128k`
- `gemini-2.5-flash-image-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-3-pro-preview-lte-128k`
- `gemini-3-pro-preview-gt-128k`
- `gemini-3-flash-preview-lte-128k`
- `gemini-3-flash-preview-gt-128k`
- `gemini-3.1-pro-preview-lte-128k`
- `gemini-3.1-pro-preview-gt-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-3-pro-image-preview-lte-128k`
- `gemini-3-pro-image-preview-gt-128k`
- `gemini-3.1-flash-image-preview-lte-128k`
- `gemini-3.1-flash-image-preview-gt-128k`
- `gemini-pro-latest-lte-128k`
- `gemini-pro-latest-gt-128k`
- `gemini-flash-latest-lte-128k`
- `gemini-flash-latest-gt-128k`
- `gemini-flash-lite-latest-lte-128k`
- `gemini-flash-lite-latest-gt-128k`
- ... and 14 more


### 📋 Model → pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤128K | $1.25/$10 input/output, cache $0.315, batch $0.625/$5, web_search+search |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >128K | $2.50/$15 input/output, cache $0.63, batch $1.25/$7.5, web_search+search |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat | $0.30/$2.50, cache $0.075, thinking $0.50/1M, batch $0.15/$1.25, web_search+search |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat | Same as lte (flat pricing) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash Lite, flat | $0.10/$0.40, cache $0.025, batch $0.05/$0.20, web_search+search |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash Lite, flat | Same as lte (flat pricing) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat | input $0.30, text output $2.50, image_token $30/1M, batch $0.15/$1.25, web_search+search; batch image $30/1M noted |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat | Same as lte (flat pricing) |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat | $0.10/$0.40, cache $0.025, batch $0.05/$0.20, web_search+search |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat | Same as lte (flat pricing) |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash 001, flat | Same as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash 001, flat | Same as lte (flat pricing) |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash Lite, flat | $0.075/$0.30, batch $0.0375/$0.15, no web search |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash Lite, flat | Same as lte (flat pricing) |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash Lite 001, flat | Same as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash Lite 001, flat | Same as lte (flat pricing) |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro, ≤128K | $1.25/$10, cache $0.25, batch $0.625/$5, web_search+search |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro, >128K | $2.50/$20, cache $0.50, batch $1.25/$10, web_search+search |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash, flat | $0.10/$0.40, cache $0.025, batch $0.05/$0.20, web_search+search |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash, flat | Same as lte (flat pricing) |
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro, ≤128K | $1.25/$10, cache $0.045, thinking $1/1M, batch $0.625/$5, web_search+search |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro, >128K | $2.50/$20, cache $0.09, thinking $1/1M, batch $1.25/$10, web_search+search |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash Lite, flat | $0.025/$0.15, cache $0.006, batch $0.0125/$0.075, web_search+search |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash Lite, flat | Same as lte (flat pricing) |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image (Nano Banana Pro), flat | input $2.00, text output $12, image_token $120/1M, batch $1/$6, web_search+search |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image (Nano Banana Pro), flat | Same as lte (flat pricing) |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image (Nano Banana 2), flat | input $0.25, text output $1.50, image_token $60/1M, batch $0.125/$0.75, batch image $30/1M noted |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image (Nano Banana 2), flat | Same as lte (flat pricing) |
| gemini-pro-latest-lte-128k | *-latest → resolves to gemini-3.1-pro-preview (verified from pricing page) | Same pricing as gemini-3.1-pro-preview ≤128K |
| gemini-pro-latest-gt-128k | *-latest → resolves to gemini-3.1-pro-preview (verified from pricing page) | Same pricing as gemini-3.1-pro-preview >128K |
| gemini-flash-latest-lte-128k | *-latest → resolves to gemini-3-flash-preview (verified from pricing page) | Same pricing as gemini-3-flash-preview |
| gemini-flash-latest-gt-128k | *-latest → resolves to gemini-3-flash-preview (verified from pricing page) | Same as lte (flat pricing) |
| gemini-flash-lite-latest-lte-128k | *-latest → resolves to gemini-3.1-flash-lite-preview (verified from pricing page) | Same pricing as gemini-3.1-flash-lite-preview |
| gemini-flash-lite-latest-gt-128k | *-latest → resolves to gemini-3.1-flash-lite-preview (verified from pricing page) | Same as lte (flat pricing) |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | input $0.01/1M, output $0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 | Same as lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview | input $0.01/1M, output $0 |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview | Same as lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4.0 Generate | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4.0 Generate | $0.04/image |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4.0 Ultra Generate | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4.0 Ultra Generate | $0.06/image |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4.0 Fast Generate | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4.0 Fast Generate | $0.02/image |
| veo-2.0-generate-001-lte-128k | Veo 2.0 Generate | $0.50/s (50¢/s), default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2.0 Generate | Same as lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0 Generate | $0.20/s (20¢/s), default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3.0 Generate | Same as lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast Generate | $0.12/s (12¢/s), default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast Generate | Same as lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Generate Preview | $0.20/s (20¢/s), default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Generate Preview | Same as lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast Generate Preview | $0.12/s (12¢/s), default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast Generate Preview | Same as lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite Generate Preview | $0.10/s (10¢/s), default 8s, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite Generate Preview | Same as lte |

### Excluded models (from API list)
- `gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts` — TTS models
- `gemma-*` family — Gemma, not Gemini
- `gemini-3.1-flash-live-preview` — *-live-* excluded
- `gemini-2.5-flash-native-audio-*`, `gemini-2.5-flash-native-audio-latest` — native-audio excluded
- `gemini-2.5-computer-use-preview-10-2025` — computer-use excluded
- `nano-banana-pro-preview` — alias for gemini-3-pro-image-preview, not a separate model
- `aqa` — AQA excluded
- `lyria-3-*` — not in include list
- `gemini-robotics-er-1.5-preview` — Robotics excluded
- `deep-research-pro-preview-12-2025` — not in include list
- `gemini-3.1-pro-preview-customtools` — custom tools variant, not in include list

---
*Generated by Pricing Agent on 2026-04-10*