### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,340 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-pro-computer-use-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-mini-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "o1-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "o1-mini-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3.1-70b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3.1-8b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3-70b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3-8b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama2-70b-chat-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama2-7b-chat-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama2-13b-chat-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "codellama-34b-instruct-hf": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "codellama-7b-instruct-hf": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "codellama-13b-instruct-hf": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3.2-90b-vision-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3.2-11b-vision-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3.2-3b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3.2-1b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3-8b-instruct-256k": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3-70b-instruct-256k": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-guard-3-8b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mistral-medium-3-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mistral-small-3-1-25-03-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "codestral-2-25-07-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mistral-large-2-25-01-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mistral-nemo-2407-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mistral-7b-instruct-v0-3-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mixtral-8x7b-instruct-v0-1-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "pixtral-large-25-02-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "codestral-2501-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3-1-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3-2-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-zero-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v2-5-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v2-chat-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-lite-preview-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3-0324-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-next-80b-thinking-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-next-80b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-235b-a22b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-72b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-coder-32b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-vl-72b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-72b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwq-32b-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-coder-7b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-vl-7b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-7b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-72b-instruct-2501-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "minimax-text-01-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "kimi-k1-5-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "kimi-latest-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4-7-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4-9b-chat-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4-plus-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4v-plus-0111-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4v-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-image-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "jamba-large-1-6-maas": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -550,7 +550,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -630,7 +630,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -984,6 +984,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -1015,6 +1018,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -1082,7 +1088,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -1114,6 +1126,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -1201,7 +1216,7 @@
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
@@ -1294,10 +1309,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1305,15 +1320,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1322,10 +1343,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
@@ -1445,7 +1466,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000025
         }
       },
       "batch_config": {
@@ -1482,7 +1509,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "finetune_config": {
@@ -1524,7 +1551,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "finetune_config": {
@@ -1560,10 +1587,13 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.000025
         }
       },
       "finetune_config": {
@@ -1602,7 +1632,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00003125
         }
       },
       "finetune_config": {
@@ -1641,7 +1671,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -2295,7 +2325,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2522,7 +2552,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2577,6 +2607,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2682,7 +2715,7 @@
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
@@ -2693,6 +2726,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2761,6 +2797,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2792,7 +2831,13 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -3515,6 +3560,959 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-computer-use-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "gpt-4o-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gpt-4o-mini-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "o1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "o1-mini-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000125
+        },
+        "response_token": {
+          "price": 0.000035
+        }
+      }
+    }
+  },
+  "llama-3.1-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.1-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama2-70b-chat-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama2-7b-chat-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama2-13b-chat-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "codellama-34b-instruct-hf": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "codellama-7b-instruct-hf": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "codellama-13b-instruct-hf": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.2-90b-vision-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.2-11b-vision-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.2-3b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.2-1b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3-8b-instruct-256k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3-70b-instruct-256k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-guard-3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-medium-3-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "mistral-small-3-1-25-03-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "codestral-2-25-07-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "mistral-large-2-25-01-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-nemo-2407-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-7b-instruct-v0-3-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mixtral-8x7b-instruct-v0-1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "pixtral-large-25-02-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "codestral-2501-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3-1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00017
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000085
+        }
+      }
+    }
+  },
+  "deepseek-v3-2-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.0000056
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "deepseek-r1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r1-zero-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v2-5-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v2-chat-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r1-lite-preview-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3-0324-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-next-80b-thinking-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen3-next-80b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-72b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-coder-32b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-vl-72b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-72b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwq-32b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-coder-7b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-vl-7b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-7b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-72b-instruct-2501-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "minimax-text-01-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "kimi-k1-5-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "kimi-latest-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-7-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        }
+      }
+    }
+  },
+  "glm-4-9b-chat-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-plus-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4v-plus-0111-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4v-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-image-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "jamba-large-1-6-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 69 |
| 🔄 Models updated (merged) | 21 |

