### PR TITLE
chore(pricing): Update dashscope pricing

### DIFF
--- a/general/dashscope.json
+++ b/general/dashscope.json
@@ -632,5 +632,820 @@
   "qwen-mt-lite": {
     "params": [{ "key": "max_tokens", "maxValue": 8192 }],
     "type": { "primary": "chat" }
+  },
+  "qwen-plus-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-plus-2025-12-01-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-flash-latest": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-flash-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-flash-2025-07-28-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-4b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-1.7b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-0.6b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-235b-a22b-thinking-2507": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-30b-a3b-thinking-2507": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-30b-a3b-instruct-2507": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-27b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-14b-instruct-1m": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-7b-instruct-1m": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-flash-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-flash-2026-01-22-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-flash-2025-10-15-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-vl-ocr-2025-08-28": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-math-72b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-math-1.5b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-doc-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-deep-research": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-embedding-v4": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-embedding-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-rerank": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gte-rerank-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3.2-exp": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3.1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-0528": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-distill-qwen-7b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-distill-qwen-14b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-distill-qwen-32b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-omni-plus-2026-03-15": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-omni-flash-2026-03-15": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0-pro-2026-03-03": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0-2026-03-03": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-max": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-max-2025-12-30": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-plus-2026-01-09": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-max": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-max-2026-01-16": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-plus-2025-12-15": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-plus-2025-10-30": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "z-image-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-t2i": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-t2i-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-t2i-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-t2i-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2i-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2i-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-i2i-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-t2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-t2v-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-i2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-i2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-i2v-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-kf2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-kf2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-r2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan.6-r2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-vace-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-animate-move": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-animate-mix": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-s2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "animate-anyone-template-gen2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "animate-anyone-gen2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "emo-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "liveportrait": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "emoji-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "videoretalk": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "video-style-transform": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-s2v-detect": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "animate-anyone-detect-gen2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "emo-detect-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "liveportrait-detect": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "emoji-detect-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-mt-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-voice-enrollment": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-voice-design": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-instruct-flash-2026-01-26": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash-2025-11-27": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash-2025-09-18": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime-2026-01-22": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vd-realtime-2026-01-15": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vd-realtime-2025-12-16": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vc-realtime-2026-01-15": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vc-realtime-2025-11-27": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash-realtime-2025-11-27": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash-realtime-2025-09-18": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3.5-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3.5-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-latest": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-2025-05-22": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-2025-04-10": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-realtime-latest": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-realtime-2025-07-15": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-filetrans-2025-11-17": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-2025-09-08": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-2025-09-08-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-realtime-2026-02-10": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-realtime-2025-10-27": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-2025-11-07": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-2025-08-25": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-mtl": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-mtl-2025-08-25": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-realtime-2025-11-07": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-flash-8k-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-8k-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-realtime-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-livetranslate-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-omni-flash-2025-09-15-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-embedding": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -488,10 +488,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.000016
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.000064
         },
         "reasoning_token": {
           "price": 0.00084
@@ -518,10 +518,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0035
         },
         "response_token": {
-          "price": 0.0000035
+          "price": 0.0035
         }
       }
     }
@@ -650,10 +650,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00012
         }
       }
     }
@@ -662,10 +662,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00012
         }
       }
     }
@@ -721,7 +721,6 @@
       }
     }
   },
-
   "qwen3-vl-30b-a3b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -840,10 +839,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.000058
+          "price": 0.0000861
         }
       }
     }
@@ -852,10 +851,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.0000861
         }
       }
     }
@@ -960,10 +959,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.00008
         },
         "reasoning_token": {
           "price": 0.00084
@@ -1023,10 +1022,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000861
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.0003441
+          "price": 0.0006
         }
       }
     }
@@ -1320,10 +1319,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000043
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000072
+          "price": 0.000016
         }
       }
     }
@@ -1500,10 +1499,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000058
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000023
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.0003584
@@ -1638,10 +1637,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000502
+          "price": 0.00035
         },
         "response_token": {
-          "price": 0.0001004
+          "price": 0.0007
         }
       }
     }
@@ -1650,10 +1649,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000502
+          "price": 0.00035
         },
         "response_token": {
-          "price": 0.0001004
+          "price": 0.0007
         }
       }
     }
@@ -1662,10 +1661,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000502
+          "price": 0.00035
         },
         "response_token": {
-          "price": 0.0001004
+          "price": 0.0007
         }
       }
     }
@@ -1674,10 +1673,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.0002
         }
       }
     }
@@ -1686,10 +1685,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.0002
         }
       }
     }
@@ -1698,10 +1697,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.0002
         }
       }
     }
