### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,16 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -630,7 +630,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -976,13 +976,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1
           },
           "search": {
-            "price": 3.5
+            "price": 1
           },
           "enterprise_web_search": {
-            "price": 4.5
+            "price": 2
           }
         }
       },
@@ -1106,13 +1106,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1
           },
           "search": {
-            "price": 3.5
+            "price": 1
           },
           "enterprise_web_search": {
-            "price": 4.5
+            "price": 2
           }
         }
       },
@@ -1211,7 +1211,7 @@
             "price": 1.4
           },
           "enterprise_web_search": {
-            "price": 1.4
+            "price": 4.5
           },
           "image_token": {
             "price": 0.012
@@ -1329,16 +1329,16 @@
         },
         "additional_units": {
           "input_image": {
-            "price": 0.01
+            "price": 0.0001
           },
           "input_video_plus": {
-            "price": 0.2
+            "price": 0.002
           },
           "input_video_standard": {
-            "price": 0.1
+            "price": 0.001
           },
           "input_video_essential": {
-            "price": 0.05
+            "price": 0.0005
           }
         }
       },
@@ -1560,6 +1560,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         },
         "cache_read_input_token": {
@@ -1602,7 +1605,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2522,7 +2525,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2578,6 +2581,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2693,6 +2699,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2753,7 +2762,7 @@
           "price": 0.000025
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2761,12 +2770,15 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2792,6 +2804,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -2932,6 +2947,17 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
         }
       }
     }
@@ -2944,6 +2970,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.00012
+          },
+          "input_video_plus": {
+            "price": 0.00079
+          }
         }
       }
     }
@@ -3515,6 +3549,70 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 4 |
| 🔄 Models updated (merged) | 14 |

### ➕ New Models
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `veo-3.1-lite-generate-001`
- `gemma-4-26b-a4b-it-maas`

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-2.5-computer-use-preview-10-2025`
- `gemini-2.0-flash-001`
- `gemini-2.0-flash-lite-001`
- `gemini-3-pro-preview`
- `gemini-3-flash-preview`
- `gemini-3-pro-image-preview`
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-image-preview`
- `gemini-3.1-flash-lite-preview`
- `veo-3.1-fast-generate-001`
- `multimodalembedding@001`
- `textembedding-gecko-multilingual@001`
- `gemini-embedding-2-preview`


