### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,345 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-1.5-flash-8b-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-3.1-pro": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-3.1-flash-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-3.1-flash-lite": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-3-pro": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-3-pro-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-3-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "imagen-2.0-generate-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "imagetext@001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3-generate-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3-fast-generate-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-2-generate-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-embedding-exp-03-07": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "claude-opus-4-1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "claude-opus-4": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3.1-70b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3.1-8b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3-405b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3-70b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3-8b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-2-70b-hf": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-2-13b-hf": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-2-7b-hf": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "codellama-34b-hf": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "codestral-2501-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mistral-large-2411-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "pixtral-12b-2409": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "pixtral-large-2411-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mixtral-8x7b-instruct-v0.1-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v2.5-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v2-chat-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-coder-v2-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-distill-llama-70b-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-distill-qwen-32b-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-distill-qwen-14b-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-next-80b-thinking-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-next-80b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-30b-a3b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-32b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-72b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-32b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-7b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2-5-coder-32b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4v-9b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4-9b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4-air": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4-airx": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "minimax-text-01-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "kimi-k2-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshot-v1-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-oss-20b-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.0-pro-exp-02-05": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-2.5-flash-exp-04-17": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "imagen-4.0-ultra-generate-exp-05-20": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-embedding-003": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "textembedding-gecko@002": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mistral-nemo-2407": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mistral-7b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "mixtral-8x22b-instruct-v0.1-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "jamba-1.5-large": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "jamba-1.5-mini": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -135,6 +135,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -163,6 +166,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -191,6 +197,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -351,6 +360,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -440,6 +452,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -510,7 +525,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -550,7 +565,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -630,7 +645,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -866,6 +881,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -919,6 +937,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1145,6 +1166,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1176,6 +1200,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1266,10 +1293,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1277,15 +1304,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1294,10 +1327,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1305,15 +1338,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1322,10 +1361,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.02
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
@@ -1445,7 +1484,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       },
       "batch_config": {
@@ -1602,7 +1647,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2522,7 +2567,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3331,6 +3376,17 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
         }
       },
       "batch_config": {
@@ -3507,6 +3563,20 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
         }
       },
       "batch_config": {
@@ -3515,6 +3585,1083 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-thinking-exp-01-21": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-1.5-flash-8b-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-3.1-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-lite": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000125
+        },
+        "response_token": {
+          "price": 0.000075
+        }
+      }
+    }
+  },
+  "gemini-3-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "gemini-3-pro-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-3-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-2.0-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 2
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagetext@001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 20
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3-fast-generate-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 8
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-2-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 50
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "gemini-embedding-exp-03-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.02
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "claude-opus-4-1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0015
+        },
+        "response_token": {
+          "price": 0.0075
+        },
+        "cache_write_input_token": {
+          "price": 0.001875
+        },
+        "cache_read_input_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "claude-opus-4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0015
+        },
+        "response_token": {
+          "price": 0.0075
+        },
+        "cache_write_input_token": {
+          "price": 0.001875
+        },
+        "cache_read_input_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      }
+    }
+  },
+  "llama-3.1-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.1-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3-405b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-2-70b-hf": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-2-13b-hf": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-2-7b-hf": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "codellama-34b-hf": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "codestral-2501-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "mistral-large-2411-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "pixtral-12b-2409": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "pixtral-large-2411-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mixtral-8x7b-instruct-v0.1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000135
+        },
+        "response_token": {
+          "price": 0.00054
+        }
+      }
+    }
+  },
+  "deepseek-v2.5-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v2-chat-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-coder-v2-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-llama-70b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-32b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-14b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-next-80b-thinking-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen3-next-80b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-32b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-72b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-32b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-7b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-coder-32b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4v-9b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-9b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-air": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-airx": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "minimax-text-01-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "kimi-k2-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "moonshot-v1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gpt-oss-20b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000025
+        },
+        "cache_read_input_token": {
+          "price": 0.0000007
+        }
+      }
+    }
+  },
+  "gemini-2.0-pro-exp-02-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-exp-03-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-exp-04-17": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.000125
+        }
+      }
+    }
+  },
+  "imagen-4.0-ultra-generate-exp-05-20": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 6
+            }
+          }
+        }
+      }
+    }
+  },
+  "text-embedding-003": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "textembedding-gecko@002": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-nemo-2407": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-7b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mixtral-8x22b-instruct-v0.1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "jamba-1.5-large": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "jamba-1.5-mini": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 70 |
| 🔄 Models updated (merged) | 20 |

