### PR TITLE
chore(pricing): Update cohere pricing

### DIFF
--- a/general/cohere.json
+++ b/general/cohere.json
@@ -194,5 +194,55 @@
     "type": {
       "primary": "chat"
     }
+  },
+  "command-r7b-arabic-02-2025": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-fire": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-water": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-earth": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-global": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "embed-english-v3.0-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cohere-transcribe-03-2026": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -256,7 +256,271 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.25
+          "price": 0.2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "command-a-03-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-vision-07-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-reasoning-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-translate-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-plus-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "command-r7b-12-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r7b-arabic-02-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "c4ai-aya-expanse-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-vision-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-fire": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-water": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-earth": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-global": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "embed-v4.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cohere-transcribe-03-2026": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
         },
         "response_token": {
           "price": 0


### PR DESCRIPTION
## 🔄 Pricing Update: cohere

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 22 |
| 🔄 Models updated (merged) | 1 |

### ➕ New Models
- `command-a-03-2025`
- `command-a-vision-07-2025`
- `command-a-reasoning-08-2025`
- `command-a-translate-08-2025`
- `command-r-plus-08-2024`
- `command-r-08-2024`
- `command-r7b-12-2024`
- `command-r7b-arabic-02-2025`
- `c4ai-aya-expanse-32b`
- `c4ai-aya-vision-32b`
- `tiny-aya-fire`
- `tiny-aya-water`
- `tiny-aya-earth`
- `tiny-aya-global`
- `embed-v4.0`
- `embed-english-light-v3.0`
- `embed-multilingual-light-v3.0`
- `embed-multilingual-light-v3.0-image`
- `embed-english-light-v3.0-image`
- `embed-english-v3.0-image`
- ... and 2 more

### 🔄 Updated Models
- `rerank-v4.0-pro`


## Model Coverage (29 models from API)

### Generative / Chat Models ($/1M tokens)
| Model ID | Input | Output | Notes |
|---|---|---|---|
| command-a-03-2025 | $2.50 | $10.00 | Command A family |
| command-a-vision-07-2025 | $2.50 | $10.00 | Command A Vision |
| command-a-reasoning-08-2025 | $2.50 | $10.00 | Command A Reasoning |
| command-a-translate-08-2025 | $2.50 | $10.00 | Command A Translate |
| command-r-plus-08-2024 | $2.50 | $10.00 | Command R+ |
| command-r-08-2024 | $0.15 | $0.60 | Command R |
| command-r7b-12-2024 | $0.037 | $0.15 | Command R7B |
| command-r7b-arabic-02-2025 | $0.037 | $0.15 | Command R7B Arabic (same tier) |
| c4ai-aya-expanse-32b | $0.50 | $1.50 | Aya Expanse |
| c4ai-aya-vision-32b | $0.50 | $1.50 | Aya Vision (same tier) |
| tiny-aya-fire/water/earth/global | $0.037 | $0.15 | Tiny Aya variants (smallest tier) |

### Embed Models ($/1M tokens, input only)
| Model | Price |
|---|---|
| embed-v4.0 | $0.12 |
| embed-english/multilingual-v3.0 | $0.10 |
| embed-*-light-v3.0 | $0.10 |
| embed-*-image variants | $0.10 |

### Rerank Models ($2.00/1K searches = $0.002/request)
rerank-v4.0-fast, rerank-v4.0-pro, rerank-v3.5, rerank-english-v3.0, rerank-multilingual-v3.0

### Other
- cohere-transcribe-03-2026: pricing not yet available (set to $0)

⚠️ Firecrawl credits were exhausted; pricing sourced from skill reference table (official Cohere pricing as of early 2026). New models (command-a-vision, command-a-reasoning, command-a-translate, command-r7b-arabic, c4ai-aya-vision-32b, tiny-aya-*, rerank-v4.0-fast/pro, cohere-transcribe-03-2026) used closest family pricing — **please verify against https://cohere.com/pricing**.

---
*Generated by Pricing Agent on 2026-04-12*