### PR TITLE
chore(pricing): Update dashscope pricing

### DIFF
--- a/general/dashscope.json
+++ b/general/dashscope.json
@@ -632,5 +632,775 @@
   "qwen-mt-lite": {
     "params": [{ "key": "max_tokens", "maxValue": 8192 }],
     "type": { "primary": "chat" }
+  },
+  "qwen3-max-2025-04-28": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-plus-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-plus-2025-12-01-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-flash-latest": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-flash-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-flash-2025-07-28-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-deep-research": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-doc-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-math-72b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-math-1.5b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-vl-max-2025-01-25": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-vl-ocr-2025-08-28": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-flash-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-flash-2026-01-22-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-flash-2025-10-15-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-omni-plus-2026-03-15": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-omni-flash-2026-03-15": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-embedding-v4": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-embedding-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-embedding": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-rerank": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gte-rerank-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-rerank": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-3b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-1.5b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-0.5b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-235b-a22b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-72b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-72b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-30b-a3b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-14b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-8b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-4b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-4b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-1.7b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-1.7b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-0.6b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-0.6b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-72b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qvq-72b-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-vl-7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-vl-2b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3-0324": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-0528": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshot-v1-8k": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshot-v1-32k": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshot-v1-128k": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-latest": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-2025-05-22": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-2025-04-10": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-realtime-latest": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-tts-realtime-2025-07-15": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash-2025-11-27": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash-2025-09-18": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-instruct-flash-2026-01-26": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3.5-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v3.5-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cosyvoice-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-2025-09-08": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-filetrans-2025-11-17": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-2025-09-08-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-2025-11-07": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-2025-08-25": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-mtl": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-realtime-2025-11-07": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "fun-asr-flash-8k-realtime": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-8k-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-realtime-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-t2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-t2v-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-i2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-i2v-us": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-i2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-kf2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-kf2v-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-r2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan.6-r2v-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-vace-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-s2v": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-s2v-detect": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-animate-move": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-animate-mix": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "emo-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "liveportrait": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "emoji-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "videoretalk": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "video-style-transform": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-t2i": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-t2i-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-t2i-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.2-t2i-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2i-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.1-t2i-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.6-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "wan2.5-i2i-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0-pro-2026-03-03": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0-2026-03-03": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-max": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-max-2025-12-30": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-plus-2026-01-09": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-max": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-max-2026-01-16": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-edit": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "z-image-turbo": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "animate-anyone-gen2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "aitryon-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "aitryon-parsing-v1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-voice-enrollment": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-voice-design": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -125,10 +125,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000246
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.000737
+          "price": 0.00012
         }
       }
     }
@@ -137,10 +137,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000016
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000049
+          "price": 0.00002
         }
       }
     }
@@ -149,10 +149,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000027
+          "price": 0.00002
         },
         "request_audio_token": {
           "price": 0.000444
@@ -167,10 +167,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.00002
         },
         "request_audio_token": {
           "price": 0.000444
@@ -260,10 +260,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.00014
+          "price": 0.00012
         }
       }
     }
@@ -359,10 +359,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000021
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.000063
+          "price": 0.00012
         }
       }
     }
@@ -458,10 +458,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000035
+          "price": 0.000009
         },
         "response_token": {
-          "price": 0.00014
+          "price": 0.000036
         },
         "reasoning_token": {
           "price": 0.00042
@@ -473,10 +473,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.00024
         },
         "reasoning_token": {
           "price": 0.00084
@@ -503,10 +503,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000018
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00007
+          "price": 0.00002
         },
         "reasoning_token": {
           "price": 0.00021
@@ -518,10 +518,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0035
         },
         "response_token": {
-          "price": 0.0000035
+          "price": 0
         }
       }
     }
@@ -554,10 +554,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         }
       }
     }
@@ -566,10 +566,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         }
       }
     }
@@ -578,10 +578,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.00048
         }
       }
     }
@@ -590,10 +590,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.00048
         }
       }
     }
@@ -602,10 +602,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.000028
         },
         "request_audio_token": {
           "price": 0.001
@@ -674,10 +674,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000043
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000166
+          "price": 0.000028
         },
         "request_audio_token": {
           "price": 0.000381
@@ -692,10 +692,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000052
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000199
+          "price": 0.000028
         },
         "request_audio_token": {
           "price": 0.000457
@@ -721,7 +721,6 @@
       }
     }
   },
