### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,16 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -969,10 +969,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -984,14 +984,17 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -1192,16 +1195,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00003125
         },
         "additional_units": {
           "web_search": {
@@ -1220,10 +1223,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -1322,10 +1325,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
@@ -1482,7 +1485,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "finetune_config": {
@@ -1514,7 +1517,7 @@
             "price": 3.5
           },
           "image_token": {
-            "price": 0.003
+            "price": 0.000004
           },
           "search": {
             "price": 3.5
@@ -1524,7 +1527,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "finetune_config": {
@@ -1546,24 +1549,27 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "additional_units": {
           "web_search": {
             "price": 1.4
           },
           "image_token": {
-            "price": 0.012
+            "price": 0.000004
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00003125
         }
       },
       "finetune_config": {
@@ -1573,10 +1579,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -1602,7 +1608,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00003125
         }
       },
       "finetune_config": {
@@ -1641,7 +1647,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -2199,7 +2205,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.015
         },
         "response_token": {
           "price": 0
@@ -2272,7 +2278,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2522,7 +2528,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2545,7 +2551,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2561,16 +2567,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00006
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.00000375
         },
         "additional_units": {
           "web_search": {
@@ -2578,15 +2584,18 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00003
         }
       }
     }
@@ -2673,16 +2682,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00003125
         },
         "additional_units": {
           "web_search": {
@@ -2693,15 +2702,18 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2744,16 +2756,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000025
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00001
         },
         "cache_write_input_token": {
           "price": 0.000025
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000000625
         },
         "additional_units": {
           "web_search": {
@@ -2761,15 +2773,18 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.00000125
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.000005
         }
       }
     }
@@ -2778,29 +2793,35 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00006
         },
         "additional_units": {
           "image_token": {
-            "price": 0.006
+            "price": 0.000004
           },
           "web_search": {
             "price": 1.4
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00003
         }
       }
     }
@@ -2852,7 +2873,7 @@
           "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -2889,7 +2910,7 @@
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2932,6 +2953,17 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
         }
       }
     }
@@ -3515,6 +3547,70 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 10
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 4 |
| 🔄 Models updated (merged) | 19 |

### ➕ New Models
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `veo-3.1-lite-generate-001`
- `gemma-4-26b-a4b-it-maas`