### ➕ New Models
- `gemini-2.5-pro-preview-06-05`
- `gemini-2.0-flash-thinking-exp-01-21`
- `gemini-2.0-flash-image-generation`
- `gemini-1.5-flash-8b-001`
- `gemini-3.1-pro`
- `gemini-3.1-flash-image`
- `gemini-3.1-flash-lite`
- `gemini-3-pro`
- `gemini-3-pro-image`
- `gemini-3-flash`
- `gemma-4-26b-a4b-it-maas`
- `imagen-4.0-capability-001`
- `imagen-2.0-generate-001`
- `imagetext@001`
- `veo-3.1-lite-generate-preview`
- `veo-3-generate-001`
- `veo-3-fast-generate-preview`
- `veo-2-generate-001`
- `gemini-embedding-exp-03-07`
- `claude-opus-4-1`
- ... and 50 more

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-2.5-flash-preview-05-20`
- `gemini-2.5-pro-preview-05-06`
- `gemini-2.5-flash-preview-04-17`
- `gemini-2.0-flash-exp`
- `gemini-1.5-pro-001`
- `gemini-1.5-pro-002`
- `gemini-1.5-flash-001`
- `gemini-1.5-flash-002`
- `gemini-1.0-pro-001`
- `gemini-1.0-pro-002`
- `gemini-1.0-pro-vision-001`
- `veo-3.1-fast-generate-001`
- `text-embedding-004`
- `textembedding-gecko-multilingual@001`
- `multimodalembedding@001`
- `gemini-2.5-pro-preview-03-25`
- `gemini-2.5-flash-lite-preview-06-17`
- `gemini-2.0-flash-preview-image-generation`
- `textembedding-gecko@001`


## Model-to-Pricing-Page Mapping

### Google – Gemini (token pricing, $/1M)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Standard table: $1.25/$10.00, cache $0.13; Flex: $0.625/$5.00; Search: $35/1K=3.5¢, Enterprise: $45/1K=4.5¢ |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | Standard: $0.30/$2.50, cache $0.03; Flex: $0.15/$1.25; Search 3.5¢/4.5¢ |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | Standard: $0.10/$0.40, cache $0.01; Flex: $0.05/$0.20; Search 3.5¢/4.5¢ |
| `gemini-2.5-flash-preview-05-20` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Flash pricing |
| `gemini-2.5-pro-preview-05-06` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Pro pricing |
| `gemini-2.5-pro-preview-06-05` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Pro pricing |
| `gemini-2.5-flash-preview-04-17` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Flash pricing |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | Flash Image variant; image_token $30/1M |
| `gemini-2.5-pro-exp-03-25` | Google – Gemini 2.5 | API | Exp alias → Gemini 2.5 Pro pricing |
| `gemini-2.5-flash-exp-04-17` | Google – Gemini 2.5 | API | Exp alias → Gemini 2.5 Flash pricing |
| `gemini-2.5-pro-preview-03-25` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Pro pricing |
| `gemini-2.5-flash-lite-preview-06-17` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Flash Lite pricing |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | Standard: $0.15/$0.60; Flex: $0.075/$0.30; Search 3.5¢/4.5¢ |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | Standard: $0.075/$0.30; Flex: $0.0375/$0.15; Search 3.5¢/4.5¢ |
| `gemini-2.0-flash-exp` | Google – Gemini 2.0 | API | Exp alias → Gemini 2.0 Flash pricing |
| `gemini-2.0-flash-thinking-exp-01-21` | Google – Gemini 2.0 | API | Thinking exp alias → Gemini 2.0 Flash pricing (no batch) |
| `gemini-2.0-flash-image-generation` | Google – Gemini 2.0 | API | Image generation variant; image_token $30/1M |
| `gemini-2.0-flash-preview-image-generation` | Google – Gemini 2.0 | API | Preview alias → Flash Image Generation pricing |
| `gemini-2.0-pro-exp-02-05` | Google – Gemini 2.0 | API – price not found | No pricing row for 2.0 Pro; added with price 0 |
| `gemini-1.5-pro-001` | Google – Gemini 1.5 | API – price not found | Retired/no current pricing row; price 0 |
| `gemini-1.5-pro-002` | Google – Gemini 1.5 | API – price not found | Retired/no current pricing row; price 0 |
| `gemini-1.5-flash-001` | Google – Gemini 1.5 | API – price not found | Retired/no current pricing row; price 0 |
| `gemini-1.5-flash-002` | Google – Gemini 1.5 | API – price not found | Retired/no current pricing row; price 0 |
| `gemini-1.5-flash-8b-001` | Google – Gemini 1.5 | API – price not found | Retired/no current pricing row; price 0 |
| `gemini-1.0-pro-001` | Google – Gemini 1.0 | API – price not found | Legacy; price 0 |
| `gemini-1.0-pro-002` | Google – Gemini 1.0 | API – price not found | Legacy; price 0 |
| `gemini-1.0-pro-vision-001` | Google – Gemini 1.0 | API – price not found | Legacy; price 0 |

### Google – Gemini 3.x (token pricing, $/1M)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-3.1-pro` | Google – Gemini 3.1 | API | Standard: $2.00/$12.00, cache $0.20; Flex: $1.00/$6.00; Search $14/1K=1.4¢ |
| `gemini-3.1-flash-image` | Google – Gemini 3.1 | API | Flash Image: $0.50/$3.00; image_token $60/1M; Search 1.4¢ |
| `gemini-3.1-flash-lite` | Google – Gemini 3.1 | API | Flash Lite: $0.25/$1.50, cache $0.03; Flex: $0.125/$0.75; Search 1.4¢ |
| `gemini-3-pro` | Google – Gemini 3 | API | Standard: $2.00/$12.00, cache $0.20; Flex: $1.00/$6.00; Search 1.4¢ |
| `gemini-3-pro-image` | Google – Gemini 3 | API | Pro Image: $2.00/$12.00; image_token $120/1M; Search 1.4¢ |
| `gemini-3-flash` | Google – Gemini 3 | API | Standard: $0.50/$3.00, cache $0.05; Flex: $0.25/$1.50; Search 1.4¢ |

