### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1344,6 +1344,9 @@
           },
           "response_audio_token": {
             "price": 0
+          },
+          "audio_duration_seconds": {
+            "price": 10
           }
         }
       }
@@ -1357,6 +1360,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 1.5
+        },
+        "additional_units": {
+          "characters": {
+            "price": 1500000
+          }
         }
       }
     }
@@ -1369,6 +1380,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 3
+        },
+        "additional_units": {
+          "characters": {
+            "price": 3000000
+          }
         }
       }
     }
@@ -1377,7 +1396,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -1395,7 +1414,7 @@
           "response_audio_token": {
             "price": 0.0012
           }
-        }     
+        }
       }
     }
   },
@@ -1409,7 +1428,7 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.0006
         },
         "response_audio_token": {
           "price": 0
@@ -1435,7 +1454,7 @@
           "price": 0.0005
         },
         "request_audio_token": {
-          "price": 0.3
+          "price": 0.0003
         },
         "response_audio_token": {
           "price": 0
@@ -1745,7 +1764,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1786,7 +1805,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2217,13 +2236,13 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2283,16 +2302,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2310,16 +2329,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2643,10 +2662,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2724,7 +2743,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.00004
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2751,7 +2770,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.00004
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2793,10 +2812,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2881,6 +2900,15 @@
           "price": 0.000125
         },
         "cache_read_text_input_token": {
+          "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
           "price": 0.000125
         }
       }
@@ -3420,6 +3448,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3757,7 +3791,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -3772,7 +3806,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -3821,6 +3855,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 1.5
+        },
+        "additional_units": {
+          "characters": {
+            "price": 1500000
+          }
         }
       }
     }
@@ -3833,6 +3875,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 3
+        },
+        "additional_units": {
+          "characters": {
+            "price": 3000000
+          }
         }
       }
     }
@@ -3844,16 +3894,16 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
         },
         "request_image_token": {
-          "price": 0.0008
+          "price": 0.001
         },
         "response_image_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "cache_read_image_input_token": {
           "price": 0.0002
@@ -3878,6 +3928,9 @@
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "response_image_token": {
+          "price": 0.0008
         }
       }
     }
@@ -4105,6 +4158,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }
@@ -4125,6 +4181,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 26 |


### 🔄 Updated Models
- `gpt-5.4-pro`
- `gpt-5.4-pro-2026-03-05`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `o4-mini-deep-research-2025-06-26`
- `gpt-audio-mini`
- `gpt-realtime`
- `gpt-realtime-2025-08-28`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-4o-mini-tts`
- `gpt-4o-mini-tts-2025-03-20`
- `gpt-4o-mini-tts-2025-12-15`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `tts-1`
- `tts-1-1106`
- `tts-1-hd`
- `tts-1-hd-1106`
- `whisper-1`
- `gpt-image-1`
- `gpt-image-1-mini`
- `gpt-image-1.5`
- `chatgpt-image-latest`


## Data Sources

| Source | Type | Details |
|--------|------|---------|
| OpenAI Models API (`get_openai_models`) | API | Returned 128 models (ft:* excluded) |
| LiteLLM model_prices_and_context_window.json | Pricing | `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json` — used as pricing source after firecrawl credits exhausted |

## Model Coverage (129 entries across 6 batches)

| Batch | Family | Count |
|-------|--------|-------|
| 1 | GPT-5.4, GPT-5.3, GPT-5.2 families | 25 |
| 2 | GPT-5 (codex/mini/nano/pro/search-api), GPT-4.1, GPT-4o base | 25 |
| 3 | O-series (o4-mini, o3, o1, computer-use, codex-mini) | 19 |
| 4 | Audio + Realtime (gpt-audio, gpt-realtime, gpt-4o-audio/realtime) | 22 |
| 5 | TTS, Transcribe, Whisper, Sora | 15 |
| 6 | Image (gpt-image, dall-e), Embeddings, Moderation, Legacy | 23 |

---
*Generated by Pricing Agent on 2026-04-10*