### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,65 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemini-2.5-flash-preview-image-generation": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gemini-embedding-2-flash-001": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "claude-opus-4-1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-oss-20b-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-4o-mini-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama3-405b-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -163,6 +163,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -191,6 +194,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -351,7 +357,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
         }
       },
       "finetune_config": {
@@ -432,7 +444,7 @@
           "price": 0.0000075
         },
         "response_token": {
-          "price": 0.000003
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -440,7 +452,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "finetune_config": {
@@ -453,7 +471,7 @@
           "price": 0.00000375
         },
         "response_token": {
-          "price": 0.0000015
+          "price": 0.000015
         }
       }
     }
@@ -510,7 +528,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -550,7 +568,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -630,7 +648,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -866,7 +884,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
         }
       },
       "finetune_config": {
@@ -911,7 +935,7 @@
           "price": 0.0000075
         },
         "response_token": {
-          "price": 0.000003
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -919,7 +943,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "finetune_config": {
@@ -932,7 +962,7 @@
           "price": 0.00000375
         },
         "response_token": {
-          "price": 0.0000015
+          "price": 0.000015
         }
       }
     }
@@ -984,6 +1014,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000015
         }
       },
       "batch_config": {
@@ -1322,10 +1355,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
@@ -1560,6 +1593,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1602,7 +1638,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2272,7 +2308,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2522,7 +2558,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2545,7 +2581,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2577,6 +2613,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2693,6 +2732,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2761,6 +2803,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2791,6 +2836,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2944,6 +2992,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.012
+          },
+          "input_video_essential": {
+            "price": 0.016
+          }
         }
       }
     }