@@ -1885,6 +1884,1986 @@
         },
         "response_token": {
           "price": 0.0002294
+        }
+      }
+    }
+  },
+  "qwen-plus-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen-plus-2025-12-01-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen-flash-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-flash-2025-07-28-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3-4b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-1.7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-0.6b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-thinking-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.00023
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.000092
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-thinking-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00008
+        }
+      }
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00036
+        }
+      }
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00032
+        }
+      }
+    }
+  },
+  "qwen3.5-27b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00056
+        }
+      }
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00007
+        },
+        "response_token": {
+          "price": 0.00028
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.00014
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000175
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000805
+        },
+        "response_token": {
+          "price": 0.000322
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000368
+        },
+        "response_token": {
+          "price": 0.000147
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2026-01-22-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2025-10-15-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-vl-ocr-2025-08-28": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000016
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00028
+        },
+        "response_token": {
+          "price": 0.00084
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00042
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.000105
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000021
+        },
+        "response_token": {
+          "price": 0.000063
+        }
+      }
+    }
+  },
+  "qwen2.5-math-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "qwen2.5-math-1.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "qwen-doc-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000087
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "qwen-deep-research": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0007742
+        },
+        "response_token": {
+          "price": 0.0023367
+        }
+      }
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000058
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "text-embedding-v4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-rerank": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gte-rerank-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3.2-exp": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000431
+        }
+      }
+    }
+  },
+  "deepseek-v3.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "deepseek-r1-0528": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0002294
+        }
+      }
+    }
+  },
+  "deepseek-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0001147
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-14b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000431
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-2.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-max-2025-12-30": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-plus-2026-01-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max-2026-01-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus-2025-12-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus-2025-10-30": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4.5
+        },
+        "response_token": {
+          "price": 4.5
+        }
+      }
+    }
+  },
+  "z-image-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 1.5
+        }
+      }
+    }
+  },
+  "wan2.6-t2i": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.5-t2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.6-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.5-i2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.6-t2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.6
+        },
+        "response_token": {
+          "price": 3.6
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-t2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.6-i2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 1.5
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.2-kf2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 1.5
+        }
+      }
+    }
+  },
+  "wan2.1-kf2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-r2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan.6-r2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.1-vace-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.2-animate-move": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 12
+        },
+        "response_token": {
+          "price": 12
+        }
+      }
+    }
+  },
+  "wan2.2-animate-mix": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 18
+        },
+        "response_token": {
+          "price": 18
+        }
+      }
+    }
+  },
+  "wan2.2-s2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.1677
+        },
+        "response_token": {
+          "price": 7.1677
+        }
+      }
+    }
+  },
+  "animate-anyone-template-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "animate-anyone-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "emo-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "liveportrait": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.2868
+        },
+        "response_token": {
+          "price": 0.2868
+        }
+      }
+    }
+  },
+  "emoji-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "videoretalk": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "video-style-transform": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.8671
+        },
+        "response_token": {
+          "price": 2.8671
+        }
+      }
+    }
+  },
+  "wan2.2-s2v-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "animate-anyone-detect-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "emo-detect-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "liveportrait-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "emoji-detect-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "qwen-mt-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0431
+        },
+        "response_token": {
+          "price": 0.0431
+        }
+      }
+    }
+  },
+  "qwen-voice-enrollment": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1
+        },
+        "response_token": {
+          "price": 1
+        }
+      }
+    }
+  },
+  "qwen-voice-design": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 20
+        },
+        "response_token": {
+          "price": 20
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-09-18": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143
+        },
+        "response_token": {
+          "price": 0.00143
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143
+        },
+        "response_token": {
+          "price": 0.00143
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-realtime-2026-01-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143353
+        },
+        "response_token": {
+          "price": 0.00143353
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-realtime-2025-12-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143353
+        },
+        "response_token": {
+          "price": 0.00143353
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime-2026-01-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime-2025-09-18": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0026
+        },
+        "response_token": {
+          "price": 0.0026
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "cosyvoice-v3.5-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0022
+        },
+        "response_token": {
+          "price": 0.0022
+        }
+      }
+    }
+  },
+  "cosyvoice-v3.5-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00116
+        },
+        "response_token": {
+          "price": 0.00116
+        }
+      }
+    }
+  },
+  "cosyvoice-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00286706
+        },
+        "response_token": {
+          "price": 0.00286706
+        }
+      }
+    }
+  },
+  "qwen-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-2025-05-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-2025-04-10": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000345
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000345
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime-2025-07-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000345
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans-2025-11-17": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime-2026-02-10": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime-2025-10-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "fun-asr": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-2025-08-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-mtl": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-mtl-2025-08-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "fun-asr-realtime-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "fun-asr-flash-8k-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0032
+        },
+        "response_token": {
+          "price": 0.0032
+        }
+      }
+    }
+  },
+  "paraformer-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "paraformer-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "paraformer-realtime-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen3-livetranslate-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001577
+        },
+        "response_token": {
+          "price": 0.0001577
+        }
+      }
+    }
+  },
+  "qwen3-omni-flash-2025-09-15-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000052
+        },
+        "response_token": {
+          "price": 0.000199
+        }
+      }
+    }
+  },
+  "qwen3-vl-embedding": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: dashscope

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 165 |
| 🔄 Models updated (merged) | 16 |

