### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,435 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemini-2.5-pro-001": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemini-2.5-pro-preview-computer-use": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemini-2.5-flash-001": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemma-4-26b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "gemini-embedding-exp-03-07": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "claude-opus-4-5@20250929": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "claude-opus-4-1@20250514": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gpt-oss-20b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "llama3-8b-hf": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama3-70b-hf": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama3-405b-hf-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "llama-3.1-8b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama-3.1-70b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama-3.2-90b-vision-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "llama-3.3-70b-instruct-maas-int4": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama-guard-3-8b-maas": {
+    "type": {
+      "primary": "moderation"
+    },
+    "disablePlayground": true
+  },
+  "mistral-small-3-1-25-03": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "codestral-2-25-01": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "mistral-small-3-2-25-03": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "pixtral-large-2411": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "mistral-large-2411": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "mistral-nemo-2407": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-v3-1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-v3-2": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-r1-0528": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-r1-lite": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v2-5": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-0528-qwen3-8b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-next-80b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-next-80b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-coder-480b-a35b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-235b-a22b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-30b-a3b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-32b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-14b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-8b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-4b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-1.7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-0.6b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qvq-72b-preview": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "kimi-k2-thinking": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "kimi-k2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "kimi-k1.5": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "minimax-m2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "minimax-text-01": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4.7": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-5": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4-9b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4v": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "glm-4v-plus": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "glm-4-airx": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "jamba-1-5-mini@001": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -550,7 +550,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -558,7 +558,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000002
         },
         "response_token": {
           "price": 0
@@ -984,6 +984,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -1015,6 +1018,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -1082,6 +1088,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1176,6 +1185,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1211,7 +1223,7 @@
             "price": 1.4
           },
           "enterprise_web_search": {
-            "price": 1.4
+            "price": 0
           },
           "image_token": {
             "price": 0.012
@@ -1266,10 +1278,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1277,15 +1289,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1294,10 +1312,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1305,15 +1323,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1329,7 +1353,7 @@
         },
         "additional_units": {
           "input_image": {
-            "price": 0.01
+            "price": 0.0001
           },
           "input_video_plus": {
             "price": 0.2
@@ -1445,7 +1469,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       },
       "batch_config": {
@@ -1560,6 +1590,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1602,7 +1635,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2272,7 +2305,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2522,7 +2555,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2545,7 +2578,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2578,6 +2611,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 0
           }
         }
       },
@@ -2693,6 +2729,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 0
           }
         }
       },
@@ -2753,7 +2792,7 @@
           "price": 0.000025
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2761,12 +2800,15 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 0
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2792,6 +2834,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 0
           }
         }
       },
@@ -3515,6 +3560,964 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-exp-03-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-computer-use": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.000125
+        }
+      }
+    }
+  },
+  "gemma-4-26b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0
+          },
+          "search": {
+            "price": 0
+          },
+          "enterprise_web_search": {
+            "price": 0
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "gemini-embedding-exp-03-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "claude-opus-4-5@20250929": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        }
+      }
+    }
+  },
+  "claude-opus-4-1@20250514": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0015
+        },
+        "response_token": {
+          "price": 0.0075
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000025
+        },
+        "cache_read_input_token": {
+          "price": 0.0000007
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.0000125
+        }
+      }
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000125
+        },
+        "response_token": {
+          "price": 0.000035
+        }
+      }
+    }
+  },
+  "llama3-8b-hf": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-70b-hf": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama3-405b-hf-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.1-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.1-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.2-90b-vision-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.3-70b-instruct-maas-int4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-guard-3-8b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-small-3-1-25-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "codestral-2-25-01": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "mistral-small-3-2-25-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "pixtral-large-2411": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-large-2411": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-nemo-2407": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3-1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00017
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000085
+        }
+      }
+    }
+  },
+  "deepseek-v3-2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.0000056
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "deepseek-r1-0528": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000135
+        },
+        "response_token": {
+          "price": 0.00054
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000675
+        },
+        "response_token": {
+          "price": 0.00027
+        }
+      }
+    }
+  },
+  "deepseek-r1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r1-lite": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v2-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r1-0528-qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-next-80b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen3-next-80b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen3-coder-480b-a35b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.00018
+        },
+        "cache_read_input_token": {
+          "price": 0.0000022
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.000088
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000044
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-8b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-4b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-1.7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-0.6b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qvq-72b-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "kimi-k2-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "kimi-k2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "kimi-k1.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "minimax-m2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      }
+    }
+  },
+  "minimax-text-01": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4.7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        }
+      }
+    }
+  },
+  "glm-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "glm-4-9b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-airx": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "jamba-1-5-mini@001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 63 |
| 🔄 Models updated (merged) | 19 |