### ➕ New Models
- `gemini-2.5-pro-preview-06-05`
- `gemini-2.5-pro-computer-use-preview`
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `gemini-2.0-flash-image-generation`
- `gemma-4-26b-a4b-it-maas`
- `veo-3.1-lite-generate-001`
- `gpt-4o-maas`
- `gpt-4o-mini-maas`
- `o1-maas`
- `o1-mini-maas`
- `llama-4-scout-17b-16e-instruct-maas`
- `llama-3.1-70b-instruct-maas`
- `llama-3.1-8b-instruct-maas`
- `llama-3-70b-instruct-maas`
- `llama-3-8b-instruct-maas`
- `llama2-70b-chat-001`
- `llama2-7b-chat-001`
- `llama2-13b-chat-001`
- `codellama-34b-instruct-hf`
- ... and 49 more

### 🔄 Updated Models
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-image-preview`
- `gemini-3.1-flash-lite-preview`
- `gemini-3-pro-preview`
- `gemini-3-pro-image-preview`
- `gemini-3-flash-preview`
- `gemini-2.5-pro`
- `gemini-2.5-flash`
- `gemini-2.5-flash-preview-05-20`
- `gemini-2.5-flash-image`
- `gemini-2.5-flash-lite`
- `gemini-2.5-flash-lite-preview-06-17`
- `gemini-2.0-flash-001`
- `gemini-2.0-flash`
- `gemini-2.0-flash-lite-001`
- `gemini-2.0-flash-lite`
- `veo-3.1-fast-generate-001`
- `veo-3.0-fast-generate-001`
- `text-embedding-004`
- `textembedding-gecko-multilingual@001`
- `multimodalembedding@001`


## Model-to-Pricing-Page Mapping

### Google – Gemini 3.x
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-3.1-pro-preview` | Google – Gemini 3.1 | API | Input $2/$12, grounding $14/1000 |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3.1 | API | Input $0.50/$3, image output $60/1M |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3.1 | API | Input $0.25/$1.50 |
| `gemini-3-pro-preview` | Google – Gemini 3 | API | Input $2/$12 |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API | Input $2/$12, image output $120/1M |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | Input $0.50/$3 |

### Google – Gemini 2.5
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 Pro | API | $1.25/$10, cache $0.3125, batch $0.625/$5, grounding $35/1000, enterprise $45/1000 |
| `gemini-2.5-pro-preview-06-05` | Google – Gemini 2.5 Pro | API | Same pricing as gemini-2.5-pro (preview alias) |
| `gemini-2.5-pro-computer-use-preview` | Google – Gemini 2.5 Pro | API | Same pricing as gemini-2.5-pro |
| `gemini-2.5-flash` | Google – Gemini 2.5 Flash | API | $0.30/$2.50, cache $0.075, batch $0.15/$1.25 |
| `gemini-2.5-flash-preview-05-20` | Google – Gemini 2.5 Flash | API | Same pricing as gemini-2.5-flash (preview alias) |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 Flash | API | $0.30/$2.50, image output $30/1M |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 Flash Lite | API | $0.10/$0.40, cache $0.025, batch $0.05/$0.20 |
| `gemini-2.5-flash-lite-preview-06-17` | Google – Gemini 2.5 Flash Lite | API | Same as flash-lite (preview alias) |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API – price not found | TTS variant, no dedicated pricing row; added with price 0 |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API – price not found | TTS variant, no dedicated pricing row; added with price 0 |

### Google – Gemini 2.0
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.0-flash-001` | Google – Gemini 2.0 Flash | API | $0.15/$0.60, batch $0.075/$0.30 |
| `gemini-2.0-flash` | Google – Gemini 2.0 Flash | API | Alias for gemini-2.0-flash-001 |
| `gemini-2.0-flash-image-generation` | Google – Gemini 2.0 Flash | API | $0.15/$0.60, image output $30/1M |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 Flash Lite | API | $0.075/$0.30, batch $0.0375/$0.15 |
| `gemini-2.0-flash-lite` | Google – Gemini 2.0 Flash Lite | API | Alias for gemini-2.0-flash-lite-001 |

### Google – Gemma
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemma-4-26b-a4b-it-maas` | Google – Gemma | API | $0.15/$0.60 (free until Apr 16, 2026) |

