### PR TITLE
chore(pricing): Update dashscope pricing

### DIFF
--- a/general/dashscope.json
+++ b/general/dashscope.json
@@ -632,5 +632,370 @@
   "qwen-mt-lite": {
     "params": [{ "key": "max_tokens", "maxValue": 8192 }],
     "type": { "primary": "chat" }
+  },
+  "qwen-flash-latest": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-long": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-4b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-1.7b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-0.6b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-235b-a22b-thinking-2507": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-30b-a3b-thinking-2507": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-30b-a3b-instruct-2507": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-27b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-14b-instruct-1m": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-7b-instruct-1m": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-doc-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-deep-research": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-rerank": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-max": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-max": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-t2i": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "z-image-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-t2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-i2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-i2v-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-i2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-r2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-r2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-vace-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-embedding-v4": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-embedding-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshot-kimi-k2-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "minimax-m2.5": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-0528": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3.1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-distill-qwen-7b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-distill-qwen-14b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-distill-qwen-32b": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -159,6 +159,9 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
         }
       }
     }
@@ -488,10 +491,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.000016
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.000064
         },
         "reasoning_token": {
           "price": 0.00084
@@ -518,10 +521,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0035
         },
         "response_token": {
-          "price": 0.0000035
+          "price": 0
         }
       }
     }
@@ -650,10 +653,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.0000574
         }
       }
     }
@@ -662,10 +665,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00012
         }
       }
     }
@@ -684,6 +687,9 @@
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
         }
       }
     }
@@ -702,6 +708,9 @@
         },
         "response_audio_token": {
           "price": 0.001813
+        },
+        "request_image_token": {
+          "price": 0.000094
         }
       }
     }
@@ -721,7 +730,6 @@
       }
     }
   },
-
   "qwen3-vl-30b-a3b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -840,10 +848,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.000058
+          "price": 0.0000861
         }
       }
     }
@@ -960,10 +968,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.00008
         },
         "reasoning_token": {
           "price": 0.00084
@@ -1626,10 +1634,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000381
+          "price": 0.000078
         },
         "response_token": {
           "price": 0.000306
+        },
+        "request_audio_token": {
+          "price": 0.000381
         }
       }
     }
@@ -1885,6 +1896,960 @@
         },
         "response_token": {
           "price": 0.0002294
+        }
+      }
+    }
+  },
+  "qwen-flash-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-long": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "qwen3-4b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-1.7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-0.6b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-thinking-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.00023
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.000092
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-thinking-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00008
+        }
+      }
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00036
+        }
+      }
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00032
+        }
+      }
+    }
+  },
+  "qwen3.5-27b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00056
+        }
+      }
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00007
+        },
+        "response_token": {
+          "price": 0.00028
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.00014
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000175
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000805
+        },
+        "response_token": {
+          "price": 0.000322
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000368
+        },
+        "response_token": {
+          "price": 0.000147
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00028
+        },
+        "response_token": {
+          "price": 0.00084
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00042
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.000105
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000021
+        },
+        "response_token": {
+          "price": 0.000063
+        }
+      }
+    }
+  },
+  "qwen-doc-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000087
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "qwen-deep-research": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0007742
+        },
+        "response_token": {
+          "price": 0.0023367
+        }
+      }
+    }
+  },
+  "qwen3-rerank": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-2.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-t2i": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "z-image-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-t2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_720p_per_second": {
+            "price": 10
+          },
+          "video_1080p_per_second": {
+            "price": 15
+          }
+        }
+      }
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_480p_per_second": {
+            "price": 5
+          },
+          "video_720p_per_second": {
+            "price": 10
+          },
+          "video_1080p_per_second": {
+            "price": 15
+          }
+        }
+      }
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_480p_per_second": {
+            "price": 2
+          },
+          "video_1080p_per_second": {
+            "price": 10
+          }
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.6
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-i2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_720p_per_second": {
+            "price": 10
+          },
+          "video_1080p_per_second": {
+            "price": 15
+          }
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_720p_per_second": {
+            "price": 5
+          },
+          "video_1080p_per_second": {
+            "price": 7.5
+          }
+        }
+      }
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_480p_per_second": {
+            "price": 5
+          },
+          "video_720p_per_second": {
+            "price": 10
+          },
+          "video_1080p_per_second": {
+            "price": 15
+          }
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_480p_per_second": {
+            "price": 2
+          },
+          "video_1080p_per_second": {
+            "price": 10
+          }
+        }
+      }
+    }
+  },
+  "wan2.1-i2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.6
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-r2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_720p_per_second": {
+            "price": 10
+          },
+          "video_1080p_per_second": {
+            "price": 15
+          }
+        }
+      }
+    }
+  },
+  "wan2.6-r2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_720p_per_second": {
+            "price": 5
+          },
+          "video_1080p_per_second": {
+            "price": 7.5
+          }
+        }
+      }
+    }
+  },
+  "wan2.1-vace-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0026
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-v4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000058
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "moonshot-kimi-k2-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0002294
+        }
+      }
+    }
+  },
+  "minimax-m2.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000304
+        },
+        "response_token": {
+          "price": 0.0001213
+        }
+      }
+    }
+  },
+  "deepseek-r1-0528": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0002294
+        }
+      }
+    }
+  },
+  "deepseek-v3.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "deepseek-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0001147
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-14b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000431
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000861
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: dashscope

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 73 |
| 🔄 Models updated (merged) | 10 |

