### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/pricing/google.json
+++ b/pricing/google.json
@@ -1433,7 +1433,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1711,7 +1711,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -1872,29 +1872,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1903,29 +1903,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1934,32 +1934,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -1968,32 +1968,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2395,29 +2395,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.000013
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2426,29 +2426,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.00075
         }
       }
     }
@@ -3283,68 +3283,6 @@
         },
         "response_token": {
           "price": 0.001
-        }
-      }
-    }
-  },
-  "gemini-2.0-flash-image-generation-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.003
-          },
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "gemini-2.0-flash-image-generation-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.003
-          },
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -924,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1433,7 +1433,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.00001
         }
       },
       "batch_config": {
@@ -1711,7 +1711,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1943,7 +1943,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1956,7 +1956,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1977,7 +1977,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1990,7 +1990,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2463,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2476,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2494,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2507,7 +2507,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2581,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3174,7 +3174,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3214,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3238,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3283,102 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-image-generation-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-image-generation-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 27 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-2.5-pro-lte-128k`
- `gemini-pro-latest-lte-128k`
- `gemini-pro-latest-gt-128k`
- `gemini-flash-latest-lte-128k`
- `gemini-flash-latest-gt-128k`
- `gemini-flash-lite-latest-lte-128k`
- `gemini-flash-lite-latest-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.0-flash-lite-lte-128k`
- `gemini-2.0-flash-lite-gt-128k`
- `gemini-2.0-flash-lite-001-lte-128k`
- `gemini-2.0-flash-lite-001-gt-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `veo-2.0-generate-001-lte-128k`
- `veo-2.0-generate-001-gt-128k`
- `veo-3.0-generate-001-lte-128k`
- `veo-3.0-generate-001-gt-128k`
- `veo-3.0-fast-generate-001-lte-128k`
- `veo-3.0-fast-generate-001-gt-128k`
- `veo-3.1-generate-preview-lte-128k`
- `veo-3.1-generate-preview-gt-128k`
- `veo-3.1-fast-generate-preview-lte-128k`
- `veo-3.1-fast-generate-preview-gt-128k`


### Model to pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | input $1.25/1M, output $10/1M, cache read $0.13/1M, batch $0.625/$5/1M, web search $35/1K |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | input $2.50/1M, output $15/1M, cache read $0.25/1M, batch $1.25/$7.5/1M |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat pricing | input $0.30/1M, output $2.50/1M, cache read $0.03/1M, batch $0.15/$1.25/1M |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat pricing | same as lte (no context tiers listed) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash Lite, flat pricing | input $0.10/1M, output $0.40/1M, cache read $0.01/1M, batch $0.05/$0.20/1M |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash Lite, flat pricing | same as lte (no context tiers listed) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat pricing | input $0.30/1M, text output $2.50/1M, image output $30/1M, batch input $0.15/1M, batch text output $1.25/1M |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat pricing | same as lte (flat pricing) |
| gemini-pro-latest-lte-128k | *-latest alias → resolved to gemini-2.5-pro (highest Pro in API list) | same pricing as gemini-2.5-pro lte |
| gemini-pro-latest-gt-128k | *-latest alias → resolved to gemini-2.5-pro (highest Pro in API list) | same pricing as gemini-2.5-pro gt |
| gemini-flash-latest-lte-128k | *-latest alias → resolved to gemini-2.5-flash (highest Flash in API list) | same pricing as gemini-2.5-flash |
| gemini-flash-latest-gt-128k | *-latest alias → resolved to gemini-2.5-flash | same as lte (flat pricing) |
| gemini-flash-lite-latest-lte-128k | *-latest alias → resolved to gemini-2.5-flash-lite (highest Flash-Lite in API list) | same pricing as gemini-2.5-flash-lite |
| gemini-flash-lite-latest-gt-128k | *-latest alias → resolved to gemini-2.5-flash-lite | same as lte (flat pricing) |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat pricing | input $0.15/1M, output $0.60/1M, batch $0.075/$0.30/1M, web search $35/1K |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat pricing | same as lte (no context tiers) |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash, flat pricing | same as gemini-2.0-flash (versioned alias) |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash, flat pricing | same as lte |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash Lite, flat pricing | input $0.075/1M, output $0.30/1M, batch $0.0375/$0.15/1M |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash Lite, flat pricing | same as lte |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash Lite, flat pricing | same as gemini-2.0-flash-lite (versioned alias) |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash Lite, flat pricing | same as lte |
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K | input $2/1M, output $12/1M, cache read $0.2/1M, batch $1/$6/1M, web search $14/1K |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K | input $4/1M, output $18/1M, cache read $0.4/1M, batch $2/$9/1M |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview variant, ≤200K | same pricing as gemini-3.1-pro-preview (variant in API list, no separate pricing found) |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview variant, >200K | same as gemini-3.1-pro-preview gt |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K | input $2/1M, output $12/1M, cache read $0.2/1M, batch $1/$6/1M |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K | input $4/1M, output $18/1M, cache read $0.4/1M, batch $2/$9/1M |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, flat pricing | input $0.5/1M, output $3/1M, cache read $0.05/1M, batch $0.25/$1.5/1M |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, flat pricing | same as lte |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite Preview, flat pricing | input $0.25/1M, output $1.50/1M, cache read $0.03/1M, batch $0.13/$0.75/1M |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite Preview, flat pricing | same as lte |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview, flat pricing | input $2/1M, text output $12/1M, image output $120/1M, batch input $1/1M, batch text output $6/1M |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview, flat pricing | same as lte (flat pricing) |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview, flat pricing | input $0.50/1M, text output $3/1M, image output $60/1M, batch input $0.25/1M, batch text output $1.50/1M |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview, flat pricing | same as lte |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4 Ultra | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4 Ultra | same as lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4 Standard | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4 Standard | same as lte |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4 Fast | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4 Fast | same as lte |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | input $0.15/1M ($0.00015/1K), output $0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 | same as lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview (Unified Multimodal) | text input $0.2/1M, output $0 |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview | same as lte |
| veo-2.0-generate-001-lte-128k | Veo 2 | $0.50/sec video, 50 cents/sec, default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2 | same as lte |
| veo-3.0-generate-001-lte-128k | Veo 3 (video only 720p/1080p) | $0.20/sec, 20 cents/sec, default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3 | same as lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3 Fast (video only 720p) | $0.08/sec, 8 cents/sec, default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3 Fast | same as lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 (video only 720p/1080p) | $0.20/sec, 20 cents/sec, default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 | same as lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast (video only 720p) | $0.08/sec, 8 cents/sec, default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast | same as lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite (video only 720p) | $0.03/sec, 3 cents/sec, default 8s, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite | same as lte |

### Data source notes

- Pricing source: Google Cloud Vertex AI Generative AI Pricing page (`https://cloud.google.com/vertex-ai/generative-ai/pricing`)
- Note: Firecrawl credits were exhausted; used http_request fallback to the Vertex AI pricing page
- Vertex AI page uses ≤200K / >200K context tiers; mapped ≤200K → lte-128k, >200K → gt-128k entries
- `*-latest` aliases resolved from the highest-version series present in the Gemini API model list (get_gemini_models): gemini-2.5 is the highest series available
- `gemini-3.1-pro-preview-customtools` is a variant in the API list with no separate pricing; priced same as gemini-3.1-pro-preview
- Batch image output rates (noted but not in separate field): gemini-2.5-flash-image $15/1M batch, gemini-3-pro-image-preview $60/1M batch, gemini-3.1-flash-image-preview $30/1M batch
- Gemini 3.x web search: $14/1K queries (1.4 cents each); Gemini 2.x web search: $35/1K prompts (3.5 cents each)

---
*Generated by Pricing Agent on 2026-04-10*