### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/general/openai.json
+++ b/general/openai.json
@@ -2854,5 +2854,10 @@
     ],
 
     "type": { "primary": "chat", "supported": ["tools", "image"] }
+  },
+  "gpt-5-chat": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -1333,7 +1333,7 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.0000006
         },
         "response_audio_token": {
           "price": 0
@@ -1357,6 +1357,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.0015
         }
       }
     }
@@ -1369,6 +1372,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.003
         }
       }
     }
@@ -1377,7 +1383,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -1409,7 +1415,7 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.0006
         },
         "response_audio_token": {
           "price": 0
@@ -1435,7 +1441,7 @@
           "price": 0.0005
         },
         "request_audio_token": {
-          "price": 0.3
+          "price": 0.0003
         },
         "response_audio_token": {
           "price": 0
@@ -1578,9 +1584,6 @@
         },
         "response_token": {
           "price": 0.0012
-        },
-        "cache_read_input_token": {
-          "price": 0.000075
         }
       },
       "batch_config": {
@@ -1601,9 +1604,6 @@
         },
         "response_token": {
           "price": 0.0012
-        },
-        "cache_read_input_token": {
-          "price": 0.000075
         }
       }
     }
@@ -2289,16 +2289,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2316,16 +2316,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2338,6 +2338,9 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2350,6 +2353,9 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2362,6 +2368,9 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       }
     }
@@ -2374,6 +2383,9 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       }
     }
@@ -2649,10 +2661,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2721,25 +2733,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0016
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.0016
         },
         "cache_read_audio_input_token": {
-          "price": 0.00025
+          "price": 0.0064
         },
         "response_audio_token": {
-          "price": 0.008
+          "price": 0.0064
         },
         "request_audio_token": {
-          "price": 0.004
+          "price": 0.0032
         }
       }
     }
@@ -2748,25 +2760,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0016
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.0016
         },
         "cache_read_audio_input_token": {
-          "price": 0.00025
+          "price": 0.0064
         },
         "response_audio_token": {
-          "price": 0.008
+          "price": 0.0064
         },
         "request_audio_token": {
-          "price": 0.004
+          "price": 0.0032
         }
       }
     }
@@ -2781,10 +2793,10 @@
           "price": 0.001
         },
         "response_audio_token": {
-          "price": 0.008
+          "price": 0.0064
         },
         "request_audio_token": {
-          "price": 0.004
+          "price": 0.0032
         }
       }
     }
@@ -2793,10 +2805,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00024
         },
         "response_audio_token": {
           "price": 0.002
@@ -2893,7 +2905,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.004
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -2932,10 +2944,10 @@
         },
         "additional_units": {
           "video_duration_seconds_720_1280": {
-            "price": 50
+            "price": 30
           },
           "video_duration_seconds_1280_720": {
-            "price": 50
+            "price": 30
           },
           "video_duration_seconds_1024_1792": {
             "price": 50
@@ -3092,7 +3104,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.000125
         },
         "response_token": {
           "price": 0.001
@@ -3118,7 +3130,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.000125
         },
         "response_token": {
           "price": 0.001
@@ -3322,10 +3334,10 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 0.000006
         },
         "cache_read_audio_input_token": {
-          "price": 0.00003
+          "price": 0.000008
         },
         "request_audio_token": {
           "price": 0.001
@@ -3440,7 +3452,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.004
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -3532,6 +3544,15 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -3598,7 +3619,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 0.000006
         },
         "request_audio_token": {
           "price": 0.001
@@ -3628,7 +3649,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 0.000006
         },
         "request_audio_token": {
           "price": 0.001
@@ -3685,10 +3706,10 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.004
+          "price": 0.0032
         },
         "response_audio_token": {
-          "price": 0.008
+          "price": 0.0064
         }
       }
     }
@@ -3697,10 +3718,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00024
         },
         "cache_write_input_token": {
           "price": 0
@@ -3718,10 +3739,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00024
         },
         "cache_write_input_token": {
           "price": 0
@@ -3781,7 +3802,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -3796,7 +3817,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -3845,6 +3866,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.0015
         }
       }
     }
