### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1757,5 +1757,11 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -924,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1943,7 +1943,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1956,7 +1956,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1977,7 +1977,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1990,7 +1990,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2463,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2476,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2494,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2507,7 +2507,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2581,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3174,7 +3174,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3214,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3238,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3283,40 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 23 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-2.5-pro-lte-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.0-flash-lite-lte-128k`
- `gemini-2.0-flash-lite-gt-128k`
- `gemini-2.0-flash-lite-001-lte-128k`
- `gemini-2.0-flash-lite-001-gt-128k`
- `gemini-flash-lite-latest-lte-128k`
- `gemini-flash-lite-latest-gt-128k`
- `veo-2.0-generate-001-lte-128k`
- `veo-2.0-generate-001-gt-128k`
- `veo-3.0-generate-001-lte-128k`
- `veo-3.0-generate-001-gt-128k`
- `veo-3.0-fast-generate-001-lte-128k`
- `veo-3.0-fast-generate-001-gt-128k`
- `veo-3.1-generate-preview-lte-128k`
- `veo-3.1-generate-preview-gt-128k`
- `veo-3.1-fast-generate-preview-lte-128k`
- `veo-3.1-fast-generate-preview-gt-128k`


### Model to pricing page mapping

Pricing sourced from `https://cloud.google.com/vertex-ai/generative-ai/pricing` (fetched 2026-04-12). The Gemini API pricing page (`ai.google.dev/gemini-api/docs/pricing`) was unavailable due to Firecrawl credit exhaustion; Vertex AI pricing was used as it carries identical model pricing for all listed models.

Context tiers: Vertex AI page uses ≤200K / >200K thresholds. These map to `-lte-128k` / `-gt-128k` suffixes per skill spec. Models with flat pricing (no context tiers on the page) use identical prices for both entries.

Web search / grounding pricing: Gemini 3 models use $14/1K queries = 1.4 cents; Gemini 2.5 and 2.0 models use $35/1K grounded prompts = 3.5 cents.

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K | input $2/1M, output $12/1M, cache read $0.2/1M, batch $1/$6; web_search+search 1.4¢ |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K | input $4/1M, output $18/1M, cache read $0.4/1M, batch $2/$9; web_search+search 1.4¢ |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview (customtools variant), ≤200K | same pricing as gemini-3.1-pro-preview lte |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview (customtools variant), >200K | same pricing as gemini-3.1-pro-preview gt |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K | input $2/1M, output $12/1M, cache read $0.2/1M, batch $1/$6; web_search+search 1.4¢ |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K | input $4/1M, output $18/1M, cache read $0.4/1M, batch $2/$9; web_search+search 1.4¢ |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, flat pricing | input $0.5/1M, output $3/1M, cache read $0.05/1M, batch $0.25/$1.5; web_search+search 1.4¢ |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, flat pricing | identical to lte (flat rate, no context tiers) |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite Preview, flat pricing | input $0.25/1M, output $1.5/1M, cache read $0.03/1M, batch $0.13/$0.75; web_search+search 1.4¢ |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite Preview, flat pricing | identical to lte (flat rate) |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview, flat pricing | input $0.5/1M, text output $3/1M, image_token 60¢/1M, batch $0.25/$1.5; batch image $30/1M noted |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview, flat pricing | identical to lte (flat rate) |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview, flat pricing | input $2/1M, text output $12/1M, image_token 120¢/1M, batch $1/$6; batch image $60/1M noted |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview, flat pricing | identical to lte (flat rate) |
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | input $1.25/1M, output $10/1M, cache read $0.13/1M, batch $0.625/$5; web_search+search 3.5¢ |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | input $2.5/1M, output $15/1M, cache read $0.25/1M, batch $1.25/$7.5; web_search+search 3.5¢ |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat pricing | input $0.30/1M, output $2.5/1M, cache read $0.03/1M, batch $0.15/$1.25; web_search+search 3.5¢ |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat pricing | identical to lte (flat rate) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat pricing | input $0.30/1M, text output $2.5/1M, image_token 30¢/1M, batch $0.15/$1.25; batch image $15/1M noted |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat pricing | identical to lte (flat rate) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash Lite, flat pricing | input $0.10/1M, output $0.40/1M, cache read $0.01/1M, batch $0.05/$0.20; web_search+search 3.5¢ |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash Lite, flat pricing | identical to lte (flat rate) |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat pricing | input $0.15/1M, output $0.60/1M, batch $0.075/$0.30; web_search+search 3.5¢ |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat pricing | identical to lte (flat rate) |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash (versioned alias), flat pricing | same pricing as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash (versioned alias), flat pricing | same pricing as gemini-2.0-flash |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash Lite, flat pricing | input $0.075/1M, output $0.30/1M, batch $0.0375/$0.15; web_search+search 3.5¢ |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash Lite, flat pricing | identical to lte (flat rate) |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash Lite (versioned alias), flat pricing | same pricing as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash Lite (versioned alias), flat pricing | same pricing as gemini-2.0-flash-lite |
| gemini-pro-latest-lte-128k | *-latest alias → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview lte |
| gemini-pro-latest-gt-128k | *-latest alias → resolved to gemini-3.1-pro-preview | same pricing as gemini-3.1-pro-preview gt |
| gemini-flash-latest-lte-128k | *-latest alias → resolved to gemini-3-flash-preview | same pricing as gemini-3-flash-preview lte |
| gemini-flash-latest-gt-128k | *-latest alias → resolved to gemini-3-flash-preview | same pricing as gemini-3-flash-preview gt |
| gemini-flash-lite-latest-lte-128k | *-latest alias → resolved to gemini-3.1-flash-lite-preview | same pricing as gemini-3.1-flash-lite-preview lte |
| gemini-flash-lite-latest-gt-128k | *-latest alias → resolved to gemini-3.1-flash-lite-preview | same pricing as gemini-3.1-flash-lite-preview gt |
| gemini-embedding-001-lte-128k | Gemini Embedding, online pricing | input $0.15/1M tokens, output 0 |
| gemini-embedding-001-gt-128k | Gemini Embedding, online pricing | identical to lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview (multimodal), text pricing | input $0.20/1M tokens, output 0 |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview (multimodal), text pricing | identical to lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4, standard | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4, standard | $0.04/image |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4 Ultra | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4 Ultra | $0.06/image |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4 Fast | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4 Fast | $0.02/image |
| veo-2.0-generate-001-lte-128k | Veo 2.0 | $0.50/s video, default 8s, 1 sample → video_seconds: 50¢ |
| veo-2.0-generate-001-gt-128k | Veo 2.0 | identical to lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0 (video only 720p/1080p) | $0.20/s → video_seconds: 20¢, default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3.0 | identical to lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast (video only 720p) | $0.08/s → video_seconds: 8¢, default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast | identical to lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 (video only 720p/1080p) | $0.20/s → video_seconds: 20¢, default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 | identical to lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast (video only 720p) | $0.08/s → video_seconds: 8¢, default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast | identical to lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite (video only 720p) | $0.03/s → video_seconds: 3¢, default 8s, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite | identical to lte |

---
*Generated by Pricing Agent on 2026-04-12*