### Google – Gemma

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemma-4-26b-a4b-it-maas` | Google – Gemma 4 | API | $0.15/$0.60 (free until Apr 16, 2026 per page note) |

### Google – Imagen (per-image)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `imagen-4.0-generate-001` | Google – Imagen 4 | API | $0.04/image |
| `imagen-4.0-ultra-generate-001` | Google – Imagen 4 Ultra | API | $0.06/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4 Fast | API | $0.02/image |
| `imagen-4.0-capability-001` | Google – Imagen 4 | API | Capability model → uses Imagen 4.0 Generate pricing ($0.04/image) |
| `imagen-4.0-generate-preview-05-20` | Google – Imagen 4 | API | Preview alias → $0.04/image |
| `imagen-4.0-ultra-generate-exp-05-20` | Google – Imagen 4 Ultra | API | Exp alias → $0.06/image |
| `imagen-3.0-generate-001` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-generate-002` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-fast-generate-001` | Google – Imagen 3 Fast | API | $0.02/image |
| `imagen-3.0-capability-001` | Google – Imagen 3 | API | Capability model → uses Imagen 3.0 Generate pricing ($0.04/image) |
| `imagen-2.0-generate-001` | Google – Imagen 2 | API | $0.02/image |
| `imagetext@001` | Google – Imagen | API – price not found | Legacy visual Q&A model; no pricing row; price 0 |

### Google – Veo (per-second video)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | Video only 720p/1080p: $0.20/sec → 20¢/sec; default 8s/1 sample |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | Video only 720p: $0.08/sec → 8¢/sec; default 8s/1 sample |
| `veo-3.1-lite-generate-preview` | Google – Veo 3.1 Lite | API | Video only 720p: $0.03/sec → 3¢/sec; default 8s/1 sample |
| `veo-3-generate-001` | Google – Veo 3 | API | Video only: $0.20/sec → 20¢/sec; default 8s/1 sample |
| `veo-3-fast-generate-preview` | Google – Veo 3 Fast | API | Video only 720p: $0.08/sec → 8¢/sec; default 8s/1 sample |
| `veo-2-generate-001` | Google – Veo 2 | API | $0.50/sec → 50¢/sec; default 8s/1 sample |

### Google – Embeddings

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-embedding-001` | Google – Gemini Embedding | API | $0.00015/1K tokens |
| `gemini-embedding-exp-03-07` | Google – Gemini Embedding | API | Exp alias → $0.00015/1K tokens (also listed as Gemini Embedding 2 Multimodal Preview at $0.20/1M text) |
| `text-embedding-005` | Google – Text Embedding | API | $0.000025/1K chars |
| `text-embedding-004` | Google – Text Embedding | API | $0.000025/1K chars |
| `text-embedding-003` | Google – Text Embedding | API | $0.000025/1K chars |
| `text-embedding-large-exp-03-07` | Google – Text Embedding | API | Experimental; used text-embedding-005 rate ($0.000025/1K) |
| `textembedding-gecko@003` | Google – Text Embedding | API | Legacy gecko; $0.000025/1K chars |
| `textembedding-gecko@002` | Google – Text Embedding | API | Legacy gecko; $0.000025/1K chars |
| `textembedding-gecko@001` | Google – Text Embedding | API | Legacy gecko; $0.000025/1K chars |
| `textembedding-gecko-multilingual@001` | Google – Text Embedding | API | Multilingual variant; $0.000025/1K chars |
| `text-multilingual-embedding-002` | Google – Text Embedding | API | Multilingual; $0.000025/1K chars |
| `multimodalembedding@001` | Google – Multimodal Embedding | API | Text $0.0002/1K chars; image $0.0001; video Plus $0.0020/sec, Standard $0.0010/sec, Essential $0.0005/sec |