@@ -3857,6 +3881,9 @@
         },
         "response_token": {
           "price": 0
+        },
+        "response_audio_token": {
+          "price": 0.003
         }
       }
     }
@@ -3868,16 +3895,16 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.004
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
         },
         "request_image_token": {
-          "price": 0.0008
+          "price": 0.001
         },
         "response_image_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "cache_read_image_input_token": {
           "price": 0.0002
@@ -3889,19 +3916,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00015
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000375
+          "price": 0.00002
         },
         "request_image_token": {
           "price": 0.00025
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "response_image_token": {
+          "price": 0.0008
         }
       }
     }
@@ -3979,25 +4009,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0016
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00004
         },
         "request_audio_token": {
-          "price": 0.004
+          "price": 0.0032
         },
         "response_audio_token": {
-          "price": 0.008
+          "price": 0.0064
         },
         "cache_read_audio_input_token": {
-          "price": 0.00025
+          "price": 0.00004
         },
         "request_image_token": {
           "price": 0.0005
@@ -4021,10 +4051,10 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.004
+          "price": 0.0032
         },
         "response_audio_token": {
-          "price": 0.008
+          "price": 0.0064
         }
       }
     }

--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1377,7 +1377,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -1395,7 +1395,7 @@
           "response_audio_token": {
             "price": 0.0012
           }
-        }     
+        }
       }
     }
   },
@@ -1409,7 +1409,7 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.0006
         },
         "response_audio_token": {
           "price": 0
@@ -1435,7 +1435,7 @@
           "price": 0.0005
         },
         "request_audio_token": {
-          "price": 0.3
+          "price": 0.0003
         },
         "response_audio_token": {
           "price": 0
@@ -1745,7 +1745,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1786,7 +1786,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2217,13 +2217,13 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2283,16 +2283,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2310,16 +2310,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2332,6 +2332,9 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2344,6 +2347,9 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2356,6 +2362,9 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       }
     }
@@ -2368,6 +2377,9 @@
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
         }
       }
     }
@@ -2643,10 +2655,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2724,7 +2736,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.00004
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2751,7 +2763,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.00004
         },
         "cache_read_audio_input_token": {
           "price": 0.0064
@@ -2793,10 +2805,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2881,6 +2893,15 @@
           "price": 0.000125
         },
         "cache_read_text_input_token": {
+          "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
           "price": 0.000125
         }
       }
@@ -3310,7 +3331,7 @@
           "price": 0.000006
         },
         "cache_read_audio_input_token": {
-          "price": 0.000008
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3420,6 +3441,15 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -3507,6 +3537,15 @@
           "price": 0.000125
         },
         "cache_read_text_input_token": {
+          "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
           "price": 0.000125
         }
       }
@@ -3757,7 +3796,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -3772,7 +3811,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "response_token": {
           "price": 0
@@ -3844,19 +3883,19 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
         },
         "request_image_token": {
-          "price": 0.0008
+          "price": 0.001
         },
         "response_image_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "cache_read_image_input_token": {
-          "price": 0.0002
+          "price": 0.00025
         }
       }
     }
@@ -3878,6 +3917,9 @@
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "response_image_token": {
+          "price": 0.0008
         }
       }
     }
@@ -4105,6 +4147,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }
@@ -4125,6 +4170,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }

--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -1377,7 +1377,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.00006
         },
         "response_token": {
           "price": 0
@@ -1409,7 +1409,7 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.0006
+          "price": 0.6
         },
         "response_audio_token": {
           "price": 0
@@ -1435,7 +1435,7 @@
           "price": 0.0005
         },
         "request_audio_token": {
-          "price": 0.0003
+          "price": 0.3
         },
         "response_audio_token": {
           "price": 0
@@ -1578,6 +1578,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       },
       "batch_config": {
@@ -1598,6 +1601,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       }
     }