### 🔄 Updated Models
- `gemini-3-pro-preview`
- `gemini-3-pro-image-preview`
- `gemini-3-flash-preview`
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-lite-preview`
- `gemini-3.1-flash-image-preview`
- `gemini-2.5-pro`
- `gemini-2.5-flash`
- `gemini-2.5-flash-image`
- `gemini-2.5-flash-lite`
- `gemini-2.5-computer-use-preview-10-2025`
- `gemini-2.5-flash-preview-09-2025`
- `gemini-2.5-flash-lite-preview-09-2025`
- `gemini-2.0-flash-001`
- `veo-3.1-generate-001`
- `veo-3.1-fast-generate-001`
- `veo-3.0-generate-001`
- `gemini-embedding-001`
- `multimodalembedding@001`


## Model-to-Pricing-Page Mapping

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-3-pro-preview` | Google – Gemini 3 | API | Matched "Gemini 3 Pro" on pricing page |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API | Matched "Gemini 3 Pro Image" on pricing page |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | Matched "Gemini 3 Flash" on pricing page |
| `gemini-3.1-pro-preview` | Google – Gemini 3.1 | API | Matched "Gemini 3.1 Pro" on pricing page |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3.1 | API | Matched "Gemini 3.1 Flash-Lite" on pricing page |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3.1 | API | Matched "Gemini 3.1 Flash Image" on pricing page |
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Matched "Gemini 2.5 Pro"; standard pricing (≤200K tokens) used |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | Matched "Gemini 2.5 Flash" |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | Matched "Gemini 2.5 Flash Image"; includes image_token additional |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | Matched "Gemini 2.5 Flash Lite" |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 | API | Billed as Gemini 2.5 Pro per pricing page footnote |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias; uses Gemini 2.5 Flash pricing |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias; uses Gemini 2.5 Flash Lite pricing |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no dedicated pricing row found |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no dedicated pricing row found |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | Matched "Gemini 2.0 Flash" |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | Matched "Gemini 2.0 Flash Lite"; no cache on pricing page |
| `imagen-4.0-ultra-generate-001` | Google – Imagen | API | Matched "Imagen 4.0 Ultra"; $0.06/image |
| `imagen-4.0-generate-001` | Google – Imagen | API | Matched "Imagen 4.0"; $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen | API | Matched "Imagen 4.0 Fast"; $0.02/image |
| `imagen-3.0-generate-002` | Google – Imagen | API | Matched "Imagen 3.0"; $0.04/image |
| `imagen-3.0-capability-001` | Google – Imagen | API | Capability model; uses imagen-3.0-generate-001 pricing ($0.04/image) |
| `imagen-3.0-capability-002` | Google – Imagen | API | Capability model; uses imagen-3.0-generate-002 pricing ($0.04/image) |
| `veo-3.1-generate-001` | Google – Veo | API | Matched "Veo 3.1"; $0.40/sec (video+audio 720p/1080p) |
| `veo-3.1-fast-generate-001` | Google – Veo | API | Matched "Veo 3.1 Fast"; $0.20/sec |
| `veo-3.1-lite-generate-001` | Google – Veo | API | Matched "Veo 3.1 Lite"; $0.10/sec |
| `veo-3.0-generate-001` | Google – Veo | API | Matched "Veo 3.0"; $0.40/sec |
| `veo-3.0-fast-generate-001` | Google – Veo | API | Matched "Veo 3.0 Fast"; $0.10/sec |
| `veo-2.0-generate-001` | Google – Veo | API | Matched "Veo 2.0"; $0.50/sec |
| `gemini-embedding-001` | Google – Embedding | API | Matched "Gemini Embedding 001"; $0.15/1K tokens |
| `gemini-embedding-2-preview` | Google – Embedding | API | Matched "Gemini Embedding 2"; $0.20/1M tokens |
| `text-embedding-005` | Google – Embedding | API | Matched "Text Embedding 005"; $0.000025/1K chars |
| `text-multilingual-embedding-002` | Google – Embedding | API | Matched "Text Multilingual Embedding 002"; $0.000025/1K chars |
| `text-embedding-large-exp-03-07` | Google – Embedding | API – price not found | Experimental; no dedicated pricing row found |
| `textembedding-gecko` | Google – Embedding | API | Matched "Textembedding Gecko"; $0.000025/1K chars |
| `multimodalembedding@001` | Google – Embedding | API | Matched "Multimodal Embedding"; includes per-image/video additional pricing |
| `gemma-4-26b-a4b-it-maas` | Google – Gemma | API | Matched "Gemma 4 26B"; $0.15/$0.60 per 1M tokens |
| `claude-opus-4-6` | Anthropic – Claude | API | Stripped @default; matched "Claude Opus 4.6"; includes cache pricing |
| `claude-sonnet-4-6` | Anthropic – Claude | API | Stripped @default; matched "Claude Sonnet 4.6"; includes cache pricing |
| `claude-opus-4-5@20251101` | Anthropic – Claude | API | Matched "Claude Opus 4.5"; includes cache pricing |
| `claude-haiku-4-5@20251001` | Anthropic – Claude | API | Matched "Claude Haiku 4.5"; includes cache pricing |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude | API | Matched "Claude Sonnet 4.5"; includes cache pricing |
| `claude-opus-4-1@20250805` | Anthropic – Claude | API | Matched "Claude Opus 4.1"; includes cache pricing |
| `claude-sonnet-4@20250514` | Anthropic – Claude | API | Matched "Claude Sonnet 4"; includes cache pricing |
| `claude-opus-4@20250514` | Anthropic – Claude | API | Matched "Claude Opus 4"; includes cache pricing |
| `gpt-oss-120b-maas` | OpenAI – GPT | API | Matched "gpt-oss-120b" on pricing page; $0.09/$0.36 per 1M |
| `llama-3.3-70b-instruct-maas` | Meta – Llama | API | Matched "Llama 3.3 70B"; includes batch pricing |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama | API | Matched "Llama 4 Maverick"; $0.35/$1.15 per 1M |
| `mistral-small-2503` | Mistral AI | API | Matched "Mistral Small 3.1 (25.03)"; $0.10/$0.30 per 1M |
| `mistral-medium-3` | Mistral AI | API | Matched "Mistral Medium 3"; $0.40/$2.00 per 1M |
| `codestral-2` | Mistral AI | API | Matched "Codestral 2"; $0.30/$0.90 per 1M |
| `deepseek-r1-0528-maas` | DeepSeek | API | Matched "DeepSeek-R1 (0528)"; includes batch pricing |
| `deepseek-v3.1-maas` | DeepSeek | API | Matched "DeepSeek-V3.1"; includes cache read pricing |
| `deepseek-v3.2-maas` | DeepSeek | API | Matched "DeepSeek-V3.2"; includes cache read pricing |
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen | API | Matched "Qwen3-235B-A22B-Instruct-2507" |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen | API | Matched "Qwen3-Coder-480B-A35B-Instruct" |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen | API | Matched "Qwen3-Next-80B-Instruct" |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen | API | Matched "Qwen3-Next-80B-Thinking" |
| `kimi-k2-thinking-maas` | Moonshot/Kimi | API | Matched "Kimi-K2-Thinking"; includes cache read pricing |
| `minimax-m2-maas` | MiniMax | API | Matched "MiniMax-M2"; includes cache read pricing |
| `glm-4.7-maas` | ZAI.org / GLM | API | Matched "GLM-4.7" |
| `glm-5-maas` | ZAI.org / GLM | API | Matched "GLM-5"; includes cache read pricing |