-
   "qwen3-vl-30b-a3b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -741,10 +740,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.00016
+          "price": 0.00012
         },
         "reasoning_token": {
           "price": 0.00048
@@ -792,10 +791,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000573
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.000258
+          "price": 0.0002
         }
       }
     }
@@ -804,10 +803,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000304
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0001213
+          "price": 0.00032
         }
       }
     }
@@ -840,10 +839,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.000058
+          "price": 0.00016
         }
       }
     }
@@ -948,10 +947,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00048
         }
       }
     }
@@ -960,10 +959,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.000009
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.000036
         },
         "reasoning_token": {
           "price": 0.00084
@@ -1050,10 +1049,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000028
         }
       }
     }
@@ -1062,10 +1061,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000028
         }
       }
     }
@@ -1074,10 +1073,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000028
         }
       }
     }
@@ -1086,10 +1085,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.00016
+          "price": 0.00012
         },
         "reasoning_token": {
           "price": 0.00048
@@ -1101,10 +1100,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.00016
+          "price": 0.00012
         },
         "reasoning_token": {
           "price": 0.00048
@@ -1116,10 +1115,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.00048
         }
       }
     }
@@ -1164,10 +1163,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.00024
         }
       }
     }
@@ -1176,10 +1175,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.00024
         }
       }
     }
@@ -1188,10 +1187,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.00024
         }
       }
     }
@@ -1248,10 +1247,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000021
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.000063
+          "price": 0.00012
         }
       }
     }
@@ -1284,10 +1283,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000021
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.000063
+          "price": 0.00012
         }
       }
     }
@@ -1320,10 +1319,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000043
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000072
+          "price": 0.000016
         }
       }
     }
@@ -1332,15 +1331,27 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.0004
+          "price": 0.00024
         }
       }
     }
   },
   "qwen3-vl-235b-a22b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3-vl-32b-thinking": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -1352,26 +1363,14 @@
       }
     }
   },
-  "qwen3-vl-32b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000016
-        },
-        "response_token": {
-          "price": 0.000064
-        }
-      }
-    }
-  },
   "qwen3-vl-32b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000016
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.000064
+          "price": 0.00016
         }
       }
     }
@@ -1380,10 +1379,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000009
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.000036
         }
       }
     }
@@ -1392,10 +1391,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000009
         },
         "response_token": {
-          "price": 0.00008
+          "price": 0.000036
         }
       }
     }
@@ -1404,10 +1403,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000018
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00021
+          "price": 0.00002
         }
       }
     }
@@ -1416,10 +1415,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000018
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00007
+          "price": 0.00002
         }
       }
     }
@@ -1452,10 +1451,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002294
+          "price": 0.000056
         },
         "response_token": {
-          "price": 0.0006881
+          "price": 0.000224
         }
       }
     }
@@ -1464,10 +1463,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000027
+          "price": 0.00002
         },
         "request_audio_token": {
           "price": 0.000444
@@ -1482,10 +1481,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000027
+          "price": 0.00002
         },
         "request_audio_token": {
           "price": 0.000444
@@ -1500,10 +1499,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000058
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000023
+          "price": 0.00002
         },
         "request_audio_token": {
           "price": 0.0003584
@@ -1518,10 +1517,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.00002
         },
         "request_audio_token": {
           "price": 0.000444
@@ -1536,10 +1535,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.00002
         },
         "request_audio_token": {
           "price": 0.000444
@@ -1554,10 +1553,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000043
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000166
+          "price": 0.000028
         },
         "request_audio_token": {
           "price": 0.000381
@@ -1572,10 +1571,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000043
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000166
+          "price": 0.000028
         },
         "request_audio_token": {
           "price": 0.000381
@@ -1626,10 +1625,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000381
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000306
+          "price": 0.000028
         }
       }
     }
@@ -1638,10 +1637,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000502
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0001004
+          "price": 0.00012
         }
       }
     }
@@ -1650,10 +1649,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000502
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0001004
+          "price": 0.00012
         }
       }
     }
@@ -1662,10 +1661,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000502
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0001004
+          "price": 0.00012
         }
       }
     }
@@ -1674,10 +1673,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.00002
         }
       }
     }
@@ -1686,10 +1685,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.00002
         }
       }
     }
