### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/general/openai.json
+++ b/general/openai.json
@@ -2854,5 +2854,11 @@
     ],
 
     "type": { "primary": "chat", "supported": ["tools", "image"] }
+  },
+  "gpt-5.2-image": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1395,7 +1395,7 @@
           "response_audio_token": {
             "price": 0.0012
           }
-        }     
+        }
       }
     }
   },
@@ -1409,7 +1409,7 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.0006
         },
         "response_audio_token": {
           "price": 0
@@ -1435,7 +1435,7 @@
           "price": 0.0005
         },
         "request_audio_token": {
-          "price": 0.3
+          "price": 0.0003
         },
         "response_audio_token": {
           "price": 0
@@ -1578,6 +1578,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       },
       "batch_config": {
@@ -1598,6 +1601,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       }
     }
@@ -1745,7 +1751,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1786,7 +1792,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2217,13 +2223,13 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2283,16 +2289,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2310,16 +2316,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2643,10 +2649,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2724,10 +2730,10 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.0002
         },
         "cache_read_audio_input_token": {
-          "price": 0.0064
+          "price": 0.0002
         },
         "response_audio_token": {
           "price": 0.0064
@@ -2751,10 +2757,10 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.0002
         },
         "cache_read_audio_input_token": {
-          "price": 0.0064
+          "price": 0.0002
         },
         "response_audio_token": {
           "price": 0.0064
@@ -2775,10 +2781,13 @@
           "price": 0.001
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2793,10 +2802,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2882,6 +2891,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3025,16 +3040,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
@@ -3218,10 +3233,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0021
+          "price": 0.0015
         },
         "response_token": {
-          "price": 0.0168
+          "price": 0.012
         },
         "cache_write_input_token": {
           "price": 0
@@ -3249,10 +3264,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0021
+          "price": 0.0015
         },
         "response_token": {
-          "price": 0.0168
+          "price": 0.012
         },
         "cache_write_input_token": {
           "price": 0
@@ -3298,25 +3313,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0002
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.000025
         },
         "cache_read_audio_input_token": {
-          "price": 0.000008
+          "price": 0.000025
         },
         "request_audio_token": {
-          "price": 0.001
+          "price": 0.0008
         },
         "response_audio_token": {
-          "price": 0.002
+          "price": 0.0016
         }
       }
     }
@@ -3398,10 +3413,10 @@
           }
         },
         "request_image_token": {
-          "price": 0.0008
+          "price": 0.001
         },
         "response_image_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "request_text_token": {
           "price": 0.0005
@@ -3420,6 +3435,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3568,22 +3589,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0002
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.000025
         },
         "request_audio_token": {
-          "price": 0.001
+          "price": 0.0008
         },
         "response_audio_token": {
-          "price": 0.002
+          "price": 0.0016
         },
         "cache_read_audio_input_token": {
-          "price": 0.00003
+          "price": 0.000025
         },
         "request_image_token": {
           "price": 0.00008
@@ -3598,22 +3619,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0002
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.000025
         },
         "request_audio_token": {
-          "price": 0.001
+          "price": 0.0008
         },
         "response_audio_token": {
-          "price": 0.002
+          "price": 0.0016
         },
         "cache_read_audio_input_token": {
-          "price": 0.00003
+          "price": 0.000025
         },
         "request_image_token": {
           "price": 0.00008
@@ -3661,10 +3682,13 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -3844,16 +3868,16 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
         },
         "request_image_token": {
-          "price": 0.0008
+          "price": 0.001
         },
         "response_image_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "cache_read_image_input_token": {
           "price": 0.0002
@@ -3865,7 +3889,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.00015
         },
         "response_token": {
           "price": 0
@@ -3874,10 +3898,13 @@
           "price": 0.00002
         },
         "request_image_token": {
-          "price": 0.00025
+          "price": 0.0002
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "response_image_token": {
+          "price": 0.0008
         }
       }
     }
@@ -3964,7 +3991,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0002
         },
         "request_audio_token": {
           "price": 0.0032
@@ -3973,7 +4000,7 @@
           "price": 0.0064
         },
         "cache_read_audio_input_token": {
-          "price": 0.00004
+          "price": 0.0002
         },
         "request_image_token": {
           "price": 0.0005
@@ -3994,13 +4021,13 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0
+          "price": 0.000125
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         }
       }
     }
@@ -4217,6 +4244,18 @@
           "file_search": {
             "price": 0.25
           }
+        }
+      }
+    }
+  },
+  "gpt-5.2-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000175
+        },
+        "response_token": {
+          "price": 0.0014
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 1 |
| 🔄 Models updated (merged) | 28 |

### ➕ New Models
- `gpt-5.2-image`

### 🔄 Updated Models
- `gpt-5.2-pro`
- `gpt-5.2-pro-2025-12-11`
- `gpt-5.1-codex-mini`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `o4-mini-deep-research-2025-06-26`
- `computer-use-preview`
- `computer-use-preview-2025-03-11`
- `gpt-realtime`
- `gpt-realtime-2025-08-28`
- `gpt-realtime-1.5`
- `gpt-realtime-mini`
- `gpt-realtime-mini-2025-10-06`
- `gpt-realtime-mini-2025-12-15`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-audio`
- `gpt-audio-2025-08-28`
- `gpt-audio-1.5`
- `gpt-audio-mini`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `gpt-image-1`
- `gpt-image-1-mini`
- `gpt-image-1.5`
- `chatgpt-image-latest`


## Data Sources

### Models API
- **Source**: OpenAI Models API (`get_openai_models`)
- **Result**: 128 models returned (ft:* excluded by tool)

### Pricing Data
- **Primary source attempted**: `https://platform.openai.com/docs/pricing` — blocked by Cloudflare (HTTP 403) and firecrawl credits exhausted
- **Fallback source used**: [LiteLLM model_prices_and_context_window.json](https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json) — community-maintained, comprehensive OpenAI pricing

## Model Families Processed (129 total entries)

| Family | Count |
|--------|-------|
| GPT-5.4.x (mini, nano, pro, base) | 8 |
| GPT-5.3.x / GPT-5.2.x / GPT-5.1.x | 17 |
| GPT-5 (base, mini, nano, pro, codex, search) | 10 |
| GPT-4.1.x (base, mini, nano) | 6 |
| GPT-4o family | 8 |
| O-series (o1, o3, o4-mini, deep-research, pro) | 17 |
| Audio/Realtime (gpt-realtime, gpt-audio, gpt-4o-realtime, gpt-4o-mini-realtime) | 20 |
| Transcription (gpt-4o-transcribe, gpt-4o-mini-transcribe) | 6 |
| TTS (gpt-4o-mini-tts, tts-1, tts-1-hd) | 7 |
| Whisper | 1 |
| Embeddings | 3 |
| Moderation | 2 |
| Image (dall-e-2, dall-e-3, gpt-image-1, chatgpt-image-latest) | 8 |
| Sora (sora-2, sora-2-pro) | 2 |
| Legacy (gpt-4, gpt-4-turbo, gpt-3.5-turbo, babbage, davinci) | 10 |
| Computer-use | 2 |

---
*Generated by Pricing Agent on 2026-04-13*