@@ -2283,16 +2289,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 0.0003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.002
+          "price": 0.02
         },
         "request_audio_token": {
-          "price": 0.001
+          "price": 0.01
         }
       }
     }
@@ -2310,16 +2316,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 0.0003
         },
         "cache_read_audio_input_token": {
           "price": 0.0003
         },
         "response_audio_token": {
-          "price": 0.002
+          "price": 0.02
         },
         "request_audio_token": {
-          "price": 0.001
+          "price": 0.01
         }
       }
     }
@@ -2332,9 +2338,6 @@
         },
         "response_token": {
           "price": 0.001
-        },
-        "cache_read_input_token": {
-          "price": 0.000125
         }
       }
     }
@@ -2347,9 +2350,6 @@
         },
         "response_token": {
           "price": 0.001
-        },
-        "cache_read_input_token": {
-          "price": 0.000125
         }
       }
     }
@@ -2362,9 +2362,6 @@
         },
         "response_token": {
           "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
         }
       }
     }
@@ -2377,9 +2374,6 @@
         },
         "response_token": {
           "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
         }
       }
     }
@@ -2655,10 +2649,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.002
+          "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.001
+          "price": 0.002
         }
       }
     }
@@ -2727,25 +2721,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.00025
         },
         "cache_read_audio_input_token": {
-          "price": 0.0064
+          "price": 0.00025
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2754,25 +2748,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.00025
         },
         "cache_read_audio_input_token": {
-          "price": 0.0064
+          "price": 0.00025
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2787,10 +2781,10 @@
           "price": 0.001
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2799,10 +2793,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.00006
         },
         "response_audio_token": {
           "price": 0.002
@@ -2899,7 +2893,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0
+          "price": 0.004
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -2938,10 +2932,10 @@
         },
         "additional_units": {
           "video_duration_seconds_720_1280": {
-            "price": 30
+            "price": 50
           },
           "video_duration_seconds_1280_720": {
-            "price": 30
+            "price": 50
           },
           "video_duration_seconds_1024_1792": {
             "price": 50
@@ -3098,7 +3092,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00025
         },
         "response_token": {
           "price": 0.001
@@ -3124,7 +3118,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00025
         },
         "response_token": {
           "price": 0.001
@@ -3328,7 +3322,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.00003
@@ -3446,7 +3440,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0
+          "price": 0.004
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -3538,15 +3532,6 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
-        },
-        "request_token": {
-          "price": 0.0005
-        },
-        "response_token": {
-          "price": 0
-        },
-        "cache_read_input_token": {
-          "price": 0.000125
         }
       }
     }
@@ -3613,7 +3598,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3643,7 +3628,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3700,10 +3685,10 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         }
       }
     }
@@ -3712,10 +3697,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.00006
         },
         "cache_write_input_token": {
           "price": 0
@@ -3733,10 +3718,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.00006
         },
         "cache_write_input_token": {
           "price": 0
@@ -3796,7 +3781,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.00006
         },
         "response_token": {
           "price": 0
@@ -3811,7 +3796,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.00006
         },
         "response_token": {
           "price": 0
@@ -3883,19 +3868,19 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0
+          "price": 0.004
         },
         "cache_read_input_token": {
           "price": 0.000125
         },
         "request_image_token": {
-          "price": 0.001
+          "price": 0.0008
         },
         "response_image_token": {
-          "price": 0.004
+          "price": 0.0032
         },
         "cache_read_image_input_token": {
-          "price": 0.00025
+          "price": 0.0002
         }
       }
     }
@@ -3904,22 +3889,19 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.00015
         },
         "response_token": {
-          "price": 0
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000375
         },
         "request_image_token": {
           "price": 0.00025
         },
         "cache_read_image_input_token": {
           "price": 0.000025
-        },
-        "response_image_token": {
-          "price": 0.0008
         }
       }
     }
@@ -3997,25 +3979,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.00025
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "cache_read_audio_input_token": {
-          "price": 0.00004
+          "price": 0.00025
         },
         "request_image_token": {
           "price": 0.0005
@@ -4039,10 +4021,10 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         }
       }
     }