### Anthropic – Claude

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `claude-opus-4-6` | Anthropic – Claude | API | $5/$25; cache_write $6.25 (5m), cache_read $0.50 |
| `claude-opus-4-5` | Anthropic – Claude | API | $5/$25; cache_write $6.25, cache_read $0.50 |
| `claude-sonnet-4-6` | Anthropic – Claude | API | $3/$15; cache_write $3.75, cache_read $0.30 |
| `claude-sonnet-4-5` | Anthropic – Claude | API | $3/$15; cache_write $3.75, cache_read $0.30; long-context tier noted |
| `claude-haiku-4-5` | Anthropic – Claude | API | $1/$5; cache_write $1.25, cache_read $0.10 |
| `claude-opus-4-1` | Anthropic – Claude | API | $15/$75; cache_write $18.75, cache_read $1.50 |
| `claude-opus-4` | Anthropic – Claude | API | $15/$75; cache_write $18.75, cache_read $1.50 |
| `claude-sonnet-4` | Anthropic – Claude | API | $3/$15; cache_write $3.75, cache_read $0.30 |

### Meta – Llama

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama 4 | API | $0.35/$1.15 |
| `llama-4-scout-17b-16e-instruct-maas` | Meta – Llama 4 | API | $0.25/$0.70 |
| `llama-3.3-70b-instruct-maas` | Meta – Llama 3.3 | API | $0.72/$0.72 |
| `llama-3.1-405b-instruct-maas` | Meta – Llama 3.1 | API | $5.00/$16.00 |
| `llama-3.1-70b-instruct-maas` | Meta – Llama 3.1 | API – price not found | No pricing row; price 0 |
| `llama-3.1-8b-instruct-maas` | Meta – Llama 3.1 | API – price not found | No pricing row; price 0 |
| `llama-3-405b-instruct-maas` | Meta – Llama 3 | API – price not found | Legacy; price 0 |
| `llama-3-70b-instruct-maas` | Meta – Llama 3 | API – price not found | Legacy; price 0 |
| `llama-3-8b-instruct-maas` | Meta – Llama 3 | API – price not found | Legacy; price 0 |
| `llama-2-70b-hf` | Meta – Llama 2 | API – price not found | Legacy; price 0 |
| `llama-2-13b-hf` | Meta – Llama 2 | API – price not found | Legacy; price 0 |
| `llama-2-7b-hf` | Meta – Llama 2 | API – price not found | Legacy; price 0 |
| `codellama-34b-hf` | Meta – Code Llama | API – price not found | Legacy; price 0 |

### Mistral AI

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `mistral-small-2503` | Mistral AI | API | $0.10/$0.30 |
| `mistral-medium-3` | Mistral AI | API | $0.40/$2.00 |
| `codestral-2501-maas` | Mistral AI | API | $0.30/$0.90 |
| `mistral-large-2411-maas` | Mistral AI | API – price not found | No current pricing row; price 0 |
| `pixtral-12b-2409` | Mistral AI | API – price not found | No pricing row; price 0 |
| `pixtral-large-2411-maas` | Mistral AI | API – price not found | No pricing row; price 0 |
| `mistral-nemo-2407` | Mistral AI | API – price not found | No pricing row; price 0 |
| `mistral-7b-instruct-maas` | Mistral AI | API – price not found | Legacy; price 0 |
| `mixtral-8x7b-instruct-v0.1-maas` | Mistral AI | API – price not found | Legacy; price 0 |
| `mixtral-8x22b-instruct-v0.1-maas` | Mistral AI | API – price not found | No pricing row; price 0 |