### Google – Imagen
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `imagen-4.0-ultra-generate-001` | Google – Imagen | API | $0.06/image |
| `imagen-4.0-generate-001` | Google – Imagen | API | $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen | API | $0.02/image |
| `imagen-3.0-generate-002` | Google – Imagen | API | $0.04/image |
| `imagen-3.0-generate-001` | Google – Imagen | API | $0.04/image |
| `imagen-3.0-fast-generate-001` | Google – Imagen | API | $0.02/image |
| `imagen-3.0-capability-001` | Google – Imagen | API | Capability model; uses imagen-3.0-generate price $0.04/image |
| `imagen-3.0-capability-002` | Google – Imagen | API | Capability model; uses imagen-3.0-generate price $0.04/image |

### Google – Veo
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `veo-3.1-generate-001` | Google – Veo | API | $0.20/sec video-only 720p/1080p (video+audio $0.40/sec) |
| `veo-3.1-fast-generate-001` | Google – Veo | API | $0.08/sec video-only 720p |
| `veo-3.1-lite-generate-001` | Google – Veo | API | $0.03/sec video-only 720p |
| `veo-3.0-generate-001` | Google – Veo | API | $0.20/sec video-only 720p/1080p |
| `veo-3.0-fast-generate-001` | Google – Veo | API | $0.08/sec video-only 720p |
| `veo-2.0-generate-001` | Google – Veo | API | $0.50/sec |

### Google – Embeddings
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `text-embedding-005` | Google – Embeddings | API | $0.000025/1K chars (per_thousand_tokens) |
| `text-embedding-004` | Google – Embeddings | API | $0.000025/1K chars (per_thousand_tokens) |
| `text-multilingual-embedding-002` | Google – Embeddings | API | $0.000025/1K chars (per_thousand_tokens) |
| `textembedding-gecko@003` | Google – Embeddings | API | $0.000025/1K chars (per_thousand_tokens) |
| `textembedding-gecko-multilingual@001` | Google – Embeddings | API | $0.000025/1K chars (per_thousand_tokens) |
| `gemini-embedding-001` | Google – Embeddings | API | $0.00015/1K tokens (per_thousand_tokens) |
| `multimodalembedding@001` | Google – Embeddings | API | Text $0.0002/1K chars + image $0.0001/image + video additional |

### Anthropic – Claude
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `claude-opus-4-6` | Anthropic – Claude | API | $5/$25, cache_write $6.25, cache_read $0.50, batch $2.50/$12.50; @default stripped |
| `claude-sonnet-4-6` | Anthropic – Claude | API | $3/$15, cache_write $3.75, cache_read $0.30, batch $1.50/$7.50; @default stripped |
| `claude-opus-4-5@20251101` | Anthropic – Claude | API | $5/$25, cache_write $6.25, cache_read $0.50, batch $2.50/$12.50 |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude | API | $3/$15, cache_write $3.75, cache_read $0.30, batch $1.50/$7.50 |
| `claude-haiku-4-5@20251001` | Anthropic – Claude | API | $1/$5, cache_write $1.25, cache_read $0.10, batch $0.50/$2.50 |
| `claude-opus-4-1@20250805` | Anthropic – Claude | API | $15/$75, cache_write $18.75, cache_read $1.50, batch $7.50/$37.50 |
| `claude-opus-4@20250514` | Anthropic – Claude | API | $15/$75, cache_write $18.75, cache_read $1.50, batch $7.50/$37.50 |
| `claude-sonnet-4@20250514` | Anthropic – Claude | API | $3/$15, cache_write $3.75, cache_read $0.30, batch $1.50/$7.50 |

