### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,20 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemini-2.0-flash-image-generation": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -630,7 +630,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -984,6 +984,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -1176,6 +1179,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1211,7 +1217,7 @@
             "price": 1.4
           },
           "enterprise_web_search": {
-            "price": 1.4
+            "price": 4.5
           },
           "image_token": {
             "price": 0.012
@@ -1322,10 +1328,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
@@ -1560,6 +1566,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         },
         "cache_read_input_token": {
@@ -1602,7 +1611,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -1641,7 +1650,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -2272,7 +2281,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2522,7 +2531,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2545,7 +2554,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2578,6 +2587,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2693,6 +2705,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2761,6 +2776,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2792,6 +2810,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2889,7 +2910,7 @@
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2932,6 +2953,17 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
         }
       }
     }
@@ -2944,6 +2976,17 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.012
+          },
+          "input_video_plus": {
+            "price": 0.079
+          },
+          "input_video_standard": {
+            "price": 0.016
+          }
         }
       }
     }
@@ -3515,6 +3558,118 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 5 |
| 🔄 Models updated (merged) | 18 |

### ➕ New Models
- `gemini-2.0-flash-image-generation`
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `gemma-4-26b-a4b-it-maas`
- `veo-3.1-lite-generate-001`

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-2.5-flash-lite`
- `gemini-2.5-pro-preview-05-06`
- `gemini-2.5-flash-lite-preview-09-2025`
- `gemini-2.5-computer-use-preview-10-2025`
- `gemini-2.0-flash-001`
- `gemini-3-pro-preview`
- `gemini-3-flash-preview`
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-lite-preview`
- `gemini-3.1-flash-image-preview`
- `gemini-3-pro-image-preview`
- `veo-3.0-generate-001`
- `veo-3.1-generate-001`
- `veo-3.1-fast-generate-001`
- `gemini-embedding-2-preview`
- `textembedding-gecko-multilingual@001`
- `multimodalembedding@001`


## Model-to-Pricing-Page Mapping

### Google – Gemini (text/multimodal)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 Pro | API | Standard $1.25/$10, cache $0.13, batch $0.625/$5, web_search $3.5, enterprise_web_search $4.5 |
| `gemini-2.5-flash` | Google – Gemini 2.5 Flash | API | Standard $0.30/$2.50, cache $0.03, batch $0.15/$1.25 |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 Flash-Lite | API | Standard $0.10/$0.40, cache $0.025, batch $0.05/$0.20 |
| `gemini-2.5-pro-preview-05-06` | Google – Gemini 2.5 Pro | API | Preview alias for Gemini 2.5 Pro; same pricing |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 Flash | API | Preview alias; same pricing as Gemini 2.5 Flash |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 Flash-Lite | API | Preview alias; same pricing as Flash-Lite |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 Pro | API | Computer Use preview; mapped to Gemini 2.5 Pro pricing |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 Flash | API | Standard $0.15/$0.60, cache $0.0375, batch $0.075/$0.30 |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 Flash-Lite | API | Standard $0.075/$0.30, batch $0.0375/$0.15 |
| `gemini-3-pro-preview` | Google – Gemini 3 Pro Preview | API | $2.00/$12.00, web_search $1.4/1000 |
| `gemini-3-flash-preview` | Google – Gemini 3 Flash Preview | API | $0.50/$3.00, web_search $1.4/1000 |
| `gemini-3.1-pro-preview` | Google – Gemini 3.1 Pro Preview | API | $2.00/$12.00, web_search $1.4/1000 |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3.1 Flash-Lite Preview | API | $0.25/$1.50 |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3.1 Flash Image Preview | API | $0.50/$3.00 text, $60/1M image tokens |
| `gemini-3-pro-image-preview` | Google – Gemini 3 Pro Image Preview | API | $2.00/$12.00 text, $120/1M image tokens |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 Flash Image | API | $0.30/$2.50 text, $30/1M image tokens |
| `gemini-2.0-flash-image-generation` | Google – Gemini 2.0 Flash Image Gen | API | $0.15/$0.60 text, $30/1M image tokens |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 Pro (TTS variant) | API | Mapped to Gemini 2.5 Pro pricing |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 Flash (TTS variant) | API | Mapped to Gemini 2.5 Flash pricing |
| `gemma-4-26b-a4b-it-maas` | Google – Gemma 4 26B | API | $0.15/$0.60 (free until Apr 16, 2026) |