### DeepSeek

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `deepseek-v3.2-maas` | DeepSeek | API | $0.56/$1.68; cache_read $0.056 |
| `deepseek-v3.1-maas` | DeepSeek | API | $0.60/$1.70; cache_read $0.06 |
| `deepseek-r1-0528-maas` | DeepSeek | API | $1.35/$5.40 |
| `deepseek-r1-maas` | DeepSeek | API | $1.35/$5.40 |
| `deepseek-v2.5-maas` | DeepSeek | API – price not found | Legacy; price 0 |
| `deepseek-v2-chat-maas` | DeepSeek | API – price not found | Legacy; price 0 |
| `deepseek-coder-v2-instruct-maas` | DeepSeek | API – price not found | Legacy; price 0 |
| `deepseek-r1-distill-llama-70b-maas` | DeepSeek | API – price not found | Distill variant; no row; price 0 |
| `deepseek-r1-distill-qwen-32b-maas` | DeepSeek | API – price not found | Distill variant; no row; price 0 |
| `deepseek-r1-distill-qwen-14b-maas` | DeepSeek | API – price not found | Distill variant; no row; price 0 |

### Qwen

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen | API | $0.22/$0.88 |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen | API | $0.22/$1.80; cache_read $0.022 |
| `qwen3-next-80b-thinking-maas` | Qwen | API | $0.15/$1.20 |
| `qwen3-next-80b-instruct-maas` | Qwen | API | $0.15/$1.20 |
| `qwen3-30b-a3b-instruct-maas` | Qwen | API – price not found | No pricing row; price 0 |
| `qwen3-32b-instruct-maas` | Qwen | API – price not found | No pricing row; price 0 |
| `qwen2-5-72b-instruct-maas` | Qwen | API – price not found | Legacy; price 0 |
| `qwen2-5-32b-instruct-maas` | Qwen | API – price not found | Legacy; price 0 |
| `qwen2-5-7b-instruct-maas` | Qwen | API – price not found | Legacy; price 0 |
| `qwen2-5-coder-32b-instruct-maas` | Qwen | API – price not found | Legacy; price 0 |

### ZAI.org – GLM

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `glm-4.7-maas` | ZAI.org – GLM | API | $0.60/$2.20 |
| `glm-5-maas` | ZAI.org – GLM | API | $1.00/$3.20; cache_read $0.10 |
| `glm-4v-9b` | ZAI.org – GLM | API – price not found | No pricing row; price 0 |
| `glm-4-9b` | ZAI.org – GLM | API – price not found | No pricing row; price 0 |
| `glm-4-air` | ZAI.org – GLM | API – price not found | No pricing row; price 0 |
| `glm-4-airx` | ZAI.org – GLM | API – price not found | No pricing row; price 0 |

### MiniMax

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `minimax-m2-maas` | MiniMax | API | $0.30/$1.20; cache_read $0.03 |
| `minimax-text-01-maas` | MiniMax | API – price not found | No pricing row; price 0 |

### Moonshot / Kimi

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `kimi-k2-thinking-maas` | Moonshot – Kimi | API | $0.60/$2.50; cache_read $0.06 |
| `kimi-k2-maas` | Moonshot – Kimi | API – price not found | No dedicated row; price 0 |
| `moonshot-v1-maas` | Moonshot – Kimi | API – price not found | Legacy; price 0 |

### OpenAI

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gpt-oss-120b-maas` | OpenAI – GPT OSS | API | $0.09/$0.36 |
| `gpt-oss-20b-maas` | OpenAI – GPT OSS | API | $0.07/$0.25; cache_read $0.007 |

### AI21

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `jamba-large-1.6` | AI21 – Jamba | API – price not found | No pricing row found on Vertex page; price 0 |
| `jamba-1.5-large` | AI21 – Jamba | API – price not found | Legacy; price 0 |
| `jamba-1.5-mini` | AI21 – Jamba | API – price not found | Legacy; price 0 |

## Excluded Models (not added)

| Pattern | Publisher | Reason |
|---------|-----------|--------|
| `*-live-*` | Google | Gemini Live streaming — separate product |
| `lyria-*` | Google | Music generation — no generative AI pricing endpoint |
| `model-optimizer-*` | Google | Dynamic routing meta-endpoint |
| `imagegeneration` (legacy) | Google | Superseded by Imagen 3.0+ |
| `virtual-try-on-*` | Google | Retail product-specific model |
| `glm-image` | ZAI.org | Explicitly excluded per policy |
| `qwen-image` | Qwen | Explicitly excluded per policy |
| `*-self-deploy` (no -maas) | All | Self-deploy — customer-managed infra, not MaaS |
| `mistral-ocr-*` | Mistral | OCR model excluded per policy |
| `whisper-*` | OpenAI | Audio transcription, not generative LLM |
| Gemma, Codey, PaLM, CV/NLP models | Google | Non-generative or fine-tuning-only |
| `llama-guard-*` | Meta | Safety/guard model |

---
*Generated by Pricing Agent on 2026-04-11*