## Excluded Models (per policy)

| Model | Publisher | Reason |
|-------|-----------|--------|
| `gemini-live-2.5-flash-native-audio` | Google | `*-live-*` — Gemini Live streaming |
| `lyria-002`, `lyria-3-pro-preview`, `lyria-3-clip-preview` | Google | `lyria-*` — music generation |
| `imagegeneration` | Google | Legacy, superseded by Imagen 3+ |
| `virtual-try-on-001` | Google | Retail-specific product model |
| `chirp-2`, `chirp-3` | Google | Audio transcription |
| `image-segmentation-001` | Google | Non-generative (segmentation) |
| `shieldgemma2` | Google | Safety/guard model |
| `t5gemma` | Google | Non-generative |
| `translate-llm` | Google | Fine-tuning/translation only |
| `model-optimizer-*` | Google | Meta-endpoint |
| `gemini-flash-2.5-live-*` | Google | Gemini Live streaming |
| `clip-vit-base-patch32` | OpenAI | Self-deploy + non-generative (CLIP) |
| `openclip` | OpenAI | Non-generative embedding |
| `whisper-large` | OpenAI | Audio transcription (`whisper-*`) |
| `gpt-oss` | OpenAI | Self-deploy (no `-maas`) |
| `jamba-large-1.6` | AI21 | Self-deploy (has_deploy: true, no -maas) |
| `faster-r-cnn`, `retinanet`, `mask-r-cnn`, `segment-anything` | Meta | Non-generative CV |
| `xlm-roberta-large`, `roberta-large` | Meta | Non-generative NLP |
| `codellama-7b-hf`, `llama2`, `llama-2-quantized`, `nllb`, `imagebind` | Meta | Self-deploy |
| `llama3`, `llama3_1`, `llama3-2`, `llama3-3`, `llama4`, `sam3` | Meta | Self-deploy or non-generative |
| `llama-guard`, `prompt-guard` | Meta | Safety/guard models |
| `mistral`, `mixtral` | Mistral AI (mistral-ai) | Self-deploy |
| `ministral-3`, `mistral-large-3` | Mistral AI (mistralai) | Self-deploy |
| `codestral-2501-self-deploy` | Mistral AI | Self-deploy |
| `mistral-ocr-2505` | Mistral AI | OCR model (`*ocr*`) |
| `deepseek-r1`, `deepseek-v3`, `deepseek-v3-1`, `deepseek-v3-2` | DeepSeek | Self-deploy |
| `deepseek-ocr`, `deepseek-ocr-2`, `deepseek-ocr-maas` | DeepSeek | OCR models (`*ocr*`) |
| `qwq`, `qwen3`, `qwen3-embedding`, `qwen3-5`, `qwen2`, `qwen3-coder-next`, `qwen3-coder`, `qwen3-next`, `qwen3-vl` | Qwen | Self-deploy |
| `qwen-image` | Qwen | Explicit policy exception |
| `kimi-k2`, `kimi-k2-5` | Moonshot/Kimi | Self-deploy |
| `minimax-m2` | MiniMax | Self-deploy |
| `glm-4.7`, `glm-5`, `glm-4.5`, `glm-ocr` | ZAI.org | Self-deploy or OCR |
| `glm-image` | ZAI.org | Explicit policy exception |

## Pricing Page Notes

- **Gemini 3/3.1**: web_search $14/1000 queries (1.4¢); enterprise_web_search $14/1000 (1.4¢)
- **Gemini 2.0/2.5**: web_search $35/1000 (3.5¢); enterprise_web_search $45/1000 (4.5¢)
- **Gemini 2.5 Pro**: long-context (>200K) rates noted but standard (≤200K) rate used
- **Gemini Computer Use**: billed as Gemini 2.5 Pro per footnote
- **Imagen capability models**: share pricing with equivalent generate models
- **Gemma 4 26B**: listed as available at no charge until Apr 16, 2026 but standard price included
- **Pricing page source**: https://cloud.google.com/vertex-ai/generative-ai/pricing#global (Global tab)

---
*Generated by Pricing Agent on 2026-04-13*