@@ -3003,7 +3059,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
@@ -3515,6 +3571,227 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-preview-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-flash-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.012
+          },
+          "input_video_essential": {
+            "price": 0.016
+          }
+        }
+      }
+    }
+  },
+  "claude-opus-4-1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0015
+        },
+        "response_token": {
+          "price": 0.0075
+        },
+        "cache_write_input_token": {
+          "price": 0.001875
+        },
+        "cache_read_input_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "gpt-oss-20b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000025
+        },
+        "cache_read_input_token": {
+          "price": 0.0000007
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.0000125
+        }
+      }
+    }
+  },
+  "gpt-4o-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gpt-4-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gpt-4o-mini-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-405b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0016
+        }
+      }
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000125
+        },
+        "response_token": {
+          "price": 0.000035
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 14 |
| 🔄 Models updated (merged) | 22 |

### ➕ New Models
- `gemini-2.5-flash-preview-image-generation`
- `imagen-4.0-capability-001`
- `gemma-4-26b-a4b-it-maas`
- `gemini-embedding-2-flash-001`
- `claude-opus-4-1`
- `gpt-oss-20b-maas`
- `gpt-4o-maas`
- `gpt-4-maas`
- `gpt-4o-mini-maas`
- `llama3-405b-instruct-maas`
- `llama-4-scout-17b-16e-instruct-maas`
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `veo-3.1-lite-generate-001`

### 🔄 Updated Models
- `gemini-3.1-pro-preview`
- `gemini-3-flash-preview`
- `gemini-3.1-flash-lite-preview`
- `gemini-2.5-pro`
- `gemini-2.0-flash-001`
- `gemini-1.5-flash-001`
- `gemini-1.5-flash-002`
- `gemini-1.5-pro-001`
- `gemini-1.5-pro-002`
- `gemini-1.0-pro-001`
- `gemini-1.0-pro-002`
- `gemini-3.1-flash-image-preview`
- `gemini-3-pro-image-preview`
- `veo-3.1-generate-001`
- `veo-3.1-fast-generate-001`
- `veo-3.0-generate-001`
- `text-embedding-004`
- `textembedding-gecko@001`
- `textembedding-gecko-multilingual@001`
- `multimodalembedding@001`
- `gemini-embedding-2-preview`
- `multimodalembedding`


## Model-to-Pricing-Page Mapping

### Google – Gemini Text Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-3.1-pro-preview` | Google – Gemini 3 | API | Input $2/1M ≤200K, Output $12/1M; cache $0.20; batch $1/$6 |
| `gemini-3-pro-preview` | Google – Gemini 3 | API | Same pricing as 3.1 Pro Preview |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | Input $0.50/1M, Output $3.00/1M |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3 | API | Input $0.25/1M, Output $1.50/1M |
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Input $1.25/1M ≤200K, Output $10/1M; cache $0.13; batch $0.625/$5 |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | Input $0.30/1M, Output $2.50/1M; cache $0.03; batch $0.15/$1.25 |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | Input $0.10/1M, Output $0.40/1M; cache $0.01 |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias for gemini-2.5-flash; same pricing |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias for gemini-2.5-flash-lite; same pricing |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 | API – price not found | No dedicated pricing row; added with price 0 |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | Input $0.15/1M, Output $0.60/1M; cache $0.015; batch $0.075/$0.30 |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | Input $0.075/1M, Output $0.30/1M; batch $0.0375/$0.15 |
| `gemini-1.5-flash-001` | Google – Gemini 1.5 | API (prev session) | Input $0.075/1M, Output $0.30/1M; cache $0.01875; batch $0.0375/$0.15 |
| `gemini-1.5-flash-002` | Google – Gemini 1.5 | API (prev session) | Same as gemini-1.5-flash-001 |
| `gemini-1.5-pro-001` | Google – Gemini 1.5 | API (prev session) | Input $1.25/1M, Output $5/1M; cache $0.3125; batch $0.625/$2.5 |
| `gemini-1.5-pro-002` | Google – Gemini 1.5 | API (prev session) | Same as gemini-1.5-pro-001 |
| `gemini-1.0-pro-001` | Google – Gemini 1.0 | API (prev session) | Input $0.50/1M, Output $1.50/1M |
| `gemini-1.0-pro-002` | Google – Gemini 1.0 | API (prev session) | Same as gemini-1.0-pro-001 |
| `gemma-4-26b-a4b-it-maas` | Google – Gemma | API | Input $0.15/1M, Output $0.60/1M; free until Apr 16 2026 |

### Google – Gemini Image + TTS Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | Input $0.30/1M, Output $2.50/1M, image_token $30/1M |
| `gemini-2.5-flash-preview-image-generation` | Google – Gemini 2.5 | API (prev session) | Preview image generation; Input $0.30, Output $2.50, image_token $30/1M |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3 | API | Input $0.50/1M, Output $3.00/1M, image_token $60/1M |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API | Input $2.00/1M, Output $12.00/1M, image_token $120/1M |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no token pricing row found; added with price 0 |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no token pricing row found; added with price 0 |

### Google – Imagen Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `imagen-4.0-ultra-generate-001` | Google – Imagen 4 | API | $0.06/image |
| `imagen-4.0-generate-001` | Google – Imagen 4 | API | $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4 | API | $0.02/image |
| `imagen-4.0-capability-001` | Google – Imagen 4 | API | $0.04/image; capability uses Imagen 4 generate pricing |
| `imagen-3.0-generate-001` | Google – Imagen 3 | API (prev session) | $0.04/image |
| `imagen-3.0-generate-002` | Google – Imagen 3 | API | $0.04/image; same row as 3.0 generate |
| `imagen-3.0-fast-generate-001` | Google – Imagen 3 | API (prev session) | $0.02/image |
| `imagen-3.0-capability-001` | Google – Imagen 3 | API | $0.04/image; capability uses Imagen 3 generate pricing |
| `imagen-3.0-capability-002` | Google – Imagen 3 | API | $0.04/image; capability uses Imagen 3 generate pricing |

### Google – Veo Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | $0.40/sec (video+audio 720p/1080p); default 8s, 1 sample |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | $0.10/sec (video+audio 720p); default 8s, 1 sample |
| `veo-3.1-lite-generate-001` | Google – Veo 3.1 Lite | API | $0.05/sec (video+audio 720p); default 8s, 1 sample |
| `veo-3.0-generate-001` | Google – Veo 3 | API | $0.40/sec (video+audio); default 8s, 1 sample |
| `veo-3.0-fast-generate-001` | Google – Veo 3 Fast | API | $0.10/sec (video+audio 720p); default 8s, 1 sample |
| `veo-2.0-generate-001` | Google – Veo 2 | API | $0.50/sec; default 8s, 1 sample |

### Google – Embedding Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-embedding-001` | Google – Gemini Embedding | API | $0.00015/1K tokens; batch $0.00012/1K |
| `gemini-embedding-2-preview` | Google – Gemini Embedding 2 | API | $0.2/1M tokens; image $0.00012/image; audio $0.00016/sec |
| `gemini-embedding-2-flash-001` | Google – Gemini Embedding 2 | API (prev session) | Same as gemini-embedding-2-preview |
| `text-embedding-005` | Google – Text Embedding | API | $0.000025/1K chars |
| `text-embedding-004` | Google – Text Embedding | API (prev session) | $0.000025/1K chars |
| `text-embedding-large-exp-03-07` | Google – Text Embedding | API | $0.000025/1K chars; shares pricing with text-embedding-005 |
| `textembedding-gecko` | Google – Text Embedding | API | $0.000025/1K chars; legacy gecko base |
| `textembedding-gecko@001` | Google – Text Embedding | API (prev session) | $0.000025/1K chars |
| `textembedding-gecko@003` | Google – Text Embedding | API (prev session) | $0.000025/1K chars |
| `textembedding-gecko-multilingual@001` | Google – Text Embedding | API (prev session) | $0.000025/1K chars |
| `text-multilingual-embedding-002` | Google – Text Embedding | API | $0.000025/1K chars |
| `multimodalembedding` | Google – Multimodal Embedding | API | text $0.0002/1K chars; image $0.0001/image; video plus $0.0020/sec; standard $0.0010/sec; essential $0.0005/sec |
| `multimodalembedding@001` | Google – Multimodal Embedding | API (prev session) | Same as multimodalembedding |

### Anthropic – Claude Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `claude-opus-4-6` | Anthropic – Claude | API (@default stripped) | Input $5/1M, Output $25/1M; cache write 5m $6.25; cache read $0.50 |
| `claude-opus-4-5@20251101` | Anthropic – Claude | API | Input $5/1M, Output $25/1M; cache write 5m $6.25; cache read $0.50 |
| `claude-opus-4-5` | Anthropic – Claude | API (prev session, no @date) | Input $5/1M, Output $25/1M; cache write 5m $6.25; cache read $0.50 |
| `claude-sonnet-4-6` | Anthropic – Claude | API (@default stripped) | Input $3/1M, Output $15/1M; cache write 5m $3.75; cache read $0.30 |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude | API | Input $3/1M, Output $15/1M; cache write 5m $3.75; cache read $0.30 |
| `claude-haiku-4-5@20251001` | Anthropic – Claude | API | Input $1/1M, Output $5/1M; cache write 5m $1.25; cache read $0.10 |
| `claude-haiku-4-5` | Anthropic – Claude | API (prev session, no @date) | Input $1/1M, Output $5/1M; cache write 5m $1.25; cache read $0.10 |
| `claude-opus-4-1@20250805` | Anthropic – Claude | API | Input $15/1M, Output $75/1M; cache write 5m $18.75; cache read $1.50 |
| `claude-opus-4-1` | Anthropic – Claude | API (prev session, no @date) | Input $15/1M, Output $75/1M; cache write 5m $18.75; cache read $1.50 |
| `claude-opus-4@20250514` | Anthropic – Claude | API | Input $15/1M, Output $75/1M; cache write 5m $18.75; cache read $1.50 |
| `claude-sonnet-4@20250514` | Anthropic – Claude | API | Input $3/1M, Output $15/1M; cache write 5m $3.75; cache read $0.30 |

### OpenAI Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gpt-oss-120b-maas` | OpenAI – GPT | API | Input $0.09/1M, Output $0.36/1M; batch $0.045/$0.18 |
| `gpt-oss-20b-maas` | OpenAI – GPT | API (prev session) | Input $0.07/1M, Output $0.25/1M; cache $0.007; batch $0.035/$0.125 |
| `gpt-4o-maas` | OpenAI – GPT | API (prev session) – price not found | No pricing row on Vertex page; added with price 0 |
| `gpt-4-maas` | OpenAI – GPT | API (prev session) – price not found | No pricing row on Vertex page; added with price 0 |
| `gpt-4o-mini-maas` | OpenAI – GPT | API (prev session) – price not found | No pricing row on Vertex page; added with price 0 |

### Meta – Llama Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `llama3-405b-instruct-maas` | Meta – Llama | API (prev session) | Input $5/1M, Output $16/1M; row: Llama 3.1 405B |
| `llama-3.3-70b-instruct-maas` | Meta – Llama | API | Input $0.72/1M, Output $0.72/1M; batch $0.36/$0.36 |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama | API | Input $0.35/1M, Output $1.15/1M; batch $0.175/$0.575 |
| `llama-4-scout-17b-16e-instruct-maas` | Meta – Llama | API (prev session) | Input $0.25/1M, Output $0.70/1M; batch $0.125/$0.35 |

**Meta excluded:** faster-r-cnn, retinanet, mask-r-cnn, segment-anything (CV non-generative); xlm-roberta-large, roberta-large (NLP non-generative); nllb (translation); imagebind (multimodal understanding); llama-guard, prompt-guard (guard models); codellama-7b-hf, llama2, llama-2-quantized, llama3, llama4, llama3_1, llama3-2, llama3-3 (self-deploy); sam3 (non-generative CV)

### Mistral Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `mistral-small-2503` | Mistral – MaaS | API | Input $0.10/1M, Output $0.30/1M; row: Mistral Small 3.1 |
| `mistral-medium-3` | Mistral – MaaS | API | Input $0.40/1M, Output $2.00/1M |
| `codestral-2` | Mistral – MaaS | API | Input $0.30/1M, Output $0.90/1M |

**Mistral excluded:** codestral-2501-self-deploy (self-deploy); mistral-ocr-2505 (OCR); ministral-3 (self-deploy); mistral-large-3 (self-deploy)

### DeepSeek Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `deepseek-r1-0528-maas` | DeepSeek – MaaS | API | Input $1.35/1M, Output $5.40/1M; batch $0.675/$2.70 |
| `deepseek-v3.1-maas` | DeepSeek – MaaS | API | Input $0.60/1M, Output $1.70/1M; cache $0.06; batch $0.30/$0.85 |
| `deepseek-v3.2-maas` | DeepSeek – MaaS | API | Input $0.56/1M, Output $1.68/1M; cache $0.056; batch $0.28/$0.84 |

**DeepSeek excluded:** deepseek-r1 (self-deploy); deepseek-v3 (self-deploy); deepseek-v3-1 (self-deploy); deepseek-v3-2 (self-deploy); deepseek-ocr (self-deploy); deepseek-ocr-2 (self-deploy); deepseek-ocr-maas (OCR)

### Qwen Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen – MaaS | API | Input $0.22/1M, Output $0.88/1M; batch $0.11/$0.44 |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen – MaaS | API | Input $0.22/1M, Output $1.80/1M; cache $0.022; batch $0.11/$0.90 |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen – MaaS | API | Input $0.15/1M, Output $1.20/1M |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen – MaaS | API | Input $0.15/1M, Output $1.20/1M |

**Qwen excluded:** qwq, qwen3, qwen3-embedding, qwen3-5, qwen2, qwen3-coder-next, qwen3-coder, qwen3-next, qwen3-vl (all self-deploy); qwen-image (explicit policy exception)

### MoonshotAI / Kimi Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `kimi-k2-thinking-maas` | MoonshotAI – Kimi | API | Input $0.60/1M, Output $2.50/1M; cache $0.06 |

**MoonshotAI excluded:** kimi-k2-5, kimi-k2 (self-deploy)

### MiniMax Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `minimax-m2-maas` | MiniMax – MaaS | API | Input $0.30/1M, Output $1.20/1M; cache $0.03 |

**MiniMax excluded:** minimax-m2 (self-deploy)

### ZAI.org / GLM Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `glm-4.7-maas` | ZAI.org – GLM | API | Input $0.60/1M, Output $2.20/1M |
| `glm-5-maas` | ZAI.org – GLM | API | Input $1.00/1M, Output $3.20/1M; cache $0.10 |

**ZAI.org excluded:** glm-4.7, glm-5, glm-4.5, glm-ocr (self-deploy); glm-image (explicit policy exception); glm-ocr (OCR)

### AI21 Models

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| — | AI21 | API | jamba-large-1.6 is self-deploy only (has_deploy: true, no -maas suffix); excluded per partners.md rules |

### Global Excludes Applied

- `gemini-live-2.5-flash-native-audio` — `*-live-*` streaming, separate product
- `lyria-002`, `lyria-3-pro-preview`, `lyria-3-clip-preview` — music generation
- `virtual-try-on-001` — product-specific retail model
- `imagegeneration` — legacy model superseded by imagen-3.0+
- `shieldgemma2` — safety/guard model
- All Gemma self-deploy variants (gemma, gemma2, gemma3, gemma3n, gemma4, codegemma, paligemma, etc.) — self-deploy
- All non-generative CV/NLP (BERT, ResNet, YOLO, ViT, SAM, etc.) — non-generative ML
- All weather/earth/medical foundation models — non-generative / self-deploy
- `chirp-2`, `chirp-3` — audio transcription / speech, non-generative inference
- `translate-llm`, `text-translation` — translation only, non-generative
- `pretrained-ocr` — OCR, non-generative

---
*Generated by Pricing Agent on 2026-04-12*