### OpenAI – GPT
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gpt-oss-120b-maas` | OpenAI | API | $0.09/$0.36, batch $0.045/$0.18 |
| `gpt-4o-maas` | OpenAI | API – price not found | No pricing row; added with price 0 |
| `gpt-4o-mini-maas` | OpenAI | API – price not found | No pricing row; added with price 0 |
| `o1-maas` | OpenAI | API – price not found | No pricing row; added with price 0 |
| `o1-mini-maas` | OpenAI | API – price not found | No pricing row; added with price 0 |

### Meta – Llama
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama | API | $0.35/$1.15, batch $0.175/$0.575 |
| `llama-4-scout-17b-16e-instruct-maas` | Meta – Llama | API | $0.25/$0.70, batch $0.125/$0.35 |
| `llama-3.3-70b-instruct-maas` | Meta – Llama | API | $0.72/$0.72, batch $0.36/$0.36 |
| `llama-3.1-405b-instruct-maas` | Meta – Llama | API | $5/$16 |
| `llama-3.1-70b-instruct-maas` | Meta – Llama | API – price not found | No dedicated row; added with price 0 |
| `llama-3.1-8b-instruct-maas` | Meta – Llama | API – price not found | No dedicated row; added with price 0 |
| `llama-3-70b-instruct-maas` | Meta – Llama | API – price not found | No dedicated row; added with price 0 |
| `llama-3-8b-instruct-maas` | Meta – Llama | API – price not found | No dedicated row; added with price 0 |
| `llama2-70b-chat-001` | Meta – Llama | API – price not found | Legacy; added with price 0 |
| `llama2-7b-chat-001` | Meta – Llama | API – price not found | Legacy; added with price 0 |
| `llama2-13b-chat-001` | Meta – Llama | API – price not found | Legacy; added with price 0 |
| `codellama-34b-instruct-hf` | Meta – Llama | API – price not found | Legacy CodeLlama; added with price 0 |
| `codellama-7b-instruct-hf` | Meta – Llama | API – price not found | Legacy CodeLlama; added with price 0 |
| `codellama-13b-instruct-hf` | Meta – Llama | API – price not found | Legacy CodeLlama; added with price 0 |
| `llama-3.2-90b-vision-instruct-maas` | Meta – Llama | API – price not found | No dedicated row; added with price 0 |
| `llama-3.2-11b-vision-instruct-maas` | Meta – Llama | API – price not found | No dedicated row; added with price 0 |
| `llama-3.2-3b-instruct-maas` | Meta – Llama | API – price not found | No dedicated row; added with price 0 |
| `llama-3.2-1b-instruct-maas` | Meta – Llama | API – price not found | No dedicated row; added with price 0 |
| `llama-3-8b-instruct-256k` | Meta – Llama | API – price not found | Legacy; added with price 0 |
| `llama-3-70b-instruct-256k` | Meta – Llama | API – price not found | Legacy; added with price 0 |
| `llama-guard-3-8b` | Meta – Llama | API – price not found | Guard model (included per global rules); added with price 0 |

### Mistral AI
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `mistral-medium-3-maas` | Mistral AI | API | $0.40/$2.00 |
| `mistral-small-3-1-25-03-maas` | Mistral AI | API | $0.10/$0.30 |
| `codestral-2-25-07-maas` | Mistral AI | API | $0.30/$0.90 |
| `mistral-large-2-25-01-maas` | Mistral AI | API – price not found | No dedicated row; added with price 0 |
| `mistral-nemo-2407-maas` | Mistral AI | API – price not found | No dedicated row; added with price 0 |
| `mistral-7b-instruct-v0-3-maas` | Mistral AI | API – price not found | Legacy; added with price 0 |
| `mixtral-8x7b-instruct-v0-1-maas` | Mistral AI | API – price not found | Legacy; added with price 0 |
| `pixtral-large-25-02-maas` | Mistral AI | API – price not found | No dedicated row; added with price 0 |
| `codestral-2501-maas` | Mistral AI | API – price not found | Older Codestral; added with price 0 |

### DeepSeek
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `deepseek-v3-1-maas` | DeepSeek | API | $0.60/$1.70, cache_read $0.06, batch $0.30/$0.85 |
| `deepseek-v3-2-maas` | DeepSeek | API | $0.56/$1.68, cache_read $0.056, batch $0.28/$0.84 |
| `deepseek-r1-0528-maas` | DeepSeek | API | $1.35/$5.40, batch $0.675/$2.70 |
| `deepseek-r1-maas` | DeepSeek | API – price not found | No dedicated row; added with price 0 |
| `deepseek-r1-zero-maas` | DeepSeek | API – price not found | No dedicated row; added with price 0 |
| `deepseek-v3-maas` | DeepSeek | API – price not found | Older V3; added with price 0 |
| `deepseek-v2-5-maas` | DeepSeek | API – price not found | Legacy; added with price 0 |
| `deepseek-v2-chat-maas` | DeepSeek | API – price not found | Legacy; added with price 0 |
| `deepseek-r1-lite-preview-maas` | DeepSeek | API – price not found | Preview; added with price 0 |
| `deepseek-v3-0324-maas` | DeepSeek | API – price not found | Older V3 variant; added with price 0 |

### Qwen
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `qwen3-next-80b-thinking-maas` | Qwen | API | $0.15/$1.20 |
| `qwen3-next-80b-instruct-maas` | Qwen | API | $0.15/$1.20 |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen | API | $0.22/$1.80, cache_read $0.022, batch $0.11/$0.90 |
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen | API | $0.22/$0.88, batch $0.11/$0.44 |
| `qwen3-235b-a22b-instruct-maas` | Qwen | API – price not found | No dedicated row; added with price 0 |
| `qwen2-5-72b-instruct-maas` | Qwen | API – price not found | Added with price 0 |
| `qwen2-5-coder-32b-instruct-maas` | Qwen | API – price not found | Added with price 0 |
| `qwen2-5-vl-72b-instruct-maas` | Qwen | API – price not found | Added with price 0 |
| `qwen2-72b-instruct-maas` | Qwen | API – price not found | Legacy; added with price 0 |
| `qwq-32b-maas` | Qwen | API – price not found | Added with price 0 |
| `qwen2-5-coder-7b-instruct-maas` | Qwen | API – price not found | Added with price 0 |
| `qwen2-5-vl-7b-instruct-maas` | Qwen | API – price not found | Added with price 0 |
| `qwen2-5-7b-instruct-maas` | Qwen | API – price not found | Added with price 0 |
| `qwen2-5-72b-instruct-2501-maas` | Qwen | API – price not found | Added with price 0 |

### MiniMax
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `minimax-m2-maas` | MiniMax | API | $0.30/$1.20, cache_read $0.03 |
| `minimax-text-01-maas` | MiniMax | API – price not found | Added with price 0 |

### Moonshot / Kimi
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `kimi-k2-thinking-maas` | Moonshot/Kimi | API | $0.60/$2.50, cache_read $0.06 |
| `kimi-k1-5-maas` | Moonshot/Kimi | API – price not found | Added with price 0 |
| `kimi-latest-maas` | Moonshot/Kimi | API – price not found | Added with price 0 |

### ZAI.org / GLM
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `glm-4-7-maas` | ZAI.org – GLM | API | $0.60/$2.20 |
| `glm-5-maas` | ZAI.org – GLM | API | $1.00/$3.20, cache_read $0.10 |
| `glm-4-9b-chat-maas` | ZAI.org – GLM | API – price not found | Added with price 0 |
| `glm-4-plus-maas` | ZAI.org – GLM | API – price not found | Added with price 0 |
| `glm-4v-plus-0111-maas` | ZAI.org – GLM | API – price not found | Added with price 0 |
| `glm-4v-maas` | ZAI.org – GLM | API – price not found | Added with price 0 |
| `glm-image-maas` | ZAI.org – GLM | API – price not found | glm-image excluded per policy; added with price 0 |

### AI21
| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `jamba-large-1-6-maas` | AI21 | API – price not found | Self-deploy only on pricing page; no MaaS pricing row; added with price 0 |

### Excluded Models (not in output)
| Model | Reason |
|-------|--------|
| `*-live-*` (gemini-2.0-flash-live-preview, etc.) | Gemini Live streaming — excluded per rules |
| `lyria-*` | Music generation — excluded |
| `model-optimizer-*` | Dynamic routing meta-endpoint — excluded |
| `imagegeneration` | Legacy, superseded — excluded |
| `virtual-try-on-*` | Product-specific retail — excluded |
| `imagen-4.0-upscale-001` | Upscaling only, not generative inference |
| All `*-self-deploy` models | Self-deploy, no MaaS |

---
*Generated by Pricing Agent on 2026-04-11*