@@ -1698,10 +1697,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.00002
         }
       }
     }
@@ -1710,10 +1709,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000574
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0001721
+          "price": 0.00012
         }
       }
     }
@@ -1722,10 +1721,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000574
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0001721
+          "price": 0.00012
         }
       }
     }
@@ -1734,10 +1733,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000574
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0001721
+          "price": 0.00012
         }
       }
     }
@@ -1758,10 +1757,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.00002
         }
       }
     }
@@ -1770,10 +1769,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.00002
         }
       }
     }
@@ -1782,10 +1781,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.00002
         }
       }
     }
@@ -1794,10 +1793,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.00014
+          "price": 0.00012
         }
       }
     }
@@ -1857,10 +1856,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000016
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000049
+          "price": 0.00004
         }
       }
     }
@@ -1869,10 +1868,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.0000007
         },
         "response_token": {
-          "price": 0.000036
+          "price": 0.0000028
         }
       }
     }
@@ -1881,10 +1880,1882 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000574
+          "price": 0.000055
         },
         "response_token": {
-          "price": 0.0002294
+          "price": 0.000219
+        }
+      }
+    }
+  },
+  "qwen3-max-2025-04-28": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00012
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "qwen-plus-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen-plus-2025-12-01-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen-flash-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-flash-2025-07-28-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-deep-research": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0007742
+        },
+        "response_token": {
+          "price": 0.0023367
+        }
+      }
+    }
+  },
+  "qwen-doc-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000288
+        }
+      }
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000288
+        }
+      }
+    }
+  },
+  "qwen2.5-math-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00008
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000024
+        }
+      }
+    }
+  },
+  "qwen2.5-math-1.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000024
+        }
+      }
+    }
+  },
+  "qwen-vl-max-2025-01-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00008
+        },
+        "response_token": {
+          "price": 0.00032
+        }
+      }
+    }
+  },
+  "qwen-vl-ocr-2025-08-28": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000016
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2026-01-22-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2025-10-15-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-v4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-vl-embedding": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-rerank": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gte-rerank-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-vl-rerank": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000224
+        }
+      }
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000224
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000014
+        },
+        "response_token": {
+          "price": 0.000056
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qwen2.5-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "qwen2.5-1.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "qwen2.5-0.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3-72b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00016
+        }
+      }
+    }
+  },
+  "qwen3-72b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00016
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000009
+        },
+        "response_token": {
+          "price": 0.000036
+        }
+      }
+    }
+  },
+  "qwen3-14b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000009
+        },
+        "response_token": {
+          "price": 0.000036
+        }
+      }
+    }
+  },
+  "qwen3-8b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qwen3-4b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "qwen3-4b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "qwen3-1.7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "qwen3-1.7b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "qwen3-0.6b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "qwen3-0.6b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "qwen3.5-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00016
+        }
+      }
+    }
+  },
+  "qwen3.5-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qvq-72b-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00016
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000224
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000224
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "qwen2-vl-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qwen2-vl-2b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "deepseek-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000027
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "deepseek-v3-0324": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000027
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "deepseek-r1-0528": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000055
+        },
+        "response_token": {
+          "price": 0.000219
+        }
+      }
+    }
+  },
+  "moonshot-v1-8k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "moonshot-v1-32k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00018
+        }
+      }
+    }
+  },
+  "moonshot-v1-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.00045
+        }
+      }
+    }
+  },
+  "qwen-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qwen-tts-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qwen-tts-2025-05-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qwen-tts-2025-04-10": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime-2025-07-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-09-18": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0026
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3.5-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0026
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3.5-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans-2025-11-17": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-2025-08-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-mtl": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-realtime-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-flash-8k-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-realtime-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-t2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-t2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-i2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-kf2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-kf2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-r2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan.6-r2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-vace-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-s2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-s2v-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-animate-move": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-animate-mix": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "emo-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "liveportrait": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "emoji-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "videoretalk": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "video-style-transform": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-t2i": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-t2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-i2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-2.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-max-2025-12-30": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-plus-2026-01-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max-2026-01-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "z-image-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "animate-anyone-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "aitryon-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 6
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "aitryon-parsing-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-voice-enrollment": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-voice-design": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.6
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: dashscope

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 156 |
| 🔄 Models updated (merged) | 68 |

