### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -838,6 +838,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -866,6 +869,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -917,10 +923,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -948,10 +954,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1159,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1187,10 +1193,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1395,10 +1401,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1432,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1525,14 +1531,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1556,14 +1565,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1587,7 +1599,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1608,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1633,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1642,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1693,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1727,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1872,29 +1884,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1903,29 +1915,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1934,23 +1946,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1968,23 +1980,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2080,10 +2092,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2114,10 +2126,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2281,10 +2293,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2312,10 +2324,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2343,10 +2355,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2374,10 +2386,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2395,29 +2407,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2426,29 +2438,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.00075
         }
       }
     }
@@ -2467,10 +2479,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2498,10 +2510,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2519,29 +2531,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2550,29 +2562,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2591,10 +2603,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2622,10 +2634,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2655,6 +2667,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2683,6 +2698,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -3174,7 +3192,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3232,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3256,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3301,40 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 0
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 0
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 36 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-2.5-flash-lte-128k`
- `gemini-2.5-flash-gt-128k`
- `gemini-2.5-pro-lte-128k`
- `gemini-2.5-pro-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.0-flash-lite-001-lte-128k`
- `gemini-2.0-flash-lite-001-gt-128k`
- `gemini-2.0-flash-lite-lte-128k`
- `gemini-2.0-flash-lite-gt-128k`
- `gemini-2.5-flash-lite-lte-128k`
- `gemini-2.5-flash-lite-gt-128k`
- `gemini-2.5-flash-image-lte-128k`
- `gemini-2.5-flash-image-gt-128k`
- `gemini-3-pro-preview-lte-128k`
- `gemini-3-pro-preview-gt-128k`
- `gemini-3-flash-preview-lte-128k`
- `gemini-3-flash-preview-gt-128k`
- `gemini-3.1-pro-preview-lte-128k`
- `gemini-3.1-pro-preview-gt-128k`
- `gemini-3.1-pro-preview-customtools-lte-128k`
- `gemini-3.1-pro-preview-customtools-gt-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-3-pro-image-preview-lte-128k`
- `gemini-3-pro-image-preview-gt-128k`
- `gemini-3.1-flash-image-preview-lte-128k`
- `gemini-3.1-flash-image-preview-gt-128k`
- ... and 6 more


### Data Source Note

**Primary source**: LiteLLM Model Prices JSON (`https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`) was used as a proxy for Google's live pricing page. The official Google pricing page (`https://ai.google.dev/gemini-api/docs/pricing`) was inaccessible due to Firecrawl credit exhaustion. All prices should be verified against the live Google pricing page.

### *-latest Alias Resolution

| Alias | Resolved To | Method |
|-------|------------|--------|
| `gemini-flash-latest` | `gemini-2.5-flash` pricing ($0.30/$2.50 per 1M) | LiteLLM data (could not verify from live page) |
| `gemini-flash-lite-latest` | `gemini-2.5-flash-lite` pricing ($0.10/$0.40 per 1M) | LiteLLM data (could not verify from live page) |
| `gemini-pro-latest` | `gemini-2.5-pro` pricing ($1.25/$10.00 per 1M ≤200K) | LiteLLM data (could not verify from live page) |

### Model → Pricing Page Mapping

| Model ID | Pricing section | Notes |
|----------|-----------------|-------|
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat | input $0.30, output $2.50, cache_read $0.03, batch 0.15/1.25 /1M, web_search $0.35/1K |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat | same as lte (flat pricing) |
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | input $1.25, output $10.00, cache_read $0.125, batch 0.625/5.00 /1M |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | input $2.50, output $15.00, cache_read $0.25, batch 1.25/7.50 /1M |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat | input $0.10, output $0.40, cache_read $0.025, batch 0.05/0.20 /1M |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat | same as lte (flat pricing) |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash 001, flat | input $0.10, output $0.40, cache_read $0.025, batch 0.05/0.20 /1M |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash 001, flat | same as lte (flat pricing) |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash Lite 001, flat | input $0.075, output $0.30, cache_read $0.01875 /1M |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash Lite 001, flat | same as lte (flat pricing) |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash Lite, flat | input $0.075, output $0.30, cache_read $0.01875 /1M |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash Lite, flat | same as lte (flat pricing) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash Lite, flat | input $0.10, output $0.40, cache_read $0.01 /1M |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash Lite, flat | same as lte (flat pricing) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat | input $0.30, text output $2.50, image_token $30/1M, batch 0.15/1.25 /1M |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat | same as lte (flat pricing) |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K | input $2.00, output $12.00, cache_read $0.20 /1M |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K | input $4.00, output $18.00, cache_read $0.40 /1M |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, flat | input $0.50, output $3.00, cache_read $0.05 /1M |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, flat | same as lte (flat pricing) |
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K | input $2.00, output $12.00, cache_read $0.20 /1M |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K | input $4.00, output $18.00, cache_read $0.40 /1M |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview CustomTools, ≤200K | same as 3.1-pro-preview |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview CustomTools, >200K | same as 3.1-pro-preview gt |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash Lite Preview, flat | input $0.25, output $1.50, cache_read $0.025 /1M |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash Lite Preview, flat | same as lte (flat pricing) |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview, flat | input $2.00, text output $12.00, image_token $120/1M, batch 1.00/6.00 /1M |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview, flat | same as lte (flat pricing) |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview, flat | input $0.25, text output $1.50, image_token $60/1M, batch 0.125/0.75 /1M |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview, flat | same as lte (flat pricing) |
| gemini-flash-latest-lte-128k | *-latest → resolved to gemini-2.5-flash (LiteLLM) | input $0.30, output $2.50 /1M |
| gemini-flash-latest-gt-128k | *-latest → resolved to gemini-2.5-flash (LiteLLM) | same as lte |
| gemini-flash-lite-latest-lte-128k | *-latest → resolved to gemini-2.5-flash-lite (LiteLLM) | input $0.10, output $0.40 /1M |
| gemini-flash-lite-latest-gt-128k | *-latest → resolved to gemini-2.5-flash-lite (LiteLLM) | same as lte |
| gemini-pro-latest-lte-128k | *-latest → resolved to gemini-2.5-pro (LiteLLM) | input $1.25, output $10.00 /1M ≤200K |
| gemini-pro-latest-gt-128k | *-latest → resolved to gemini-2.5-pro (LiteLLM) | input $2.50, output $15.00 /1M >200K |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | input $0.15/1M, output 0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 | same as lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview | input $0.20/1M, output 0 |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview | same as lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4.0 Generate 001 | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4.0 Generate 001 | same as lte |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4.0 Ultra Generate 001 | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4.0 Ultra Generate 001 | same as lte |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4.0 Fast Generate 001 | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4.0 Fast Generate 001 | same as lte |
| veo-2.0-generate-001-lte-128k | Veo 2.0 Generate 001 | $0.35/s, default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2.0 Generate 001 | same as lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0 Generate 001 | $0.40/s, default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3.0 Generate 001 | same as lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast Generate 001 | $0.15/s, default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast Generate 001 | same as lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Generate Preview | $0.40/s, default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Generate Preview | same as lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast Generate Preview | $0.15/s, default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast Generate Preview | same as lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite Generate Preview | price not found (0s); needs verification |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite Generate Preview | price not found (0s); needs verification |

---
*Generated by Pricing Agent on 2026-04-11*