### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,16 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -1560,6 +1560,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1602,7 +1605,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2295,7 +2298,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2522,7 +2525,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2577,6 +2580,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2693,6 +2699,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2753,7 +2762,7 @@
           "price": 0.000025
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2761,12 +2770,15 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2791,6 +2803,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2944,6 +2959,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.012
+          },
+          "input_video_plus": {
+            "price": 0.079
+          }
         }
       }
     }
@@ -3003,7 +3026,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
@@ -3515,6 +3538,69 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 4 |
| 🔄 Models updated (merged) | 10 |

### ➕ New Models
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `gemma-4-26b-a4b-it-maas`
- `veo-3.1-lite-generate-001`

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-3-pro-image-preview`
- `gemini-3-flash-preview`
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-image-preview`
- `gemini-3.1-flash-lite-preview`
- `veo-3.0-fast-generate-001`
- `veo-3.1-fast-generate-001`
- `multimodalembedding`
- `gemini-embedding-2-preview`


## Model-to-Pricing-Page Mapping

### Google – Gemini Text / Multimodal

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Standard ≤200K pricing used; batch included |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | Standard pricing; batch included |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | Standard pricing; batch included |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | Gemini image output model; image_token $30/1M; batch included |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 | API | Maps to Gemini 2.5 Pro Computer Use pricing |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias → gemini-2.5-flash pricing |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias → gemini-2.5-flash-lite pricing |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no pricing row on page |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no pricing row on page |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | Standard pricing; batch included |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | Standard pricing; batch included |
| `gemini-3-pro-preview` | Google – Gemini 3 | API | Gemini 3 Pro Preview; search $14/1000 |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API | Image output model; image_token $120/1M |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | Gemini 3 Flash Preview; batch included |
| `gemini-3.1-pro-preview` | Google – Gemini 3 | API | Gemini 3.1 Pro Preview; batch included |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3 | API | Image output; image_token $60/1M; batch included |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3 | API | Gemini 3.1 Flash Lite Preview; batch included |
| `gemma-4-26b-a4b-it-maas` | Google – Gemma | API | Matches "Gemma 4 26B" row; no web_search keys |

### Google – Excluded Models (with reason)

| Model ID | Reason |
|----------|--------|
| `gemini-live-2.5-flash-native-audio` | Excluded: `*-live-*` pattern (Gemini Live streaming) |
| `lyria-002`, `lyria-3-pro-preview`, `lyria-3-clip-preview` | Excluded: `lyria-*` pattern (music generation) |
| `imagegeneration` | Excluded: legacy model explicitly listed in exclude rules |
| `virtual-try-on-001` | Excluded: retail-specific model, exclude rule |
| `model-optimizer-*` | Excluded: dynamic routing meta-endpoint |
| `shieldgemma2` | Excluded: safety/guard model pattern |
| `chirp-2`, `chirp-3` | Excluded: audio transcription (non-generative inference) |
| `pretrained-ocr` | Excluded: OCR model |
| `image-segmentation-001` | Excluded: non-generative CV segmentation |
| `translate-llm`, `text-translation` | Excluded: non-generative translation |
| `t5-flan`, `bert-base`, etc. | Excluded: traditional NLP / non-generative ML |
| Self-deploy models (has_deploy:true, no -maas) | Excluded: self-deploy infrastructure models |

