### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1757,5 +1757,10 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -1433,7 +1433,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -1711,7 +1711,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1910,14 +1910,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -1977,14 +1977,14 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2110,14 +2110,14 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2494,14 +2494,14 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -917,14 +917,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1426,14 +1426,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.00001
         }
       },
       "batch_config": {
@@ -1525,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1681,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1711,14 +1711,14 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
@@ -1910,14 +1910,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.00001
         }
       },
       "batch_config": {
@@ -1943,20 +1943,20 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1977,20 +1977,20 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2110,14 +2110,14 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.00001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2463,20 +2463,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2494,20 +2494,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2581,29 +2581,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,29 +2612,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3174,7 +3174,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3214,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3238,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3283,40 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 46 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-3.1-pro-preview-lte-128k`
- `gemini-3.1-pro-preview-gt-128k`
- `gemini-3.1-pro-preview-customtools-lte-128k`
- `gemini-3.1-pro-preview-customtools-gt-128k`
- `gemini-3.1-flash-image-preview-lte-128k`
- `gemini-3.1-flash-image-preview-gt-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-3-pro-preview-lte-128k`
- `gemini-3-pro-preview-gt-128k`
- `gemini-3-pro-image-preview-lte-128k`
- `gemini-3-pro-image-preview-gt-128k`
- `gemini-3-flash-preview-lte-128k`
- `gemini-3-flash-preview-gt-128k`
- `gemini-pro-latest-lte-128k`
- `gemini-pro-latest-gt-128k`
- `gemini-flash-latest-lte-128k`
- `gemini-flash-latest-gt-128k`
- `gemini-flash-lite-latest-lte-128k`
- `gemini-flash-lite-latest-gt-128k`
- `gemini-2.5-pro-lte-128k`
- `gemini-2.5-pro-gt-128k`
- `gemini-2.5-flash-lte-128k`
- `gemini-2.5-flash-gt-128k`
- `gemini-2.5-flash-image-lte-128k`
- `gemini-2.5-flash-image-gt-128k`
- `gemini-2.5-flash-lite-lte-128k`
- `gemini-2.5-flash-lite-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- ... and 16 more


### 📋 Model → pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K | input $2, output $12, cache $0.2, batch $1/$6, web_search+search |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K | input $4, output $18, cache $0.4, batch $2/$9 |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview (customtools), ≤200K | same pricing as gemini-3.1-pro-preview |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview (customtools), >200K | same pricing as gemini-3.1-pro-preview gt |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image, flat pricing | input $0.50, text output $3, image_token $60, batch $0.25/$1.50 |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image, flat pricing | identical to lte (no context tiers on page) |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite, flat pricing | input $0.25, output $1.50, cache $0.03, batch $0.13/$0.75 |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite, flat pricing | identical to lte (no context tiers on page) |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro, ≤200K | input $2, output $12, cache $0.2, batch $1/$6 |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro, >200K | input $4, output $18, cache $0.4, batch $2/$9 |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image, flat pricing | input $2, text output $12, image_token $120, batch $1/$6 |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image, flat pricing | identical to lte (no context tiers on page) |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash, flat pricing | input $0.5, output $3, cache $0.05, batch $0.25/$1.50 |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash, flat pricing | identical to lte (no context tiers on page) |
| gemini-pro-latest-lte-128k | *-latest → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview lte |
| gemini-pro-latest-gt-128k | *-latest → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview gt |
| gemini-flash-latest-lte-128k | *-latest → resolved to gemini-3-flash-preview | same pricing as gemini-3-flash-preview |
| gemini-flash-latest-gt-128k | *-latest → resolved to gemini-3-flash-preview | identical to lte |
| gemini-flash-lite-latest-lte-128k | *-latest → resolved to gemini-3.1-flash-lite-preview | same pricing as gemini-3.1-flash-lite-preview |
| gemini-flash-lite-latest-gt-128k | *-latest → resolved to gemini-3.1-flash-lite-preview | identical to lte |
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | input $1.25, output $10, cache $0.13, batch $0.625/$5 |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | input $2.50, output $15, cache $0.25, batch $1.25/$7.5 |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat pricing | input $0.30, output $2.50, cache $0.03, batch $0.15/$1.25 |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat pricing | identical to lte (no context tiers on page) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat pricing | input $0.30, text output $2.50, image_token $30, batch $0.15/$1.25; batch image rate $15/1M |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat pricing | identical to lte (no context tiers on page) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash-Lite, flat pricing | input $0.10, output $0.40, cache $0.01, batch $0.05/$0.20 |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash-Lite, flat pricing | identical to lte (no context tiers on page) |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat pricing | input $0.15, output $0.60, batch $0.075/$0.30 |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat pricing | identical to lte |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash 001, flat pricing | same pricing as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash 001, flat pricing | identical to lte |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash-Lite, flat pricing | input $0.075, output $0.30, batch $0.0375/$0.15 |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash-Lite, flat pricing | identical to lte |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash-Lite 001, flat pricing | same pricing as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash-Lite 001, flat pricing | identical to lte |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | input $0.15/1M tokens ($0.00015/1K), output $0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 | identical to lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview | input $0.20/1M tokens, output $0 |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview | identical to lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4.0 Generate | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4.0 Generate | $0.04/image |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4.0 Ultra Generate | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4.0 Ultra Generate | $0.06/image |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4.0 Fast Generate | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4.0 Fast Generate | $0.02/image |
| veo-2.0-generate-001-lte-128k | Veo 2.0 Generate | $0.50/s → 50¢/s, default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2.0 Generate | identical to lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0 Generate | $0.20/s video-only → 20¢/s, default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3.0 Generate | identical to lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast Generate | $0.10/s → 10¢/s, default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast Generate | identical to lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Generate Preview | $0.20/s video-only → 20¢/s, default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Generate Preview | identical to lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast Generate Preview | $0.10/s → 10¢/s, default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast Generate Preview | identical to lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite Generate Preview | $0.05/s → 5¢/s, default 8s, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite Generate Preview | identical to lte |

### 📌 Source Notes
- Token pricing sourced from **Google Cloud Vertex AI Generative AI Pricing** (`https://cloud.google.com/vertex-ai/generative-ai/pricing`) — the Gemini API pricing page (`https://ai.google.dev/gemini-api/docs/pricing`) was inaccessible (Firecrawl insufficient credits).
- Web search pricing ($3.5/1K calls → 0.35¢/call) uses Gemini API standard rate per skill examples.
- Vertex AI uses ≤200K / >200K context tiers; mapped to `-lte-128k` / `-gt-128k` naming convention.
- `*-latest` aliases resolved: `gemini-pro-latest` → gemini-3.1-pro-preview, `gemini-flash-latest` → gemini-3-flash-preview, `gemini-flash-lite-latest` → gemini-3.1-flash-lite-preview (verified from Vertex AI pricing page showing current latest models).
- Veo video_seconds uses video-only rate as the base; audio+video rate is higher but video-only is the standard baseline.
- Thinking tokens: not listed as separate line items on the Vertex AI pricing page (included in "Text output (response and reasoning)") — not added to avoid double-counting.

---
*Generated by Pricing Agent on 2026-04-11*