### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1757,5 +1757,11 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3293,68 +3293,6 @@
       }
     }
   },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
   "veo-3.1-lite-generate-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3052,6 +3052,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3069,6 +3072,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3174,7 +3180,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3220,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3244,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3289,102 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 6 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-embedding-001-lte-128k`
- `gemini-embedding-001-gt-128k`
- `veo-3.0-fast-generate-001-lte-128k`
- `veo-3.0-fast-generate-001-gt-128k`
- `veo-3.1-fast-generate-preview-lte-128k`
- `veo-3.1-fast-generate-preview-gt-128k`


### 📋 Model → pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K | $2.00 in / $12.00 out / cache $0.20, batch 50%, web_search $14/1K |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K | $4.00 in / $18.00 out / cache $0.40, batch 50% |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview (customtools), ≤200K | Same pricing as gemini-3.1-pro-preview |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview (customtools), >200K | Same pricing as gemini-3.1-pro-preview |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite Preview, flat | $0.25 in / $1.50 out / cache $0.025, batch 50%, web_search $14/1K |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite Preview, flat | Identical to lte (flat pricing) |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, flat | $0.50 in / $3.00 out / cache $0.05, batch 50%, web_search $14/1K |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, flat | Identical to lte (flat pricing) |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview, flat | $2.00 in / $12.00 text out / $120.00 image_token, batch 50%, web_search $14/1K |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview, flat | Identical to lte (flat pricing) |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview 🍌, flat | $0.50 in / $3.00 text out / $60.00 image_token, batch 50%, web_search $14/1K |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview 🍌, flat | Identical to lte (flat pricing) |
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | $1.25 in / $10.00 out / cache $0.125, batch 50%, web_search $35/1K |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | $2.50 in / $15.00 out / cache $0.25, batch 50% |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat | $0.30 in / $2.50 out / cache $0.03, batch 50%, web_search $35/1K |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat | Identical to lte (flat pricing) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash-Lite, flat | $0.10 in / $0.40 out / cache $0.01, batch 50%, web_search $35/1K |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash-Lite, flat | Identical to lte (flat pricing) |
| gemini-2.5-flash-lite-preview-09-2025-lte-128k | Gemini 2.5 Flash-Lite Preview, flat | Same pricing as gemini-2.5-flash-lite GA |
| gemini-2.5-flash-lite-preview-09-2025-gt-128k | Gemini 2.5 Flash-Lite Preview, flat | Identical to lte (flat pricing) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image 🍌, flat | $0.30 in / $2.50 text out (inherited from 2.5 Flash) / $30.00 image_token, batch 50% |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image 🍌, flat | Identical to lte (flat pricing) |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash (deprecated Jun 2026), flat | $0.10 in / $0.40 out / cache $0.025, batch 50%, web_search $35/1K |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat | Identical to lte (flat pricing) |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash (001 alias), flat | Same as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash (001 alias), flat | Same as gemini-2.0-flash |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash-Lite (deprecated Jun 2026), flat | $0.075 in / $0.30 out, batch 50%, no cache, no search |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash-Lite, flat | Identical to lte (flat pricing) |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash-Lite (001 alias), flat | Same as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash-Lite (001 alias), flat | Same as gemini-2.0-flash-lite |
| gemini-pro-latest-lte-128k | *-latest → resolved to gemini-3.1-pro-preview (verified from live page) | Same pricing as 3.1-pro-preview ≤200K |
| gemini-pro-latest-gt-128k | *-latest → resolved to gemini-3.1-pro-preview | Same pricing as 3.1-pro-preview >200K |
| gemini-flash-latest-lte-128k | *-latest → resolved to gemini-3-flash-preview (verified from live page) | Same pricing as 3-flash-preview flat |
| gemini-flash-latest-gt-128k | *-latest → resolved to gemini-3-flash-preview | Same pricing as 3-flash-preview flat |
| gemini-flash-lite-latest-lte-128k | *-latest → resolved to gemini-3.1-flash-lite-preview (verified from live page) | Same pricing as 3.1-flash-lite-preview flat |
| gemini-flash-lite-latest-gt-128k | *-latest → resolved to gemini-3.1-flash-lite-preview | Same pricing as 3.1-flash-lite-preview flat |
| gemini-embedding-001-lte-128k | Gemini Embedding, flat | $0.15/1M in, output 0, batch 50% |
| gemini-embedding-001-gt-128k | Gemini Embedding, flat | Identical to lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview (multimodal), flat | $0.20/1M text in, output 0; image/audio/video priced separately on page but not separately modeled |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview, flat | Identical to lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4 Standard | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4 Standard | $0.04/image |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4 Ultra | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4 Ultra | $0.06/image |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4 Fast | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4 Fast | $0.02/image |
| veo-2.0-generate-001-lte-128k | Veo 2, flat | $0.35/s → 35¢/s, default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2, flat | Same as lte |
| veo-3.0-generate-001-lte-128k | Veo 3 Standard, flat | $0.40/s → 40¢/s (720p+1080p), default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3 Standard, flat | Same as lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3 Fast, flat | $0.10/s → 10¢/s (720p), default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3 Fast, flat | Same as lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Standard, flat | $0.40/s → 40¢/s (720p+1080p), default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Standard, flat | Same as lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast, flat | $0.10/s → 10¢/s (720p), default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast, flat | Same as lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite, flat | $0.05/s → 5¢/s (720p), default 8s, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite, flat | Same as lte |

### ℹ️ Exclusions
- `gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts` — TTS models, excluded per scope rules
- `gemini-3.1-flash-live-preview` — *-live-* model, excluded
- `gemini-2.5-flash-native-audio-*` — native-audio models, excluded
- `gemini-2.5-computer-use-preview-10-2025` — computer-use model, excluded
- `gemma-*`, `aqa`, `gemini-robotics-er-1.5-preview` — Gemma/Robotics, excluded
- `lyria-3-*`, `deep-research-pro-preview-12-2025`, `nano-banana-pro-preview` — not in include list

### 🍌 *-latest Alias Resolutions (verified from live pricing page, last updated 2026-04-09)
- `gemini-pro-latest` → `gemini-3.1-pro-preview`
- `gemini-flash-latest` → `gemini-3-flash-preview`
- `gemini-flash-lite-latest` → `gemini-3.1-flash-lite-preview`

### 🔍 Web Search Pricing
- Gemini 3.x models: $14/1,000 queries → 1.4¢ per query
- Gemini 2.5/2.0 models: $35/1,000 grounded prompts → 3.5¢ per prompt

---
*Generated by Pricing Agent on 2026-04-13*