### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -924,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1956,7 +1956,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1990,7 +1990,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2476,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2507,7 +2507,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2581,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3174,7 +3174,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3214,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3238,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3283,40 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 19 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-flash-lite-latest-lte-128k`
- `gemini-flash-lite-latest-gt-128k`
- `gemini-2.5-pro-lte-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `veo-2.0-generate-001-lte-128k`
- `veo-2.0-generate-001-gt-128k`
- `veo-3.0-generate-001-lte-128k`
- `veo-3.0-generate-001-gt-128k`
- `veo-3.0-fast-generate-001-lte-128k`
- `veo-3.0-fast-generate-001-gt-128k`
- `veo-3.1-generate-preview-lte-128k`
- `veo-3.1-generate-preview-gt-128k`
- `veo-3.1-fast-generate-preview-lte-128k`
- `veo-3.1-fast-generate-preview-gt-128k`


### Data Sources

**Note**: The primary pricing source for this update is the **Google Cloud Vertex AI pricing page** (`https://cloud.google.com/vertex-ai/generative-ai/pricing`), used as a fallback because the Gemini API pricing page (`https://ai.google.dev/gemini-api/docs/pricing`) was inaccessible during this run (firecrawl out of credits / response too large). The Vertex AI page uses 200K context tiers (≤200K vs >200K tokens); these are mapped to the `-lte-128k` / `-gt-128k` suffix convention used in this repo.

---

### Model → Pricing Page Mapping

| Model ID | Pricing Page Section | Notes |
|----------|----------------------|-------|
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K | input $2/M, output $12/M, cache read $0.2/M, batch $1/$6 |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K | input $4/M, output $18/M, cache read $0.4/M, batch $2/$9 |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K | input $2/M, output $12/M, cache read $0.2/M, batch $1/$6 |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K | input $4/M, output $18/M, cache read $0.4/M, batch $2/$9 |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, flat | input $0.5/M, output $3/M, batch $0.25/$1.5; web_search $14/1K |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, flat | identical to lte (no context tiers listed) |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite Preview, flat | input $0.25/M, output $1.5/M, batch $0.13/$0.75 |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite Preview, flat | identical to lte (no context tiers listed) |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview, flat | input $0.5/M, text output $3/M, image_token $60/M, batch $0.25/$1.5 |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview, flat | identical to lte (no context tiers listed) |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview, flat | input $2/M, text output $12/M, image_token $120/M, batch $1/$6 |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview, flat | identical to lte (no context tiers listed) |
| gemini-pro-latest-lte-128k | *-latest → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview ≤200K |
| gemini-pro-latest-gt-128k | *-latest → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview >200K |
| gemini-flash-latest-lte-128k | *-latest → resolved to gemini-3-flash-preview | same pricing as gemini-3-flash-preview (flat) |
| gemini-flash-latest-gt-128k | *-latest → resolved to gemini-3-flash-preview | identical to lte |
| gemini-flash-lite-latest-lte-128k | *-latest → resolved to gemini-3.1-flash-lite-preview | same pricing as gemini-3.1-flash-lite-preview (flat) |
| gemini-flash-lite-latest-gt-128k | *-latest → resolved to gemini-3.1-flash-lite-preview | identical to lte |
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | input $1.25/M, output $10/M, cache read $0.13/M, batch $0.625/$5 |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | input $2.5/M, output $15/M, cache read $0.25/M, batch $1.25/$7.5 |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat | input $0.3/M, output $2.5/M, cache read $0.03/M, batch $0.15/$1.25 |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat | identical to lte (no context tiers listed) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat | input $0.3/M, text output $2.5/M, image_token $30/M, batch $0.15/$1.25 |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat | identical to lte (no context tiers listed) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash Lite, flat | input $0.1/M, output $0.4/M, cache read $0.01/M, batch $0.05/$0.2 |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash Lite, flat | identical to lte (no context tiers listed) |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat | input $0.15/M, output $0.6/M, batch $0.075/$0.3 |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat | identical to lte (no context tiers listed) |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash (versioned), flat | same as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash (versioned), flat | identical to lte |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash Lite, flat | input $0.075/M, output $0.3/M, batch $0.0375/$0.15 |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash Lite, flat | identical to lte (no context tiers listed) |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash Lite (versioned), flat | same as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash Lite (versioned), flat | identical to lte |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4 Ultra | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4 Ultra | identical to lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4 Standard | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4 Standard | identical to lte |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4 Fast | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4 Fast | identical to lte |
| veo-2.0-generate-001-lte-128k | Veo 2 | $0.50/second, default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2 | identical to lte |
| veo-3.0-generate-001-lte-128k | Veo 3 (video only 720p/1080p) | $0.20/second, default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3 (video only 720p/1080p) | identical to lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3 Fast (video only 720p) | $0.08/second, default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3 Fast (video only 720p) | identical to lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 (video only 720p/1080p) | $0.20/second, default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 (video only 720p/1080p) | identical to lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast (video only 720p) | $0.08/second, default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast (video only 720p) | identical to lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite (video only 720p) | $0.03/second, default 8s, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite (video only 720p) | identical to lte |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | $0.00015/1K input tokens = $0.15/1M tokens, output 0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 | identical to lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview | text $0.2/1M tokens, output 0 |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview | identical to lte |

---

### Web Search Pricing Notes

- Gemini 3.x models: $14/1K search queries (5,000 free queries/month per project)
- Gemini 2.5/2.0 models: $35/1K grounded prompts (Vertex AI)

### Pricing Source Caveat

The Vertex AI pricing page (`https://cloud.google.com/vertex-ai/generative-ai/pricing`) was used as source because the Gemini API pricing page (`https://ai.google.dev/gemini-api/docs/pricing`) could not be scraped. Pricing values may differ slightly between Vertex AI and Gemini API tiers — reviewers should verify against the Gemini API pricing page when available.

---
*Generated by Pricing Agent on 2026-04-11*