@@ -4265,6 +4247,21 @@
           "file_search": {
             "price": 0.25
           }
+        }
+      }
+    }
+  },
+  "gpt-5-chat": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.0000125
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 1 |
| 🔄 Models updated (merged) | 29 |

### ➕ New Models
- `gpt-5-chat`

### 🔄 Updated Models
- `gpt-5.4-pro`
- `gpt-5.4-pro-2026-03-05`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `o4-mini-deep-research-2025-06-26`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-audio-mini`
- `gpt-4o-mini-tts`
- `gpt-4o-mini-tts-2025-03-20`
- `gpt-4o-mini-tts-2025-12-15`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `gpt-4o-search-preview`
- `gpt-4o-search-preview-2025-03-11`
- `gpt-4o-mini-search-preview`
- `gpt-4o-mini-search-preview-2025-03-11`
- `whisper-1`
- `tts-1`
- `tts-1-hd`
- `tts-1-1106`
- `tts-1-hd-1106`
- `gpt-image-1`
- `gpt-image-1-mini`
- `gpt-image-1.5`
- `gpt-image-1.5-2025-12-16`
- `chatgpt-image-latest`


## Pricing Sources

| Source | URL |
|--------|-----|
| Models API | `get_openai_models` tool (128 unique model IDs) |
| Pricing Data | LiteLLM `model_prices_and_context_window.json` (used as fallback — OpenAI's official pricing page at `platform.openai.com/docs/pricing` was inaccessible due to Cloudflare protection and insufficient Firecrawl credits) |

## Model Families Covered (130 entries)

| Family | Count | Notes |
|--------|-------|-------|
| GPT-5.4.x | 8 | gpt-5.4, gpt-5.4-pro, gpt-5.4-mini, gpt-5.4-nano + dated variants |
| GPT-5.3/5.2.x | 7 | gpt-5.3-chat-latest, gpt-5.2, gpt-5.2-pro, gpt-5.2-codex + variants |
| GPT-5.1.x | 6 | gpt-5.1, gpt-5.1-codex, gpt-5.1-codex-max, gpt-5.1-codex-mini + variants |
| GPT-5.x | 11 | gpt-5, gpt-5-pro, gpt-5-mini, gpt-5-nano, gpt-5-codex, gpt-5-chat, search + variants |
| GPT-4.1.x | 6 | gpt-4.1, gpt-4.1-mini, gpt-4.1-nano + dated variants |
| GPT-4o.x | 9 | gpt-4o, gpt-4o-mini + dated/search variants |
| GPT-4 legacy | 4 | gpt-4-turbo, gpt-4, gpt-3.5-turbo variants |
| O-series | 16 | o4-mini, o3, o3-mini, o3-pro, o3-deep-research, o4-mini-deep-research, o1, o1-pro + variants |
| Realtime/Audio | 22 | gpt-4o-realtime, gpt-4o-mini-realtime, gpt-4o-audio, gpt-realtime, gpt-audio + variants |
| TTS | 5 | gpt-4o-mini-tts + variants, tts-1, tts-1-hd + 1106 variants |
| Transcription | 5 | gpt-4o-transcribe, gpt-4o-mini-transcribe + variants, gpt-4o-transcribe-diarize |
| Embeddings | 3 | text-embedding-3-large, text-embedding-3-small, text-embedding-ada-002 |
| Moderation | 2 | omni-moderation-latest, omni-moderation-2024-09-26 |
| Image | 7 | dall-e-3, dall-e-2, gpt-image-1, gpt-image-1-mini, gpt-image-1.5 + variants, chatgpt-image-latest |
| Video | 2 | sora-2, sora-2-pro |
| Special | 4 | codex-mini-latest, computer-use-preview + variant, davinci-002, babbage-002 |
| Whisper | 1 | whisper-1 |

---
*Generated by Pricing Agent on 2026-04-12*