### PR TITLE
chore(pricing): Update fireworks-ai pricing

### DIFF
--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -56,6 +56,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -112,10 +123,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -124,10 +135,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -136,10 +147,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -212,6 +223,17 @@
         },
         "response_token": {
           "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00016
         }
       }
     }
@@ -224,6 +246,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -236,6 +269,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -284,6 +328,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -308,6 +363,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -320,6 +386,330 @@
         },
         "response_token": {
           "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "deepseek-v3p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "deepseek-v3p2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "glm-4p7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "glm-5p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00016
+        }
+      }
+    }
+  },
+  "gpt-oss-120b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.0000035
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00012
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000008
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "flux-1-dev-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.025
+          }
+        }
+      }
+    }
+  },
+  "flux-1-schnell-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.035
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 8
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: fireworks-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 16 |
| 🔄 Models updated (merged) | 7 |

### ➕ New Models
- `deepseek-v3p1`
- `deepseek-v3p2`
- `glm-4p7`
- `glm-5p1`
- `gpt-oss-120b`
- `gpt-oss-20b`
- `llama-v3p3-70b-instruct`
- `qwen3-8b`
- `qwen3p6-plus`
- `qwen3-vl-30b-a3b-instruct`
- `qwen3-vl-30b-a3b-thinking`
- `qwen3-embedding-8b`
- `flux-1-dev-fp8`
- `flux-1-schnell-fp8`
- `flux-kontext-pro`
- `flux-kontext-max`

### 🔄 Updated Models
- `glm-5`
- `kimi-k2-instruct-0905`
- `kimi-k2-thinking`
- `kimi-k2p5`
- `minimax-m2p1`
- `minimax-m2p5`
- `mixtral-8x22b-instruct`


## Model → Pricing Page Mapping

### Named Families (from pricing page scrape, March 2026)
| Model ID | Display Name | Input | Output | Cache Read |
|---|---|---|---|---|
| deepseek-v3p1, deepseek-v3p2 | DeepSeek V3 family | $0.56 | $1.68 | $0.28 |
| glm-4p7 | GLM-4.7 | $0.60 | $2.20 | $0.30 |
| glm-5, glm-5p1 | GLM-5 / GLM 5.1 | $1.00 | $3.20 | $0.20 (named) |
| kimi-k2-instruct-0905, kimi-k2-thinking | Kimi K2 | $0.60 | $2.50 | $0.30 |
| kimi-k2p5 | Kimi K2.5 | $0.60 | $3.00 | $0.10 (named) |
| gpt-oss-120b | OpenAI gpt-oss-120b | $0.15 | $0.60 | $0.075 |
| gpt-oss-20b | OpenAI gpt-oss-20b | $0.07 | $0.30 | $0.035 |
| minimax-m2p1, minimax-m2p5 | MiniMax M2 family | $0.30 | $1.20 | $0.03 (named) |
| qwen3-vl-30b-a3b-instruct, qwen3-vl-30b-a3b-thinking | Qwen3 VL 30B A3B | $0.15 | $0.60 | $0.075 |

### Tier-Based (text/vision)
| Model ID | Tier | Input | Output |
|---|---|---|---|
| llama-v3p3-70b-instruct | >16B dense | $0.90 | $0.90 |
| mixtral-8x22b-instruct | MoE 56.1–176B | $1.20 | $1.20 |
| qwen3-8b | 4B–16B | $0.20 | $0.20 |
| qwen3p6-plus | MoE 56.1–176B (tier-based; new model, pricing page tier applied) | $1.20 | $1.20 |

### Image Models
| Model ID | Pricing Type | Price |
|---|---|---|
| flux-1-dev-fp8 | Per step | $0.00025/step |
| flux-1-schnell-fp8 | Per step | $0.00035/step |
| flux-kontext-pro | Per image | $0.04 |
| flux-kontext-max | Per image | $0.08 |

### Embedding Models
| Model ID | Input |
|---|---|
| qwen3-embedding-8b | $0.008/1M |

### Skipped (per skill rules)
- qwen3-reranker-8b (reranker — excluded)

---
*Generated by Pricing Agent on 2026-04-12*