### Google – Imagen (per-image)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `imagen-4.0-generate-001` | Google – Imagen 4 | API | $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4 | API | $0.02/image |
| `imagen-4.0-ultra-generate-001` | Google – Imagen 4 | API | $0.06/image |
| `imagen-3.0-generate-002` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-capability-001` | Google – Imagen 3 | API | Capability model → uses imagen-3.0-generate price ($0.04/image) |
| `imagen-3.0-capability-002` | Google – Imagen 3 | API | Capability model → uses imagen-3.0-generate price ($0.04/image) |

### Google – Veo (per-second video)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `veo-2.0-generate-001` | Google – Veo 2 | API | $0.50/sec; default 8s, 1 sample |
| `veo-3.0-generate-001` | Google – Veo 3 | API | $0.20/sec video only (standard); default 8s, 1 sample |
| `veo-3.0-fast-generate-001` | Google – Veo 3 Fast | API | $0.08/sec video 720p; default 8s, 1 sample |
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | $0.20/sec video 720p/1080p; default 8s, 1 sample |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | $0.08/sec video 720p; default 8s, 1 sample |
| `veo-3.1-lite-generate-001` | Google – Veo 3.1 Lite | API | $0.03/sec video 720p; default 8s, 1 sample |

### Google – Embedding

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-embedding-001` | Google – Gemini Embedding | API | $0.00015/1K tokens |
| `text-embedding-005` | Google – Text Embeddings | API | $0.000025/1K chars (per_thousand_tokens) |
| `text-multilingual-embedding-002` | Google – Text Embeddings | API | $0.000025/1K chars |
| `text-embedding-large-exp-03-07` | Google – Text Embeddings | API | Experimental; shares text-embedding-005 pricing |
| `textembedding-gecko` | Google – Text Embeddings | API | Legacy; shares text-embedding pricing |
| `multimodalembedding` | Google – Multimodal Embedding | API | Text $0.0002/1K chars; Image $0.0001; Video Plus $0.002/sec |
| `gemini-embedding-2-preview` | Google – Gemini Embedding 2 | API | $0.2/1M tokens text; $0.00012/image; $0.00079/frame |

### Anthropic – Claude

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `claude-opus-4-6` | Anthropic – Claude | API | @default stripped; $5/$25; batch included |
| `claude-opus-4-1@20250805` | Anthropic – Claude | API | Pinned; $15/$75 (uniform pricing) |
| `claude-sonnet-4-6` | Anthropic – Claude | API | @default stripped; $3/$15; batch included |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude | API | Pinned; $3/$15 (≤200K) |
| `claude-haiku-4-5@20251001` | Anthropic – Claude | API | Pinned; $1/$5 |
| `claude-opus-4-5@20251101` | Anthropic – Claude | API | Pinned; $5/$25 |
| `claude-opus-4@20250514` | Anthropic – Claude | API | Pinned; $15/$75 (uniform pricing) |
| `claude-sonnet-4@20250514` | Anthropic – Claude | API | Pinned; $3/$15 (uniform pricing) |

All Claude models use 5m Cache Write price per anthropic.md rules.

### Meta – Llama

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `llama-3.3-70b-instruct-maas` | Meta – Llama | API | Matches "Llama 3.3 70B"; $0.72/$0.72; batch included |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama | API | Matches "Llama 4 Maverick"; $0.35/$1.15; batch included |

### Meta – Excluded Models (with reason)

| Model ID | Reason |
|----------|--------|
| `codellama-7b-hf`, `llama2`, `llama-2-quantized`, `llama3`, `llama4`, `llama3_1`, `llama3-2`, `llama3-3` | Excluded: has_deploy:true, no -maas suffix |
| `llama-guard`, `prompt-guard` | Excluded: guard models |
| `segment-anything`, `sam3` | Excluded: non-generative segmentation |
| `imagebind` | Excluded: non-generative multimodal feature extraction |
| `nllb` | Excluded: translation model (non-generative) |
| `faster-r-cnn`, `retinanet`, `mask-r-cnn` | Excluded: non-generative CV detection |
| `roberta-large`, `xlm-roberta-large` | Excluded: non-generative NLP classification |

### Mistral AI

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `mistral-small-2503` | Mistral AI | API | Matches "Mistral Small 3.1 (25.03)"; $0.10/$0.30 |
| `mistral-medium-3` | Mistral AI | API | Matches "Mistral Medium 3"; $0.40/$2.00 |
| `codestral-2` | Mistral AI | API | Matches "Codestral 2"; $0.30/$0.90 |

### Mistral AI – Excluded Models

| Model ID | Reason |
|----------|--------|
| `mistral` (mistral-ai publisher) | Excluded: has_deploy:true, no -maas |
| `mixtral` (mistral-ai publisher) | Excluded: has_deploy:true, no -maas |
| `codestral-2501-self-deploy` | Excluded: self-deploy in name, has_deploy:true |
| `mistral-ocr-2505` | Excluded: OCR model |
| `ministral-3` | Excluded: has_deploy:true, no -maas |
| `mistral-large-3` | Excluded: has_deploy:true, no -maas |