### ➕ New Models
- `qwen-plus-us`
- `qwen-plus-2025-12-01-us`
- `qwen-flash-latest`
- `qwen-flash-us`
- `qwen-flash-2025-07-28-us`
- `qwen3-4b`
- `qwen3-1.7b`
- `qwen3-0.6b`
- `qwen3-235b-a22b-thinking-2507`
- `qwen3-235b-a22b-instruct-2507`
- `qwen3-30b-a3b-thinking-2507`
- `qwen3-30b-a3b-instruct-2507`
- `qwen3.5-397b-a17b`
- `qwen3.5-122b-a10b`
- `qwen3.5-27b`
- `qwen3.5-35b-a3b`
- `qwen2.5-72b-instruct`
- `qwen2.5-32b-instruct`
- `qwen2.5-14b-instruct`
- `qwen2.5-7b-instruct`
- ... and 145 more

### 🔄 Updated Models
- `qwen3-max-2025-09-23`
- `qwen3-32b`
- `qwen3-30b-a3b`
- `qwen3-next-80b-a3b-thinking`
- `qwen3-next-80b-a3b-instruct`
- `qwen-vl-ocr-latest`
- `qwq-32b`
- `qwq-32b-preview`
- `qwen-coder-plus`
- `qwen-coder-plus-latest`
- `qwen-coder-plus-2024-11-06`
- `qwen-coder-turbo`
- `qwen-coder-turbo-latest`
- `qwen-coder-turbo-2024-09-19`
- `qwen-omni-turbo-2025-01-19`
- `qwen3-asr-flash`


## Data Sources

| Source | URL | Coverage |
|--------|-----|----------|
| Models page | https://www.alibabacloud.com/help/en/model-studio/models | Commercial Qwen models, tiers, snapshots |
| Model pricing page | https://www.alibabacloud.com/help/en/model-studio/model-pricing | Open-source, TTS, ASR, video, image, embeddings, third-party |

## Model Families Covered (282 models)

- **Text generation (commercial):** qwen3-max, qwen3.5-plus, qwen-plus, qwen3.5-flash, qwen-flash, qwen-turbo, qwq-plus, qwen-long + snapshots + US variants
- **Text generation (open-source):** Qwen3 (235b–0.6b), Qwen3.5 (397b–35b), Qwen2.5 (72b–7b), Qwen3-next variants
- **Vision-language (commercial):** qwen3-vl-plus, qwen3-vl-flash + snapshots + US variants, qwen-vl-max, qwen-vl-plus, qwen-vl-ocr
- **Vision-language (open-source):** qwen3-vl (235b–8b), qwen2.5-vl (72b–3b), qvq-max, qvq-plus, qwq-32b
- **Omni/multimodal:** qwen3-omni-flash, qwen3.5-omni-plus/flash (free), qwen-omni-turbo, qwen2.5-omni-7b, qwen3-omni-30b-a3b-captioner
- **Realtime omni:** qwen3-omni-flash-realtime, qwen-omni-turbo-realtime
- **Code:** qwen3-coder-plus/flash, qwen3-coder-480b/30b, qwen-coder-plus/turbo
- **Math:** qwen-math-plus/turbo, qwen2.5-math (72b–1.5b)
- **Translation:** qwen-mt-plus/flash/lite/turbo
- **Domain-specific:** qwen-doc-turbo, qwen-deep-research (per_thousand_tokens), qwen-plus/flash-character, tongyi-intent-detect-v3
- **Image generation:** qwen-image (2.0-pro, 2.0, max, plus), qwen-image-edit, z-image-turbo, wan2.x-t2i, wan2.x-i2i
- **Video generation:** wan2.x-t2v, wan2.x-i2v, wan2.x-kf2v, wan2.x-r2v, wan2.1-vace-plus, US variants
- **Digital human/animation:** wan2.2-s2v/detect, animate-anyone-gen2, emo-v1, liveportrait, emoji-v1, videoretalk, video-style-transform
- **TTS:** qwen3-tts (instruct-flash, vd, vc, flash + realtime variants), qwen-tts-flash/realtime, cosyvoice-v3/v3.5/v2, voice enrollment/design
- **ASR:** qwen3-asr-flash (filetrans, realtime, US), fun-asr (mtl, realtime, 8k), paraformer-v2 family
- **LiveTranslate:** qwen3-livetranslate-flash-realtime + snapshot
- **Embeddings:** text-embedding-v4/v3, tongyi-embedding-vision-plus/flash, qwen3-vl-embedding
- **Reranking:** qwen3-rerank, gte-rerank-v2
- **Third-party hosted:** deepseek-v3/r1 family, kimi-k2/k2.5, Moonshot-Kimi-K2-Instruct, MiniMax-M2.5, glm-5/4.7/4.6

## Pricing Rules Applied
- Priority: International → Global → Chinese Mainland/other (one region per model_id)
- Tiered pricing: lowest tier used as default
- Non-thinking output rates used as default where both modes exist
- `qwen-deep-research`: per_thousand_tokens exception applied ($0.007742/$0.023367)
- TTS: per_million_characters (scaled from $/10K chars × 100)
- Video/ASR: per_second
- Image gen: per_image

---
*Generated by Pricing Agent on 2026-04-10*