### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1333,7 +1333,7 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.01
         },
         "response_audio_token": {
           "price": 0
@@ -1357,6 +1357,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.0015
         }
       }
     }
@@ -1369,6 +1372,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.003
         }
       }
     }
@@ -1377,10 +1383,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0
+          "price": 0.001
         },
         "request_audio_token": {
           "price": 0
@@ -1395,7 +1401,7 @@
           "response_audio_token": {
             "price": 0.0012
           }
-        }     
+        }
       }
     }
   },
@@ -1409,7 +1415,7 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.0006
         },
         "response_audio_token": {
           "price": 0
@@ -1435,7 +1441,7 @@
           "price": 0.0005
         },
         "request_audio_token": {
-          "price": 0.3
+          "price": 0.0003
         },
         "response_audio_token": {
           "price": 0
@@ -1745,7 +1751,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1786,7 +1792,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2217,13 +2223,13 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2283,16 +2289,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2310,16 +2316,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2332,6 +2338,9 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2344,6 +2353,9 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2356,6 +2368,9 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       }
     }
@@ -2368,6 +2383,9 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       }
     }
@@ -2643,10 +2661,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2724,7 +2742,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.0004
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2751,7 +2769,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.0004
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2793,10 +2811,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2881,6 +2899,15 @@
           "price": 0.000125
         },
         "cache_read_text_input_token": {
+          "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.004
+        },
+        "cache_read_input_token": {
           "price": 0.000125
         }
       }
@@ -3420,6 +3447,15 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0032
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -3757,10 +3793,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0
+          "price": 0.001
         },
         "response_audio_token": {
           "price": 0.0012
@@ -3772,10 +3808,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0
+          "price": 0.001
         },
         "response_audio_token": {
           "price": 0.0012
@@ -3821,6 +3857,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.0015
         }
       }
     }
@@ -3833,6 +3872,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.003
         }
       }
     }
@@ -3844,19 +3886,19 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.004
         },
         "cache_read_input_token": {
           "price": 0.000125
         },
         "request_image_token": {
-          "price": 0.0008
+          "price": 0.001
         },
         "response_image_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "cache_read_image_input_token": {
-          "price": 0.0002
+          "price": 0.00025
         }
       }
     }
@@ -3868,7 +3910,7 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0
+          "price": 0.0008
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -3878,6 +3920,9 @@
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "response_image_token": {
+          "price": 0.0008
         }
       }
     }
@@ -3964,7 +4009,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0004
         },
         "request_audio_token": {
           "price": 0.0032
@@ -4105,6 +4150,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }
@@ -4125,6 +4173,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 31 |


### 🔄 Updated Models
- `gpt-5.4-pro`
- `gpt-5.4-pro-2026-03-05`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `o4-mini-deep-research-2025-06-26`
- `gpt-4o-search-preview`
- `gpt-4o-search-preview-2025-03-11`
- `gpt-4o-mini-search-preview`
- `gpt-4o-mini-search-preview-2025-03-11`
- `gpt-realtime`
- `gpt-realtime-1.5`
- `gpt-realtime-2025-08-28`
- `gpt-audio-mini`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-4o-mini-tts`
- `gpt-4o-mini-tts-2025-03-20`
- `gpt-4o-mini-tts-2025-12-15`
- `tts-1`
- `tts-1-1106`
- `tts-1-hd`
- `tts-1-hd-1106`
- `whisper-1`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `gpt-image-1`
- `gpt-image-1-mini`
- `gpt-image-1.5`
- ... and 1 more


## Model-to-Pricing Mapping

### Data Sources
- **Models API**: `get_openai_models` tool — returned 128 models
- **Pricing Source**: LiteLLM `model_prices_and_context_window.json` (GitHub raw) — used as fallback after OpenAI pricing page was inaccessible (Cloudflare WAF + insufficient Firecrawl credits)

### Batch Summary (129 entries across 6 batches)

| Batch | Family | Count |
|-------|--------|-------|
| 1 | GPT-5.4, GPT-5.3, GPT-5.2, GPT-5.1, GPT-5 core | 25 |
| 2 | GPT-5 variants (search/codex/pro/mini/nano), GPT-4.1, GPT-4o, GPT-4 | 25 |
| 3 | O-series (o1, o3, o4-mini, deep-research, pro), search, computer-use, codex-mini, GPT-3.5 | 25 |
| 4 | Realtime (gpt-realtime, gpt-4o-realtime, gpt-4o-mini-realtime, gpt-audio, gpt-4o-audio) | 22 |
| 5 | TTS (gpt-4o-mini-tts, tts-1, tts-1-hd), Transcribe (gpt-4o-transcribe, gpt-4o-mini-transcribe), Whisper | 13 |
| 6 | Image (gpt-image-1, gpt-image-1.5, gpt-image-1-mini, chatgpt-image-latest, dall-e-2/3), Sora (sora-2, sora-2-pro), Embeddings, Moderation, Legacy | 19 |

### Notable Pricing Details
- **gpt-5.4-pro**: $30/$180 per MTok (most expensive text model)
- **o1-pro**: $150/$600 per MTok
- **Sora-2**: $0.10/second video output; sora-2-pro: $0.30/second
- **Audio/Realtime**: Separate `request_audio_price` / `response_audio_price` fields
- **TTS models**: Priced per million characters (not tokens)
- **Whisper**: Priced per second of audio
- **gpt-image-1 family**: Token-based image pricing with separate text/image token rates
- **DALL-E models**: Per-image pricing with size/quality tiers

---
*Generated by Pricing Agent on 2026-04-11*