### ➕ New Models
- `qwen3-max-2025-04-28`
- `qwen-plus-us`
- `qwen-plus-2025-12-01-us`
- `qwen-flash-latest`
- `qwen-flash-us`
- `qwen-flash-2025-07-28-us`
- `qwen-deep-research`
- `qwen-doc-turbo`
- `tongyi-intent-detect-v3`
- `qwen2.5-math-72b-instruct`
- `qwen2.5-math-7b-instruct`
- `qwen2.5-math-1.5b-instruct`
- `qwen-vl-max-2025-01-25`
- `qwen-vl-ocr-2025-08-28`
- `qwen3-vl-flash-us`
- `qwen3-vl-flash-2026-01-22-us`
- `qwen3-vl-flash-2025-10-15-us`
- `qwen3.5-omni-plus`
- `qwen3.5-omni-plus-2026-03-15`
- `qwen3.5-omni-flash`
- ... and 136 more

### 🔄 Updated Models
- `qvq-plus`
- `qvq-plus-latest`
- `qvq-plus-2025-05-15`
- `qwen-plus-character`
- `qwen-plus-character-ja`
- `qwen-mt-plus`
- `qwen-mt-flash`
- `qwen-mt-lite`
- `qwen-mt-turbo`
- `qwen-math-plus`
- `qwen-math-plus-latest`
- `qwen-math-plus-2024-09-19`
- `qwen-math-turbo`
- `qwen-math-turbo-latest`
- `qwen-math-turbo-2024-09-19`
- `qwen-coder-plus`
- `qwen-coder-plus-latest`
- `qwen-coder-plus-2024-11-06`
- `qwen-coder-turbo`
- `qwen-coder-turbo-latest`
- `qwen-coder-turbo-2024-09-19`
- `qwen3-coder-plus`
- `qwen3-coder-plus-2025-09-23`
- `qwen3-coder-plus-2025-07-22`
- `qwen3-coder-flash`
- `qwen3-coder-flash-2025-07-28`
- `qwen3-coder-next`
- `qwen-vl-plus`
- `qwen-vl-plus-latest`
- `qwen-vl-plus-2025-01-25`
- ... and 38 more


## Data Sources

| Source | URL |
|--------|-----|
| Commercial models + tiered pricing | https://www.alibabacloud.com/help/en/model-studio/models |
| Open-source + specialized models | https://www.alibabacloud.com/help/en/model-studio/model-pricing |

## Model Families Covered (260 models)

| Family | Count | Notes |
|--------|-------|-------|
| Commercial Qwen text (qwen3-max, qwen3.5-plus/flash, qwen-max/plus/flash/turbo, qwq-plus, qwen-long) | ~35 | International pricing, lowest tier |
| Qwen VL / OCR / Omni / QVQ commercial | ~30 | International pricing |
| Qwen Coder / Math / MT / Doc / Research / Intent / Character | ~25 | Mixed regions per priority rule |
| Open-source Qwen3 / Qwen3.5 / Qwen2.5 text | ~25 | International |
| Open-source VL (Qwen3-VL, Qwen2.5-VL, Qwen2-VL, Qwen2.5-Omni) | ~15 | International |
| Third-party (DeepSeek, Moonshot/Kimi, GLM, MiniMax) | ~7 | International |
| Embeddings + Reranking | ~6 | International |
| TTS (Qwen3-TTS, Qwen-TTS, CosyVoice, voice enrollment/design) | ~20 | per_million_characters or per_request |
| ASR (Qwen3-ASR, Fun-ASR, Paraformer, LiveTranslate) | ~15 | per_second |
| Video generation (Wan t2v/i2v/kf2v/r2v/vace, digital human, animate, EMO, etc.) | ~30 | per_second |
| Image generation (Qwen-Image, Wan t2i, Z-Image, image editing, OutfitAnyone) | ~25 | per_image |

## Region Priority Applied
- International → Global → Chinese Mainland (per skill rules)
- `qwen-long`, `qwen-math-*`, `qwen-doc-turbo`, `tongyi-intent-detect-v3`, `qvq-plus`, `gte-rerank-v2`, `paraformer-*`, `cosyvoice-v2`: Chinese Mainland only
- `qwen3.5-omni-plus/flash`: In preview, temporarily free (price=0)
- `qwen-deep-research`: per_thousand_tokens exception applied

---
*Generated by Pricing Agent on 2026-04-11*