### ➕ New Models
- `qwen-flash-latest`
- `qwen-long`
- `qwen3-4b`
- `qwen3-1.7b`
- `qwen3-0.6b`
- `qwen3-235b-a22b-thinking-2507`
- `qwen3-235b-a22b-instruct-2507`
- `qwen3-30b-a3b-thinking-2507`
- `qwen3-30b-a3b-instruct-2507`
- `qwen3.5-397b-a17b`
- `qwen3.5-122b-a10b`
- `qwen3.5-27b`
- `qwen3.5-35b-a3b`
- `qwen2.5-72b-instruct`
- `qwen2.5-32b-instruct`
- `qwen2.5-14b-instruct`
- `qwen2.5-7b-instruct`
- `qwen2.5-14b-instruct-1m`
- `qwen2.5-7b-instruct-1m`
- `qwen2.5-vl-72b-instruct`
- ... and 53 more

### 🔄 Updated Models
- `qwen3-32b`
- `qwen3-30b-a3b`
- `qwen3-next-80b-a3b-thinking`
- `qwen3-next-80b-a3b-instruct`
- `qwq-32b`
- `qwen3-asr-flash`
- `qwen3-omni-flash`
- `qwen-omni-turbo`
- `qwen3-omni-flash-realtime`
- `qwen3-omni-30b-a3b-captioner`


## Model-to-pricing-page mapping

All prices sourced from: https://www.alibabacloud.com/help/en/model-studio/models (Last Updated: Apr 01, 2026)

**Region priority applied:** International (Singapore) → Global → Chinese Mainland (fallback for region-locked families)

### Families covered (133 models total)

| Family | Region used | Notes |
|--------|-------------|-------|
| Flagship: qwen3-max, qwen3.5-plus, qwen3.5-flash | International | Lowest input tier |
| Commercial text: qwen-max, qwen-plus, qwen-flash, qwen-turbo, qwq-plus | International | Non-thinking rates, lowest tier |
| qwen-long | Chinese Mainland | Only available there |
| Translation: qwen-mt-* | International | |
| VL commercial: qwen3-vl-plus/flash, qvq-max, qwen-vl-max/plus/ocr | International | Lowest tier |
| Coder: qwen3-coder-plus/flash/next, qwen3-coder-480b/30b | International | Lowest tier |
| Open-source Qwen3: 235b–0.6b + 2507 snapshots + next variants | International | Non-thinking rates |
| Qwen3.5 open-source: 397b, 122b, 27b, 35b | International | Lowest tier |
| Qwen2.5 instruct: 72b–7b + 1M variants | International | |
| Open-source VL: qwen3-vl-235b/32b/30b/8b, qwen2.5-vl-72b/32b/7b/3b | International | Non-thinking for dual-mode |
| Math: qwen-math-plus/turbo | Chinese Mainland | Region-locked |
| Data mining: qwen-doc-turbo | Chinese Mainland | Region-locked |
| Deep research: qwen-deep-research | Chinese Mainland | Region-locked |
| QwQ open-source: qwq-32b | Chinese Mainland | Region-locked |
| Omni: qwen3-omni-flash, qwen-omni-turbo, qwen3-omni-flash-realtime | International | Per-modality audio/image fields |
| Captioner: qwen3-omni-30b-a3b-captioner | International | |
| Image generation: qwen-image-*, wan2.6-t2i, z-image-turbo | International | per_image |
| Image editing: qwen-image-edit-*, wan2.6-image | International | per_image |
| Video: wan2.6/2.5/2.2/2.1 t2v/i2v/r2v/vace | International | per_second; resolution tiers in additional |
| TTS: qwen3-tts-*, cosyvoice-v3-* | International | per_million_characters (10K char page unit converted) |
| ASR: qwen3-asr-flash*, fun-asr* | International | per_second |
| Embeddings: text-embedding-v4/v3, tongyi-embedding-vision-* | International | |
| Reranking: qwen3-rerank | International | input only |
| Intent detection: tongyi-intent-detect-v3 | Chinese Mainland | Region-locked |
| Role-playing: qwen-plus-character, qwen-plus-character-ja | International | |
| Third-party DeepSeek (International): deepseek-v3.2 | International | |
| Third-party DeepSeek (CN): deepseek-r1/r1-0528/v3.1/v3/distill | Chinese Mainland | |
| Third-party Kimi: kimi-k2.5, kimi-k2-thinking, moonshot-kimi-k2-instruct | Chinese Mainland | |
| Third-party MiniMax: minimax-m2.5 | Chinese Mainland | |
| Third-party GLM: glm-5, glm-4.7, glm-4.6 | Chinese Mainland | Lowest tier |

---
*Generated by Pricing Agent on 2026-04-10*