### ➕ New Models
- `gemini-2.5-pro-preview-06-05`
- `gemini-2.5-pro-001`
- `gemini-2.5-pro-exp-03-25`
- `gemini-2.5-pro-preview-computer-use`
- `gemini-2.5-flash-001`
- `gemma-4-26b`
- `imagen-4.0-capability-001`
- `veo-3.1-lite-generate-001`
- `gemini-embedding-exp-03-07`
- `claude-opus-4-5@20250929`
- `claude-opus-4-1@20250514`
- `gpt-oss-20b`
- `llama-4-scout-17b-16e-instruct-maas`
- `llama3-8b-hf`
- `llama3-70b-hf`
- `llama3-405b-hf-maas`
- `llama-3.1-8b-instruct-maas`
- `llama-3.1-70b-instruct-maas`
- `llama-3.2-90b-vision-instruct-maas`
- `llama-3.3-70b-instruct-maas-int4`
- ... and 43 more

### 🔄 Updated Models
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-image-preview`
- `gemini-3.1-flash-lite-preview`
- `gemini-3-pro-preview`
- `gemini-3-pro-image-preview`
- `gemini-3-flash-preview`
- `gemini-2.5-pro`
- `gemini-2.5-pro-preview-05-06`
- `gemini-2.5-flash-preview-04-17`
- `gemini-2.5-flash-preview-05-20`
- `gemini-2.5-flash-lite-preview-06-17`
- `gemini-2.0-flash-001`
- `gemini-2.0-flash-lite`
- `gemini-2.0-flash`
- `veo-3.1-generate-001`
- `veo-3.1-fast-generate-001`
- `veo-3.0-generate-001`
- `text-embedding-004`
- `multimodalembedding@001`


## Model-to-Pricing-Page Mapping

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-3.1-pro-preview` | Google – Gemini 3.1 | API | Standard ≤200K: $2/$12; batch $1/$6; cache read $0.20; search $14/1K |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3.1 | API | $0.50/$3; image_token $60/1M; batch $0.25/$1.50 |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3.1 | API | $0.25/$1.50; cache read $0.03; batch $0.13/$0.75 |
| `gemini-3-pro-preview` | Google – Gemini 3 | API | Standard ≤200K: $2/$12; batch $1/$6; cache read $0.20; search $14/1K |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API | $2/$12; image_token $120/1M; batch $1/$6 |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | $0.50/$3; cache read $0.05; batch $0.25/$1.50 |
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | $1.25/$10; batch $0.625/$5; cache read $0.13; search $35/1K; enterprise $45/1K |
| `gemini-2.5-pro-preview-05-06` | Google – Gemini 2.5 | API | Same pricing as gemini-2.5-pro (preview variant) |
| `gemini-2.5-pro-preview-06-05` | Google – Gemini 2.5 | API | Same pricing as gemini-2.5-pro (preview variant) |
| `gemini-2.5-pro-001` | Google – Gemini 2.5 | API | Same pricing as gemini-2.5-pro |
| `gemini-2.5-pro-exp-03-25` | Google – Gemini 2.5 | API | Same pricing as gemini-2.5-pro (exp variant) |
| `gemini-2.5-pro-preview-computer-use` | Google – Gemini 2.5 | API | Same pricing as gemini-2.5-pro; no batch listed |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | $0.30/$2.50; batch $0.15/$1.25; cache read $0.03; search $35/1K |
| `gemini-2.5-flash-preview-04-17` | Google – Gemini 2.5 | API | Same pricing as gemini-2.5-flash (preview variant) |
| `gemini-2.5-flash-preview-05-20` | Google – Gemini 2.5 | API | Same pricing as gemini-2.5-flash (preview variant) |
| `gemini-2.5-flash-001` | Google – Gemini 2.5 | API | Same pricing as gemini-2.5-flash |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | $0.30/$2.50; image_token $30/1M; batch $0.15/$1.25 |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | $0.10/$0.40; batch $0.05/$0.20; cache read $0.01; search $35/1K |
| `gemini-2.5-flash-lite-preview-06-17` | Google – Gemini 2.5 | API | Same pricing as gemini-2.5-flash-lite (preview variant) |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | $0.15/$0.60; batch $0.075/$0.30; cache read $0.0375; search $35/1K |
| `gemini-2.0-flash` | Google – Gemini 2.0 | API | Alias for gemini-2.0-flash-001; same pricing |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | $0.075/$0.30; batch $0.0375/$0.15; search $35/1K |
| `gemini-2.0-flash-lite` | Google – Gemini 2.0 | API | Alias for gemini-2.0-flash-lite-001; same pricing |
| `gemma-4-26b` | Google – Gemma | API | $0.15/$0.60; no search/web grounding listed |
| `imagen-4.0-ultra-generate-001` | Google – Imagen 4 | API | $0.06/image |
| `imagen-4.0-generate-001` | Google – Imagen 4 | API | $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4 | API | $0.02/image |
| `imagen-4.0-capability-001` | Google – Imagen 4 | API | Capability model; uses imagen-4.0-generate-001 price: $0.04/image |
| `imagen-3.0-generate-002` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-generate-001` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-fast-generate-001` | Google – Imagen 3 | API | $0.02/image |
| `imagen-3.0-capability-001` | Google – Imagen 3 | API | Capability model; uses imagen-3.0-generate pricing: $0.04/image |
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | $0.40/sec (720p/1080p Video+Audio); default 8s, 1 sample |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | $0.10/sec (720p); default 8s, 1 sample |
| `veo-3.1-lite-generate-001` | Google – Veo 3.1 Lite | API | $0.05/sec (720p); default 8s, 1 sample |
| `veo-3.0-generate-001` | Google – Veo 3 | API | $0.40/sec (Video+Audio); default 8s, 1 sample |
| `veo-3.0-fast-generate-001` | Google – Veo 3 Fast | API | $0.10/sec (720p); default 8s, 1 sample |
| `veo-2.0-generate-001` | Google – Veo 2 | API | $0.50/sec; default 8s, 1 sample |
| `gemini-embedding-001` | Google – Embedding | API | $0.00015/1K tokens input; batch $0.00012/1K |
| `gemini-embedding-exp-03-07` | Google – Embedding | API | $0.00015/1K tokens input (experimental variant) |
| `text-embedding-005` | Google – Embedding | API | $0.000025/1K chars input; batch $0.00002/1K |
| `text-embedding-004` | Google – Embedding | API | $0.000025/1K chars input; batch $0.00002/1K |
| `text-multilingual-embedding-002` | Google – Embedding | API | $0.000025/1K chars input; batch $0.00002/1K |
| `multimodalembedding@001` | Google – Multimodal Embedding | API | Image $0.0001/image; video plus $0.0020/sec, standard $0.0010/sec, essential $0.0005/sec |
| `text-embedding-large-exp-03-07` | Google – Embedding | API | Experimental large embedding; no dedicated row — uses text-embedding-005 pricing |
| `claude-opus-4-6` | Anthropic – Claude | API | $5/$25; 5m cache write $6.25, cache read $0.50 |
| `claude-opus-4-5@20250929` | Anthropic – Claude | API | $5/$25; 5m cache write $6.25, cache read $0.50 |
| `claude-sonnet-4-6` | Anthropic – Claude | API | $3/$15; 5m cache write $3.75, cache read $0.30 |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude | API | $3/$15; 5m cache write $3.75, cache read $0.30 |
| `claude-haiku-4-5@20251001` | Anthropic – Claude | API | $1/$5; 5m cache write $1.25, cache read $0.10 |
| `claude-opus-4-1@20250514` | Anthropic – Claude | API | $15/$75; no cache listed on Vertex page |
| `claude-opus-4@20250514` | Anthropic – Claude | API | $15/$75; no cache listed on Vertex page |
| `claude-sonnet-4@20250514` | Anthropic – Claude | API | $3/$15; no cache listed on Vertex page |
| `gpt-oss-120b-maas` | OpenAI – GPT OSS | API | $0.09/$0.36; batch $0.045/$0.18 |
| `gpt-oss-20b` | OpenAI – GPT OSS | API | $0.07/$0.25; cache hit $0.007; batch $0.035/$0.125 |
| `llama-3.1-405b-instruct-maas` | Meta – Llama | API | $5.00/$16.00 |
| `llama-3.3-70b-instruct-maas` | Meta – Llama | API | $0.72/$0.72; batch $0.36/$0.36 |
| `llama-4-scout-17b-16e-instruct-maas` | Meta – Llama 4 | API | $0.25/$0.70; batch $0.125/$0.35 |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama 4 | API | $0.35/$1.15; batch $0.175/$0.575 |
| `llama3-8b-hf` | Meta – Llama | API – price not found | No pricing row on Vertex page; added with price 0 |
| `llama3-70b-hf` | Meta – Llama | API – price not found | No pricing row on Vertex page; added with price 0 |
| `llama3-405b-hf-maas` | Meta – Llama | API – price not found | No pricing row on Vertex page; added with price 0 |
| `llama-3.1-8b-instruct-maas` | Meta – Llama | API – price not found | No pricing row on Vertex page; added with price 0 |
| `llama-3.1-70b-instruct-maas` | Meta – Llama | API – price not found | No pricing row on Vertex page; added with price 0 |
| `llama-3.2-90b-vision-instruct-maas` | Meta – Llama | API – price not found | No pricing row on Vertex page; added with price 0 |
| `llama-3.3-70b-instruct-maas-int4` | Meta – Llama | API – price not found | No pricing row on Vertex page; added with price 0 |
| `llama-guard-3-8b-maas` | Meta – Llama Guard | API – price not found | Guard model — included per partners.md (no pricing row); price 0 |
| `mistral-medium-3` | Mistral AI | API | $0.40/$2.00 |
| `mistral-small-3-1-25-03` | Mistral AI | API | $0.10/$0.30 |
| `codestral-2-25-01` | Mistral AI | API | $0.30/$0.90 |
| `mistral-small-3-2-25-03` | Mistral AI | API | $0.10/$0.30 (same tier as mistral-small-3-1) |
| `pixtral-large-2411` | Mistral AI | API – price not found | No pricing row on Vertex page; added with price 0 |
| `mistral-large-2411` | Mistral AI | API – price not found | No pricing row on Vertex page; added with price 0 |
| `mistral-nemo-2407` | Mistral AI | API – price not found | No pricing row on Vertex page; added with price 0 |
| `deepseek-v3-1` | DeepSeek | API | $0.60/$1.70; cache hit $0.06; batch $0.30/$0.85 |
| `deepseek-v3-2` | DeepSeek | API | $0.56/$1.68; cache hit $0.056; batch $0.28/$0.84 |
| `deepseek-r1-0528` | DeepSeek | API | $1.35/$5.40; batch $0.675/$2.70 |
| `deepseek-r1` | DeepSeek | API – price not found | No pricing row; added with price 0 |
| `deepseek-v3` | DeepSeek | API – price not found | No pricing row; added with price 0 |
| `deepseek-r1-lite` | DeepSeek | API – price not found | No pricing row; added with price 0 |
| `deepseek-r2` | DeepSeek | API – price not found | No pricing row; added with price 0 |
| `deepseek-v2` | DeepSeek | API – price not found | No pricing row; added with price 0 |
| `deepseek-v2-5` | DeepSeek | API – price not found | No pricing row; added with price 0 |
| `deepseek-r1-0528-qwen3-8b` | DeepSeek | API – price not found | No pricing row; added with price 0 |
| `qwen3-next-80b-thinking` | Qwen | API | $0.15/$1.20 |
| `qwen3-next-80b-instruct` | Qwen | API | $0.15/$1.20 |
| `qwen3-coder-480b-a35b-instruct` | Qwen | API | $0.22/$1.80; cache hit $0.022; batch $0.11/$0.90 |
| `qwen3-235b-a22b-instruct-2507` | Qwen | API | $0.22/$0.88; batch $0.11/$0.44 |
| `qwen3-235b-a22b-instruct` | Qwen | API – price not found | No pricing row; added with price 0 |
| `qwen3-30b-a3b-instruct` | Qwen | API – price not found | No pricing row; added with price 0 |
| `qwen3-32b-instruct` | Qwen | API – price not found | No pricing row; added with price 0 |
| `qwen3-14b-instruct` | Qwen | API – price not found | No pricing row; added with price 0 |
| `qwen3-8b-instruct` | Qwen | API – price not found | No pricing row; added with price 0 |
| `qwen3-4b-instruct` | Qwen | API – price not found | No pricing row; added with price 0 |
| `qwen3-1.7b-instruct` | Qwen | API – price not found | No pricing row; added with price 0 |
| `qwen3-0.6b-instruct` | Qwen | API – price not found | No pricing row; added with price 0 |
| `qvq-72b-preview` | Qwen | API – price not found | No pricing row; added with price 0 |
| `kimi-k2-thinking` | Kimi / Moonshot | API | $0.60/$2.50; cache hit $0.06 |
| `kimi-k2` | Kimi / Moonshot | API – price not found | No pricing row; added with price 0 |
| `kimi-k1.5` | Kimi / Moonshot | API – price not found | No pricing row; added with price 0 |
| `minimax-m2` | MiniMax | API | $0.30/$1.20; cache hit $0.03 |
| `minimax-text-01` | MiniMax | API – price not found | No pricing row; added with price 0 |
| `glm-4.7` | ZAI.org – GLM | API | $0.60/$2.20 |
| `glm-5` | ZAI.org – GLM | API | $1.00/$3.20; cache hit $0.10 |
| `glm-4-9b` | ZAI.org – GLM | API – price not found | No pricing row; added with price 0 |
| `glm-4v` | ZAI.org – GLM | API – price not found | No pricing row; added with price 0 |
| `glm-4v-plus` | ZAI.org – GLM | API – price not found | No pricing row; added with price 0 |
| `glm-4-airx` | ZAI.org – GLM | API – price not found | No pricing row; added with price 0 |
| `glm-4-flash` | ZAI.org – GLM | API – price not found | No pricing row; added with price 0 |
| `jamba-1-5-mini@001` | AI21 | API – price not found | No pricing row on Vertex page; added with price 0 |

## Exclusions Applied

| Model / Pattern | Publisher | Reason |
|----------------|-----------|--------|
| `gemini-*-live-*` | Google | Live streaming — separate product |
| `lyria-*` | Google | Music generation — no inference endpoint |
| `model-optimizer-*` | Google | Dynamic routing meta-endpoint |
| `imagegeneration` | Google | Legacy model superseded by imagen-3.0+ |
| `virtual-try-on-*` | Google | Retail-specific model |
| `shieldgemma*` | Google | Safety/guard model |
| `chirp*` | Google | Audio transcription — not generative inference |
| `gemini-*-embedding-*` (non-included) | Google | Non-matching embedding variants |
| `*-self-deploy` | All | Self-deploy (has_deploy: true, no -maas suffix) |
| `mistral-ocr-*` | Mistral | OCR model excluded per global rules |
| `glm-image` | ZAI.org | Explicit policy exclusion |
| `qwen-image` | Qwen | Explicit policy exclusion |
| `llama-guard-*` (except llama-guard-3-8b-maas) | Meta | Guard/safety models |
| `whisper-*` | OpenAI | Audio transcription — not generative |
| `clip-*` | OpenAI | Non-generative, vision classification |

---
*Generated by Pricing Agent on 2026-04-13*