### Google – Imagen (per-image)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `imagen-4.0-ultra-generate-001` | Google – Imagen 4 Ultra | API | $0.06/image |
| `imagen-4.0-generate-001` | Google – Imagen 4 | API | $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4 Fast | API | $0.02/image |
| `imagen-3.0-generate-002` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-capability-001` | Google – Imagen 3 (capability → generate pricing) | API | Capability model; uses Imagen 3 Generate price $0.04/image |
| `imagen-3.0-capability-002` | Google – Imagen 3 (capability → generate pricing) | API | Capability model; uses Imagen 3 Generate price $0.04/image |

### Google – Veo (per-second video)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `veo-2.0-generate-001` | Google – Veo 2 | API | $0.50/sec |
| `veo-3.0-generate-001` | Google – Veo 3 | API | $0.40/sec (video+audio 720p/1080p) |
| `veo-3.0-fast-generate-001` | Google – Veo 3 Fast | API | $0.10/sec (video+audio 720p) |
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | $0.40/sec (video+audio 720p/1080p) |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | $0.10/sec (video+audio 720p) |
| `veo-3.1-lite-generate-001` | Google – Veo 3.1 Lite | API | $0.05/sec (video+audio 720p) |

### Google – Embeddings

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-embedding-001` | Google – Gemini Embedding | API | $0.00015/1K tokens online, batch $0.00012/1K |
| `gemini-embedding-2-preview` | Google – Gemini Embedding 2 Preview | API | $0.2/1M tokens text, $0.00012/image, $0.00079/frame, $0.00016/sec audio |
| `text-embedding-005` | Google – Text Embedding | API | $0.025/1M chars |
| `text-embedding-large-exp-03-07` | Google – Text Embedding Large (experimental) | API | $0.025/1M chars; shares Text Embedding pricing |
| `text-multilingual-embedding-002` | Google – Text Multilingual Embedding | API | $0.025/1M chars |
| `textembedding-gecko@003` | Google – Textembedding Gecko 003 | API | $0.025/1M chars (legacy) |
| `textembedding-gecko-multilingual@001` | Google – Textembedding Gecko Multilingual | API | $0.025/1M chars (legacy) |
| `multimodalembedding@001` | Google – Multimodal Embedding | API | $0.0002/1K chars text; $0.01/image; video plus $0.20/sec, standard $0.10/sec, essential $0.05/sec |

### Google – Excluded models

| Model ID | Reason |
|----------|--------|
| `gemini-live-2.5-flash-native-audio` | Excluded: `*-live-*` pattern (Gemini Live streaming) |
| `lyria-3-pro-preview`, `lyria-3-clip-preview`, `lyria-002` | Excluded: `lyria-*` (music generation) |
| `imagegeneration` | Excluded: legacy model, superseded by Imagen 3+ |
| `virtual-try-on-001` | Excluded: `virtual-try-on-*` (retail product model) |
| `pretrained-ocr` | Excluded: OCR model |
| All self-deploy & non-generative (Gemma, Codey, PaLM, CV/NLP, shieldgemma, etc.) | Excluded: non-generative or fine-tuning-only |

---

### Anthropic – Claude

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `claude-opus-4-6` | Anthropic – Claude Opus 4.6 | API | `@default` stripped; $5/$25, cache write 5m $6.25, cache read $0.50 |
| `claude-sonnet-4-6` | Anthropic – Claude Sonnet 4.6 | API | `@default` stripped; $3/$15, cache write 5m $3.75, cache read $0.30 |
| `claude-opus-4@20250514` | Anthropic – Claude Opus 4 | API | $15/$75 |
| `claude-sonnet-4@20250514` | Anthropic – Claude Sonnet 4 | API | $3/$15, cache write 5m $3.75, cache read $0.30 |
| `claude-opus-4-1@20250805` | Anthropic – Claude Opus 4.1 | API | $15/$75 |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude Sonnet 4.5 | API | $3/$15, cache write 5m $3.75, cache read $0.30 |
| `claude-haiku-4-5@20251001` | Anthropic – Claude Haiku 4.5 | API | $1/$5, cache write 5m $1.25, cache read $0.10 |
| `claude-opus-4-5@20251101` | Anthropic – Claude Opus 4.5 | API | $5/$25, cache write 5m $6.25, cache read $0.50 |

---

