### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -812,10 +812,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.001
         },
         "additional_units": {
           "web_search": {
@@ -824,6 +824,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       },
       "batch_config": {
@@ -1269,10 +1272,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1395,7 +1398,7 @@
           "response_audio_token": {
             "price": 0.0012
           }
-        }     
+        }
       }
     }
   },
@@ -1409,7 +1412,7 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.0006
         },
         "response_audio_token": {
           "price": 0
@@ -1435,7 +1438,7 @@
           "price": 0.0005
         },
         "request_audio_token": {
-          "price": 0.3
+          "price": 0.0003
         },
         "response_audio_token": {
           "price": 0
@@ -1578,6 +1581,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -1598,6 +1604,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
         }
       }
     }
@@ -1745,7 +1754,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1786,7 +1795,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2217,7 +2226,7 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
@@ -2289,10 +2298,10 @@
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2316,10 +2325,10 @@
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2466,7 +2475,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00001
         },
         "additional_units": {
           "web_search": {
@@ -2503,7 +2512,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00001
         },
         "additional_units": {
           "web_search": {
@@ -2529,7 +2538,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000005
+          "price": 0.000002
         }
       },
       "batch_config": {
@@ -2558,7 +2567,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000005
+          "price": 0.000002
         }
       }
     }
@@ -2643,10 +2652,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2724,7 +2733,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.00004
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2751,7 +2760,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.00004
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2793,10 +2802,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2882,6 +2891,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.004
         }
       }
     }
@@ -3034,7 +3049,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00001
         },
         "additional_units": {
           "web_search": {
@@ -3218,10 +3233,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0021
+          "price": 0.000175
         },
         "response_token": {
-          "price": 0.0168
+          "price": 0.0014
         },
         "cache_write_input_token": {
           "price": 0
@@ -3233,6 +3248,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000175
         }
       },
       "batch_config": {
@@ -3249,10 +3267,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0021
+          "price": 0.000175
         },
         "response_token": {
-          "price": 0.0168
+          "price": 0.0014
         },
         "cache_write_input_token": {
           "price": 0
@@ -3264,6 +3282,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000175
         }
       }
     }
@@ -3420,6 +3441,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0032
         }
       }
     }
@@ -3844,13 +3871,13 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.004
         },
         "cache_read_input_token": {
           "price": 0.000125
         },
         "request_image_token": {
-          "price": 0.0008
+          "price": 0.001
         },
         "response_image_token": {
           "price": 0.0032
@@ -3868,7 +3895,7 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0
+          "price": 0.0008
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -4053,7 +4080,7 @@
           "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.000125
         },
         "additional_units": {
           "web_search": {
@@ -4076,7 +4103,7 @@
           "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.000125
         },
         "additional_units": {
           "web_search": {
@@ -4139,7 +4166,7 @@
           "price": 0.00045
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -4162,7 +4189,7 @@
           "price": 0.00045
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -4185,7 +4212,7 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000008
         },
         "additional_units": {
           "web_search": {
@@ -4208,7 +4235,7 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.000008
         },
         "additional_units": {
           "web_search": {


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 32 |


### 🔄 Updated Models
- `gpt-5.4`
- `gpt-5.4-2026-03-05`
- `gpt-5.4-mini`
- `gpt-5.4-mini-2026-03-17`
- `gpt-5.4-nano`
- `gpt-5.4-nano-2026-03-17`
- `gpt-5.2-pro`
- `gpt-5.2-pro-2025-12-11`
- `gpt-5.1-codex-mini`
- `gpt-5-nano`
- `gpt-5-nano-2025-08-07`
- `gpt-5-mini`
- `gpt-5-mini-2025-08-07`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `gpt-4o-2024-05-13`
- `o4-mini-deep-research-2025-06-26`
- `computer-use-preview`
- `computer-use-preview-2025-03-11`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-audio-mini`
- `gpt-realtime`
- `gpt-realtime-2025-08-28`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `gpt-image-1`
- `gpt-image-1-mini`
- ... and 2 more


## Data Sources

- **OpenAI Models API**: 128 models fetched via `get_openai_models` tool
- **LiteLLM pricing database**: `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json` (used as alternative source since OpenAI pricing page returned 403/was too large to parse)

## Model Families Covered

| Family | Count |
|--------|-------|
| GPT-5.4 (including pro, mini, nano) | 8 |
| GPT-5.3 (chat-latest, codex) | 2 |
| GPT-5.2 (including pro, codex, chat-latest) | 6 |
| GPT-5.1 (including codex, codex-mini, codex-max, chat-latest) | 6 |
| GPT-5 (including nano, mini, pro, codex, search-api, chat-latest) | 11 |
| GPT-4.1 (including mini, nano) | 6 |
| GPT-4o (including mini, search-preview) | 9 |
| O-series (o4-mini, o3, o3-pro, o3-mini, o1, o1-pro, deep-research) | 16 |
| Audio/Realtime (gpt-4o-audio, gpt-4o-realtime, gpt-audio, gpt-realtime, mini variants) | 18 |
| TTS/Transcription (gpt-4o-mini-tts, transcribe variants, whisper-1, tts-1) | 12 |
| Image (gpt-image-1, gpt-image-1-mini, gpt-image-1.5, chatgpt-image-latest, dall-e) | 5 |
| Video (sora-2, sora-2-pro) | 2 |
| Embedding (text-embedding-3-large, text-embedding-3-small, ada-002) | 3 |
| Moderation (omni-moderation) | 2 |
| Legacy/Other (gpt-4-turbo, gpt-4, gpt-3.5-turbo variants, computer-use-preview, babbage-002, davinci-002) | 12 |

---
*Generated by Pricing Agent on 2026-04-11*