### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1333,7 +1333,7 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 10
         },
         "response_audio_token": {
           "price": 0
@@ -1357,6 +1357,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.0015
         }
       }
     }
@@ -1369,6 +1372,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.003
         }
       }
     }
@@ -1377,10 +1383,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0
+          "price": 0.001
         },
         "request_audio_token": {
           "price": 0
@@ -1395,7 +1401,7 @@
           "response_audio_token": {
             "price": 0.0012
           }
-        }     
+        }
       }
     }
   },
@@ -1409,7 +1415,7 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.0006
         },
         "response_audio_token": {
           "price": 0
@@ -1435,7 +1441,7 @@
           "price": 0.0005
         },
         "request_audio_token": {
-          "price": 0.3
+          "price": 0.0003
         },
         "response_audio_token": {
           "price": 0
@@ -1745,7 +1751,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1786,7 +1792,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2217,13 +2223,13 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2283,16 +2289,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2310,16 +2316,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2332,6 +2338,9 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2344,6 +2353,9 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2356,6 +2368,9 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       }
     }
@@ -2368,6 +2383,9 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       }
     }
@@ -2643,10 +2661,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2793,10 +2811,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2882,6 +2900,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.004
         }
       }
     }
@@ -3420,6 +3444,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0032
         }
       }
     }
@@ -3757,10 +3787,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0
+          "price": 0.001
         },
         "response_audio_token": {
           "price": 0.0012
@@ -3772,10 +3802,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0
+          "price": 0.001
         },
         "response_audio_token": {
           "price": 0.0012
@@ -3821,6 +3851,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.0015
         }
       }
     }
@@ -3833,6 +3866,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.003
         }
       }
     }
@@ -3844,7 +3880,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.004
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -3868,7 +3904,7 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0
+          "price": 0.0008
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -4105,6 +4141,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }
@@ -4125,6 +4164,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 28 |


### 🔄 Updated Models
- `gpt-5.4-pro-2026-03-05`
- `gpt-5.4-pro`
- `gpt-4o-search-preview-2025-03-11`
- `gpt-4o-search-preview`
- `chatgpt-image-latest`
- `gpt-4o-mini-tts-2025-12-15`
- `gpt-4o-mini-tts-2025-03-20`
- `gpt-image-1.5`
- `gpt-audio-mini`
- `gpt-image-1-mini`
- `o4-mini-deep-research-2025-06-26`
- `gpt-image-1`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `gpt-4o-mini-tts`
- `gpt-4o-mini-transcribe`
- `gpt-4o-transcribe`
- `gpt-4o-mini-search-preview`
- `gpt-4o-mini-search-preview-2025-03-11`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-4o-audio-preview`
- `tts-1-hd-1106`
- `tts-1-1106`
- `tts-1-hd`
- `tts-1`
- `whisper-1`


## Model Coverage

All 128 models from the OpenAI Models API processed across 5 batches:

| Batch | Models | Count |
|-------|--------|-------|
| 1 | gpt-5.4 family, gpt-5.2-pro, gpt-5.3-chat-latest, gpt-4o-search-preview, audio/realtime/TTS/transcribe mini variants | 25 |
| 2 | gpt-5.2, gpt-5.1, gpt-5.1-codex family, sora-2/pro, gpt-realtime, gpt-audio, gpt-5-pro/codex, image-1 variants | 25 |
| 3 | gpt-5/mini/nano, o-series (o3, o4-mini, deep-research, o3-pro), gpt-4.1 family, gpt-image-1, gpt-4o transcribe | 25 |
| 4 | o4-mini/o3 dated, o1/o1-pro, o3-mini, computer-use-preview, gpt-4o-mini audio/realtime, gpt-4o-realtime-preview | 25 |
| 5 | gpt-4o family, gpt-4-turbo, gpt-4, gpt-3.5-turbo family, embeddings, TTS, DALL-E, whisper | 28 |

## Pricing Source
- **Models API**: `get_openai_models` tool (128 models, ft:* excluded)
- **Pricing data**: LiteLLM community pricing JSON (`https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`) — used as fallback after OpenAI pricing page returned 403 (Cloudflare-protected)

## Special Model Notes
- **sora-2 / sora-2-pro**: Video generation; priced per second (`video_duration_seconds_720_1280`)
- **dall-e-2 / dall-e-3**: Image generation with per-image tier pricing (standard/hd + resolution)
- **tts-1 / tts-1-hd (+ dated variants)**: TTS models priced per million characters
- **whisper-1**: Audio transcription priced per minute
- **omni-moderation-***: Free (input/output = 0)
- **gpt-image-1 / gpt-image-1-mini / gpt-image-1.5 / chatgpt-image-latest**: Image generation with token-based pricing

---
*Generated by Pricing Agent on 2026-04-12*