### OpenAI – gpt-oss

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gpt-oss-120b-maas` | OpenAI – gpt-oss-120b | API | $0.09/$0.36, batch $0.045/$0.18 |
| `gpt-oss` | — | API – excluded | Self-deploy (no -maas suffix) |
| `clip-vit-base-patch32` | — | API – excluded | Self-deploy + non-generative CV |
| `openclip` | — | API – excluded | Self-deploy + non-generative CV |
| `whisper-large` | — | API – excluded | Self-deploy + audio transcription (not generative AI) |

---

### Meta – Llama

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `llama-3.3-70b-instruct-maas` | Meta – Llama 3.3 70B | API | $0.72/$0.72, batch $0.36/$0.36 |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama 4 Maverick | API | $0.35/$1.15, batch $0.175/$0.575 |
| `faster-r-cnn`, `retinanet`, `mask-r-cnn` | — | API – excluded | Non-generative CV (object detection, segmentation) |
| `segment-anything` | — | API – excluded | Non-generative CV |
| `xlm-roberta-large`, `roberta-large` | — | API – excluded | Non-generative NLP |
| `codellama-7b-hf`, `llama2`, `llama2-quantized` | — | API – excluded | Self-deploy |
| `nllb` | — | API – excluded | Self-deploy + translation |
| `imagebind` | — | API – excluded | Self-deploy + non-generative multimodal |
| `llama3`, `llama3_1`, `llama3-2`, `llama3-3`, `llama4` | — | API – excluded | Self-deploy |
| `llama-guard`, `prompt-guard` | — | API – excluded | Guard models |
| `sam3` | — | API – excluded | Non-generative CV (segmentation) |

---

### Qwen

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen – Qwen3-235B-A22B-Instruct-2507 | API | $0.22/$0.88, batch $0.11/$0.44 |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen – Qwen3-Coder-480B-A35B-Instruct | API | $0.22/$1.80, cache $0.022, batch $0.11/$0.90 |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen – Qwen3-Next-80B-Instruct | API | $0.15/$1.20 |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen – Qwen3-Next-80B-Thinking | API | $0.15/$1.20 |
| `qwq`, `qwen3`, `qwen3-embedding`, `qwen3-5`, `qwen2`, `qwen3-coder-next`, `qwen3-coder`, `qwen3-next`, `qwen3-vl` | — | API – excluded | Self-deploy (no -maas suffix) |
| `qwen-image` | — | API – excluded | Explicit policy exclusion (image gen excluded from Vertex AI pricing) |

---

### Mistral AI

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `mistral-small-2503` | Mistral – Mistral Small 3.1 (25.03) | API | $0.10/$0.30 |
| `mistral-medium-3` | Mistral – Mistral Medium 3 | API | $0.40/$2.00 |
| `codestral-2` | Mistral – Codestral 2 | API | $0.30/$0.90 |
| `codestral-2501-self-deploy` | — | API – excluded | Self-deploy |
| `mistral-ocr-2505` | — | API – excluded | OCR model (global exclude rule: any model with "ocr" in name) |
| `ministral-3`, `mistral-large-3` | — | API – excluded | Self-deploy |
| `mistral` (mistral-ai publisher) | — | API – excluded | Self-deploy |
| `mixtral` (mistral-ai publisher) | — | API – excluded | Self-deploy |

---

### DeepSeek

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `deepseek-r1-0528-maas` | DeepSeek – DeepSeek-R1 (0528) | API | $1.35/$5.40, batch $0.675/$2.70 |
| `deepseek-v3.1-maas` | DeepSeek – DeepSeek-V3.1 | API | $0.60/$1.70, cache hit $0.06, batch $0.30/$0.85 |
| `deepseek-v3.2-maas` | DeepSeek – DeepSeek-V3.2 | API | $0.56/$1.68, cache hit $0.056, batch $0.28/$0.84 |
| `deepseek-r1`, `deepseek-v3`, `deepseek-v3-1`, `deepseek-v3-2` | — | API – excluded | Self-deploy |
| `deepseek-ocr-2`, `deepseek-ocr` | — | API – excluded | Self-deploy + OCR |
| `deepseek-ocr-maas` | — | API – excluded | OCR model (global exclude rule: any model with "ocr" in name) |
| `deepseek` publisher (0 models) | — | — | Publisher returned 0 models; deepseek-ai used |
| DeepSeek-OCR pricing row on page | — | Pricing page only | API model excluded by OCR rule; noted but not added |

---

### Moonshot / Kimi

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `kimi-k2-thinking-maas` | Moonshot – Kimi-K2-Thinking | API | $0.60/$2.50, cache hit $0.06 |
| `kimi-k2-5`, `kimi-k2` | — | API – excluded | Self-deploy |

---

### MiniMax

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `minimax-m2-maas` | MiniMax – MiniMax-M2 | API | $0.30/$1.20, cache hit $0.03 |
| `minimax-m2` | — | API – excluded | Self-deploy |

---

### ZAI.org / GLM

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `glm-4.7-maas` | ZAI.org – GLM-4.7 | API | $0.60/$2.20 |
| `glm-5-maas` | ZAI.org – GLM-5 | API | $1.00/$3.20, cache read $0.10 |
| `glm-image` | — | API – excluded | Explicit policy exclusion (image gen excluded from Vertex AI pricing) |
| `glm-ocr` | — | API – excluded | OCR model |
| `glm-4.7`, `glm-5`, `glm-4.5` | — | API – excluded | Self-deploy |

---

### AI21

| Model ID | Notes |
|----------|-------|
| `jamba-large-1.6` | API – excluded: self-deploy only (has_deploy: true, no -maas suffix) |

---

### xAI Grok (pricing page only – not in any API publisher)

| Pricing page row | Notes |
|-----------------|-------|
| Grok 4.20 Non-Reasoning ($2.00/$6.00) | Pricing page only – not returned by get_vertex_models; not added |
| Grok 4.1 Fast Reasoning ($0.20/$0.50) | Pricing page only – not returned by get_vertex_models; not added |
| Grok 4.1 Fast Non-Reasoning ($0.20/$0.50) | Pricing page only – not returned by get_vertex_models; not added |

---

**Data sources:**
- Vertex AI Generative AI Pricing Page: https://cloud.google.com/vertex-ai/generative-ai/pricing#global (Global tab, scraped fresh)
- Vertex AI Models API: `get_vertex_models` called for all known publishers
- Claude on Vertex AI docs: https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai

---
*Generated by Pricing Agent on 2026-04-11*