## Model-to-Pricing-Page Mapping

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 Pro | API | Standard tier (≤200K) pricing used; batch included |
| `gemini-2.5-flash` | Google – Gemini 2.5 Flash | API | Standard pricing; batch included |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 Flash | API | Preview alias; same pricing as gemini-2.5-flash |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 Flash Lite | API | Standard pricing; batch included |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 Flash Lite | API | Preview alias; same pricing as gemini-2.5-flash-lite |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 Flash Image | API | Token pricing + image_token additional ($30/M); batch included |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 Pro Computer Use | API | Same pricing as Gemini 2.5 Pro per pricing page |
| `gemini-2.5-pro-tts` | Google – Gemini | API – price not found | TTS model; no pricing row on page |
| `gemini-2.5-flash-tts` | Google – Gemini | API – price not found | TTS model; no pricing row on page |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 Flash | API | Standard pricing; batch included; web_search $10/1000 |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 Flash Lite | API | Standard pricing; batch included |
| `gemini-3-pro-preview` | Google – Gemini 3 Pro Preview | API | Standard tier (≤200K) pricing; batch included |
| `gemini-3-flash-preview` | Google – Gemini 3 Flash Preview | API | Standard pricing; batch included |
| `gemini-3-pro-image-preview` | Google – Gemini 3 Pro Image Preview | API | Token pricing + image_token additional ($120/M); batch included |
| `gemini-3.1-pro-preview` | Google – Gemini 3.1 Pro Preview | API | Same pricing as Gemini 3 Pro Preview |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3.1 Flash Image Preview | API | Token pricing + image_token additional ($60/M); batch included |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3.1 Flash Lite Preview | API | Standard pricing; batch included |
| `imagen-4.0-ultra-generate-001` | Google – Imagen 4 Ultra | API | $0.06/image |
| `imagen-4.0-generate-001` | Google – Imagen 4 | API | $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4 Fast | API | $0.02/image |
| `imagen-3.0-generate-002` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-capability-001` | Google – Imagen 3 (capability) | API | Shares pricing with imagen-3.0-generate ($0.04/image) |
| `imagen-3.0-capability-002` | Google – Imagen 3 (capability) | API | Shares pricing with imagen-3.0-generate ($0.04/image) |
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | $0.20/sec video-only 720p/1080p |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | $0.10/sec video-only 720p/1080p |
| `veo-3.1-lite-generate-001` | Google – Veo 3.1 Lite | API | $0.03/sec video-only 720p |
| `veo-3.0-generate-001` | Google – Veo 3 | API | $0.20/sec video-only |
| `veo-3.0-fast-generate-001` | Google – Veo 3 Fast | API | $0.10/sec video-only |
| `veo-2.0-generate-001` | Google – Veo 2 | API | $0.50/sec |
| `gemini-embedding-001` | Google – Gemini Embedding | API | $0.00015/1K tokens |
| `gemini-embedding-2-preview` | Google – Gemini Embedding 2 Preview | API | $0.2/M tokens; image/video additional |
| `text-embedding-005` | Google – Text Embedding | API | $0.000025/1K chars (text embedding) |
| `text-multilingual-embedding-002` | Google – Text Multilingual Embedding | API | $0.000025/1K chars |
| `text-embedding-large-exp-03-07` | Google – Text Embedding (experimental) | API | $0.000025/1K chars; no dedicated row, shares text embedding pricing |
| `multimodalembedding@001` | Google – Multimodal Embedding | API | Per-image/video additional units |
| `textembedding-gecko@003` | Google – Textembedding Gecko (legacy) | API | $0.000025/1K chars |
| `textembedding-gecko-multilingual@001` | Google – Textembedding Gecko Multilingual (legacy) | API | $0.000025/1K chars |
| `gemma-4-26b-a4b-it-maas` | Google – Gemma 4 | API | $0.15/$0.60 per 1M tokens; free until Apr 16, 2026 per page note |
| `claude-opus-4-6` | Anthropic – Claude Opus 4.6 | API | @default stripped; $5/$25 per 1M; cache write 5m $6.25; batch included |
| `claude-sonnet-4-6` | Anthropic – Claude Sonnet 4.6 | API | @default stripped; $3/$15 per 1M; cache write 5m $3.75; batch included |
| `claude-opus-4-5@20251101` | Anthropic – Claude Opus 4.5 | API | $5/$25 per 1M; cache write 5m $6.25; batch included |
| `claude-haiku-4-5@20251001` | Anthropic – Claude Haiku 4.5 | API | $1/$5 per 1M; cache write 5m $1.25; batch included |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude Sonnet 4.5 | API | Standard tier (≤200K) $3/$15; cache write 5m $3.75; batch included |
| `claude-opus-4-1@20250805` | Anthropic – Claude Opus 4.1 | API | $15/$75 per 1M; cache write 5m $18.75; batch included |
| `claude-opus-4@20250514` | Anthropic – Claude Opus 4 | API | $15/$75 per 1M; cache write 5m $18.75; batch included |
| `claude-sonnet-4@20250514` | Anthropic – Claude Sonnet 4 | API | $3/$15 per 1M; cache write 5m $3.75; batch included |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama 4 Maverick | API | $0.35/$1.15 per 1M; batch included |
| `llama-3.3-70b-instruct-maas` | Meta – Llama 3.3 70B | API | $0.72/$0.72 per 1M; batch included |
| `gpt-oss-120b-maas` | OpenAI – GPT OSS 120B | API | $0.09/$0.36 per 1M; batch included |
| `mistral-small-2503` | Mistral – Mistral Small 3.1 | API | $0.10/$0.30 per 1M |
| `mistral-medium-3` | Mistral – Mistral Medium 3 | API | $0.40/$2.00 per 1M |
| `codestral-2` | Mistral – Codestral 2 | API | $0.30/$0.90 per 1M |
| `deepseek-v3.1-maas` | DeepSeek – DeepSeek V3.1 | API | $0.60/$1.70 per 1M; cache hit; batch included |
| `deepseek-v3.2-maas` | DeepSeek – DeepSeek V3.2 | API | $0.56/$1.68 per 1M; cache hit; batch included |
| `deepseek-r1-0528-maas` | DeepSeek – DeepSeek R1 0528 | API | $1.35/$5.40 per 1M; batch included |
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen – Qwen3 235B | API | $0.22/$0.88 per 1M; batch included |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen – Qwen3 Coder 480B | API | $0.22/$1.80 per 1M; cache hit; batch included |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen – Qwen3 Next 80B Instruct | API | $0.15/$1.20 per 1M |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen – Qwen3 Next 80B Thinking | API | $0.15/$1.20 per 1M |
| `kimi-k2-thinking-maas` | Moonshot/Kimi – Kimi K2 Thinking | API | $0.60/$2.50 per 1M; cache hit |
| `minimax-m2-maas` | MiniMax – MiniMax M2 | API | $0.30/$1.20 per 1M; cache hit |
| `glm-4.7-maas` | ZAI.org – GLM-4.7 | API | $0.60/$2.20 per 1M |
| `glm-5-maas` | ZAI.org – GLM-5 | API | $1.00/$3.20 per 1M; cache hit; free until Feb 19, 2026 per page note |

## Excluded Models

| Model | Publisher | Reason |
|-------|-----------|--------|
| `virtual-try-on-001` | Google | Excluded per google.md (product-specific retail) |
| `lyria-002`, `lyria-3-pro-preview`, `lyria-3-clip-preview` | Google | `lyria-*` music generation — no inference pricing |
| `gemini-live-2.5-flash-native-audio` | Google | `*-live-*` streaming product |
| `whisper-large` | OpenAI | Audio transcription — not generative inference |
| `openclip`, `clip-vit-base-patch32` | OpenAI | Non-generative (vision classification/embedding) |
| `gpt-oss` | OpenAI | `has_deploy: true`, no `-maas` suffix |
| `sam3`, `faster-r-cnn`, `retinanet`, `mask-r-cnn` | Meta | Non-generative (segmentation/detection) |
| `roberta-large`, `xlm-roberta-large` | Meta | Non-generative NLP |
| `llama-guard`, `prompt-guard` | Meta | Safety/guard models |
| `llama2`, `llama3`, `llama4`, `llama3_1`, `llama3-2`, `llama3-3`, `llama-2-quantized`, `codellama-7b-hf` | Meta | `has_deploy: true`, no `-maas` |
| `imagebind` | Meta | Self-deploy embedding |
| `nllb` | Meta | Self-deploy translation |
| `segment-anything` | Meta | Non-generative (segmentation) |
| `qwen-image` | Qwen | Explicit policy exception (image generation excluded from Vertex pricing) |
| `qwq`, `qwen3`, `qwen3-embedding`, `qwen3-5`, `qwen2`, `qwen3-coder-next`, `qwen3-coder`, `qwen3-next`, `qwen3-vl` | Qwen | `has_deploy: true`, no `-maas` |
| `codestral-2501-self-deploy` | Mistral | Name contains `self-deploy` |
| `mistral-ocr-2505` | Mistral | OCR model |
| `ministral-3`, `mistral-large-3` | Mistral | `has_deploy: true`, no `-maas` |
| All `mistral-ai` publisher models (2) | Mistral | `has_deploy: true`, no `-maas` |
| `deepseek-r1`, `deepseek-v3`, `deepseek-v3-1`, `deepseek-v3-2` | DeepSeek | `has_deploy: true`, no `-maas` |
| `deepseek-ocr-maas`, `deepseek-ocr`, `deepseek-ocr-2` | DeepSeek | OCR models |
| `kimi-k2-5`, `kimi-k2` | Moonshot | `has_deploy: true`, no `-maas` |
| `minimax-m2` | MiniMax | `has_deploy: true`, no `-maas` |
| `glm-image` | ZAI.org | Explicit policy exception |
| `glm-ocr` | ZAI.org | OCR model |
| `glm-4.7`, `glm-5`, `glm-4.5` | ZAI.org | `has_deploy: true`, no `-maas` |
| `jamba-large-1.6` | AI21 | `has_deploy: true`, no `-maas` |
| All non-generative Google models | Google | Gemma, Codey, PaLM, CV/detection, OCR, non-generative variants |

---
*Generated by Pricing Agent on 2026-04-12*