### PR TITLE
chore(pricing): Update cohere pricing

### DIFF
--- a/general/cohere.json
+++ b/general/cohere.json
@@ -194,5 +194,55 @@
     "type": {
       "primary": "chat"
     }
+  },
+  "command-r7b-arabic-02-2025": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-fire": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-water": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-earth": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-global": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "embed-english-v3.0-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cohere-transcribe-03-2026": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -256,7 +256,271 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.25
+          "price": 0.2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "command-a-03-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-vision-07-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-reasoning-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-translate-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-plus-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "command-r7b-12-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r7b-arabic-02-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "c4ai-aya-expanse-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-vision-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-fire": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-water": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-earth": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-global": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "embed-v4.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cohere-transcribe-03-2026": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.2
         },
         "response_token": {
           "price": 0


### PR DESCRIPTION
## 🔄 Pricing Update: cohere

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 22 |
| 🔄 Models updated (merged) | 1 |

### ➕ New Models
- `command-a-03-2025`
- `command-a-vision-07-2025`
- `command-a-reasoning-08-2025`
- `command-a-translate-08-2025`
- `command-r-plus-08-2024`
- `command-r-08-2024`
- `command-r7b-12-2024`
- `command-r7b-arabic-02-2025`
- `c4ai-aya-expanse-32b`
- `c4ai-aya-vision-32b`
- `tiny-aya-fire`
- `tiny-aya-water`
- `tiny-aya-earth`
- `tiny-aya-global`
- `embed-v4.0`
- `embed-english-light-v3.0`
- `embed-multilingual-light-v3.0`
- `embed-english-v3.0-image`
- `embed-multilingual-v3.0-image`
- `embed-english-light-v3.0-image`
- ... and 2 more

### 🔄 Updated Models
- `rerank-v4.0-pro`


## Model-to-Pricing Mapping

### Generative / Chat Models ($/1M tokens)
| Model ID | Input | Output | Notes |
|----------|-------|--------|-------|
| command-a-03-2025 | $2.50 | $10.00 | Command A family |
| command-a-vision-07-2025 | $2.50 | $10.00 | Command A vision variant |
| command-a-reasoning-08-2025 | $2.50 | $10.00 | Command A reasoning variant |
| command-a-translate-08-2025 | $2.50 | $10.00 | Command A translate variant |
| command-r-plus-08-2024 | $2.50 | $10.00 | Command R+ latest |
| command-r-08-2024 | $0.15 | $0.60 | Command R latest |
| command-r7b-12-2024 | $0.037 | $0.15 | Command R7B |
| command-r7b-arabic-02-2025 | $0.037 | $0.15 | Command R7B Arabic |
| c4ai-aya-expanse-32b | $0.50 | $1.50 | Aya Expanse 32B |
| c4ai-aya-vision-32b | $0.50 | $1.50 | Aya Vision 32B |
| tiny-aya-fire/water/earth/global | $0.037 | $0.15 | Tiny Aya variants (R7B-class) |

### Embed Models ($/1M tokens, input only)
| Model ID | Input | Notes |
|----------|-------|-------|
| embed-v4.0 | $0.12 | Latest embed |
| embed-english-v3.0 / image | $0.10 | |
| embed-multilingual-v3.0 / image | $0.10 | |
| embed-english-light-v3.0 / image | $0.10 | |
| embed-multilingual-light-v3.0 / image | $0.10 | |

### Rerank Models ($2.00/1K searches = $0.002/search)
| Model ID | Price |
|----------|-------|
| rerank-v3.5 | $0.002/search |
| rerank-v4.0-fast | $0.002/search |
| rerank-v4.0-pro | $0.002/search |
| rerank-english-v3.0 | $0.002/search |
| rerank-multilingual-v3.0 | $0.002/search |

### Other
| Model ID | Notes |
|----------|-------|
| cohere-transcribe-03-2026 | Transcription model; priced as $0.002/request (no public per-token pricing found) |

## Data Sources
- Models: Cohere API (`/v2/models`) — 29 models
- Pricing: Skill reference table (cohere.com/pricing was JS-rendered; Firecrawl scrape failed due to insufficient credits)
- New models without explicit pricing (tiny-aya-*, command-a variants, rerank-v4.0, cohere-transcribe): assigned closest family pricing

---
*Generated by Pricing Agent on 2026-04-11*