### DeepSeek

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `deepseek-v3.1-maas` | DeepSeek | API | Matches "DeepSeek-V3.1"; $0.60/$1.70; cache hit; batch included |
| `deepseek-v3.2-maas` | DeepSeek | API | Matches "DeepSeek-V3.2"; $0.56/$1.68; cache hit; batch included |
| `deepseek-r1-0528-maas` | DeepSeek | API | Matches "DeepSeek-R1 (0528)"; $1.35/$5.40; batch included |

### DeepSeek – Excluded Models

| Model ID | Reason |
|----------|--------|
| `deepseek-r1`, `deepseek-v3`, `deepseek-v3-1`, `deepseek-v3-2` | Excluded: has_deploy:true, no -maas |
| `deepseek-ocr`, `deepseek-ocr-2`, `deepseek-ocr-maas` | Excluded: OCR models |

### Qwen

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen | API | Matches "Qwen3-235B-A22B-Instruct-2507"; $0.22/$0.88; batch included |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen | API | Matches "Qwen3-Coder-480B-A35B-Instruct"; $0.22/$1.80; cache hit; batch included |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen | API | Matches "Qwen3-Next-80B-Instruct"; $0.15/$1.20 |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen | API | Matches "Qwen3-Next-80B-Thinking"; $0.15/$1.20 |

### Qwen – Excluded Models

| Model ID | Reason |
|----------|--------|
| `qwq`, `qwen3`, `qwen3-embedding`, `qwen3-5`, `qwen2`, `qwen3-coder-next`, `qwen3-coder`, `qwen3-next`, `qwen3-vl` | Excluded: has_deploy:true, no -maas |
| `qwen-image` | Excluded: explicitly excluded by policy (qwen-image) |

### MiniMax

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `minimax-m2-maas` | MiniMax | API | Matches "MiniMax-M2"; $0.30/$1.20; cache hit |

### Moonshot / Kimi

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `kimi-k2-thinking-maas` | Moonshot/Kimi | API | Matches "Kimi-K2-Thinking"; $0.60/$2.50; cache hit |

### ZAI.org / GLM

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `glm-4.7-maas` | ZAI.org – GLM | API | Matches "GLM-4.7"; $0.60/$2.20 |
| `glm-5-maas` | ZAI.org – GLM | API | Matches "GLM-5"; $1.00/$3.20; cache hit |

### ZAI.org – Excluded Models

| Model ID | Reason |
|----------|--------|
| `glm-4.7`, `glm-5`, `glm-4.5` | Excluded: has_deploy:true, no -maas |
| `glm-ocr` | Excluded: OCR model |
| `glm-image` | Excluded: explicitly excluded by policy |

### AI21

| Model ID | Reason |
|----------|--------|
| `jamba-large-1.6` | Excluded: has_deploy:true, no -maas (self-deploy) |

No AI21 models included.

### OpenAI (on Vertex)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gpt-oss-120b-maas` | OpenAI | API | Matches "gpt-oss-120b"; $0.09/$0.36; batch included |

### OpenAI – Excluded Models

| Model ID | Reason |
|----------|--------|
| `gpt-oss` | Excluded: has_deploy:true, no -maas |
| `clip-vit-base-patch32`, `openclip` | Excluded: non-generative vision models |
| `whisper-large` | Excluded: audio transcription, not generative inference |

### Pricing Page Only (not in API – not added)

| Model / Section | Notes |
|----------------|-------|
| `gpt-oss-20b` | OpenAI pricing page only; not returned by get_vertex_models → not added |
| Llama 3.1 405B, Llama 4 Scout | Pricing page only; not returned by get_vertex_models with -maas suffix → not added |
| Grok 4.20, Grok 4.1 Fast | xAI section on pricing page; get_vertex_models returned 0 models for xAI publisher → not added |
| Lyria 3 Pro, Lyria 3, Lyria 2 | Music generation; excluded by lyria-* rule |
| Claude deprecated models (3 Haiku, 3.5 Haiku, 3.7 Sonnet) | Not returned by API (deprecated) → not added |

---
*Generated by Pricing Agent on 2026-04-12*