### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1757,5 +1757,15 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "nano-banana-pro-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -917,10 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1681,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2591,10 +2591,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2622,10 +2622,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3052,6 +3052,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3069,6 +3072,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3174,7 +3180,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3220,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3244,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3289,102 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 0.14
+          },
+          "search": {
+            "price": 0.14
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 0.14
+          },
+          "search": {
+            "price": 0.14
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 4 |
| 🔄 Models updated (merged) | 38 |

### ➕ New Models
- `nano-banana-pro-preview-lte-128k`
- `nano-banana-pro-preview-gt-128k`
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-2.5-pro-lte-128k`
- `gemini-2.5-pro-gt-128k`
- `gemini-2.5-flash-lte-128k`
- `gemini-2.5-flash-gt-128k`
- `gemini-2.5-flash-lite-lte-128k`
- `gemini-2.5-flash-lite-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.5-flash-image-lte-128k`
- `gemini-2.5-flash-image-gt-128k`
- `gemini-3-flash-preview-lte-128k`
- `gemini-3-flash-preview-gt-128k`
- `gemini-3-pro-preview-lte-128k`
- `gemini-3-pro-preview-gt-128k`
- `gemini-3.1-pro-preview-lte-128k`
- `gemini-3.1-pro-preview-gt-128k`
- `gemini-3.1-pro-preview-customtools-lte-128k`
- `gemini-3.1-pro-preview-customtools-gt-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-3.1-flash-image-preview-lte-128k`
- `gemini-3.1-flash-image-preview-gt-128k`
- `gemini-3-pro-image-preview-lte-128k`
- `gemini-3-pro-image-preview-gt-128k`
- `gemini-pro-latest-lte-128k`
- `gemini-pro-latest-gt-128k`
- `gemini-flash-latest-lte-128k`
- `gemini-flash-latest-gt-128k`
- ... and 8 more


### 📋 Model → pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | $1.25 input, $10 output, cache $0.125, batch $0.625/$5, web_search $0.35/1K |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | $2.50 input, $15 output, cache $0.25, batch $1.25/$7.5 |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat pricing | $0.30 input, $2.50 output, cache $0.03, batch $0.15/$1.25, web_search $0.35/1K |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat pricing (identical) | same as lte — no context tier on page |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash-Lite, flat pricing | $0.10 input, $0.40 output, cache $0.01, batch $0.05/$0.20, web_search $0.35/1K |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash-Lite, flat pricing (identical) | same as lte — no context tier on page |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat pricing | $0.10 input, $0.40 output, cache $0.025, batch $0.05/$0.20, web_search $0.35/1K |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat pricing (identical) | same as lte |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash (versioned), flat pricing | same pricing as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash (versioned), flat pricing (identical) | same as lte |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash-Lite, flat pricing | $0.075 input, $0.30 output, batch $0.0375/$0.15, no web_search/cache |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash-Lite, flat pricing (identical) | same as lte |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash-Lite (versioned), flat pricing | same pricing as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash-Lite (versioned), flat pricing (identical) | same as lte |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat pricing | $0.30 input, $2.50 text output, image_token $30/1M, batch $0.15/$1.25 |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat pricing (identical) | same as lte — no context tier on page |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, flat pricing | $0.50 input, $3.00 output, cache $0.05, batch $0.25/$1.50, web_search $0.14/1K ($14/1K) |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, flat pricing (identical) | same as lte |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K | $2.00 input, $12.00 output, cache $0.20, batch $1.00/$6.00, web_search $0.14/1K |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K | $4.00 input, $18.00 output, cache $0.40, batch $2.00/$9.00 |
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K | $2.00 input, $12.00 output, cache $0.20, batch $1.00/$6.00, web_search $0.14/1K |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K | $4.00 input, $18.00 output, cache $0.40, batch $2.00/$9.00 |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview (customtools), ≤200K | same pricing as gemini-3.1-pro-preview |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview (customtools), >200K | same pricing as gemini-3.1-pro-preview gt |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite Preview, flat pricing | $0.25 input, $1.50 output, cache $0.025, batch $0.125/$0.75, web_search $0.14/1K |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite Preview, flat pricing (identical) | same as lte |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview (Nano Banana 2), flat | $0.50 input, $3.00 text output, image_token $60/1M, batch $0.25/$1.50 (text). Batch image output $30/1M noted separately |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview, flat (identical) | same as lte |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview (Nano Banana Pro), flat | $2.00 input, $12.00 text output, image_token $120/1M, batch $1.00/$6.00 (text) |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview, flat (identical) | same as lte |
| nano-banana-pro-preview-lte-128k | nano-banana-pro-preview alias → same as gemini-3-pro-image-preview | $2.00 input, $12.00 text output, image_token $120/1M, batch $1.00/$6.00 |
| nano-banana-pro-preview-gt-128k | nano-banana-pro-preview alias (identical) | same as lte |
| gemini-pro-latest-lte-128k | *-latest → resolves to gemini-3.1-pro-preview (verified from pricing page), ≤200K | $2.00 input, $12.00 output, cache $0.20, batch $1.00/$6.00 |
| gemini-pro-latest-gt-128k | *-latest → resolves to gemini-3.1-pro-preview, >200K | $4.00 input, $18.00 output, cache $0.40, batch $2.00/$9.00 |
| gemini-flash-latest-lte-128k | *-latest → resolves to gemini-3-flash-preview (verified from pricing page), flat | $0.50 input, $3.00 output, cache $0.05, batch $0.25/$1.50 |
| gemini-flash-latest-gt-128k | *-latest → resolves to gemini-3-flash-preview (identical) | same as lte |
| gemini-flash-lite-latest-lte-128k | *-latest → resolves to gemini-3.1-flash-lite-preview (verified from pricing page), flat | $0.25 input, $1.50 output, cache $0.025, batch $0.125/$0.75 |
| gemini-flash-lite-latest-gt-128k | *-latest → resolves to gemini-3.1-flash-lite-preview (identical) | same as lte |
| gemini-embedding-001-lte-128k | Gemini Embedding 001, text-only | $0.15 input, $0 output, batch $0.075 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 (identical) | same as lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview, multimodal | $0.20 text input, $0 output; batch: not available. Image/audio/video inputs priced separately on page |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview (identical) | same as lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4 Standard, per-image | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4 Standard (identical) | $0.04/image |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4 Ultra, per-image | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4 Ultra (identical) | $0.06/image |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4 Fast, per-image | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4 Fast (identical) | $0.02/image |
| veo-2.0-generate-001-lte-128k | Veo 2.0 Generate, per-second | $0.35/s → 35¢/s, default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2.0 Generate (identical) | same as lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0 Generate (standard), per-second | $0.40/s → 40¢/s, default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3.0 Generate (identical) | same as lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast Generate, per-second | $0.10/s → 10¢/s, default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast Generate (identical) | same as lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Generate (standard 720p), per-second | $0.40/s → 40¢/s, default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Generate (identical) | same as lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast Generate (720p), per-second | $0.10/s → 10¢/s, default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast Generate (identical) | same as lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite Generate (720p), per-second | $0.05/s → 5¢/s, default 8s, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite Generate (identical) | same as lte |

### 🚫 Excluded models (per skill rules)
| Model ID | Reason |
|----------|--------|
| gemini-2.5-flash-preview-tts, gemini-2.5-pro-preview-tts | TTS models (excluded) |
| gemini-2.5-flash-native-audio-latest, gemini-2.5-flash-native-audio-preview-09-2025, gemini-2.5-flash-native-audio-preview-12-2025 | native-audio models (excluded) |
| gemini-3.1-flash-live-preview | live model (excluded) |
| gemma-3-1b-it, gemma-3-4b-it, gemma-3-12b-it, gemma-3-27b-it, gemma-3n-e4b-it, gemma-3n-e2b-it, gemma-4-26b-a4b-it, gemma-4-31b-it | Gemma models (excluded) |
| aqa | AQA (excluded) |
| gemini-2.5-computer-use-preview-10-2025 | computer-use model (excluded) |
| gemini-robotics-er-1.5-preview | Robotics model (excluded) |
| deep-research-pro-preview-12-2025 | Not in included scope |
| lyria-3-clip-preview, lyria-3-pro-preview | Music generation, not in included scope |

---
*Generated by Pricing Agent on 2026-04-10*