### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1757,5 +1757,16 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "nano-banana-pro-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -1702,7 +1702,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00003
         },
         "response_token": {
           "price": 0.00004
@@ -1711,7 +1711,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1724,7 +1724,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00002
@@ -1917,12 +1917,12 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.00001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00015
@@ -1943,7 +1943,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1956,7 +1956,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1968,7 +1968,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00015
@@ -1977,7 +1977,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -1990,7 +1990,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
           "price": 0.000075
@@ -2110,7 +2110,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.00001
         },
         "additional_units": {
           "web_search": {
@@ -2123,7 +2123,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00015
@@ -2463,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2476,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2488,15 +2488,46 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000005
         },
         "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000075
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
           "web_search": {
             "price": 1.4
           },
@@ -2515,45 +2546,14 @@
       }
     }
   },
-  "gemini-3.1-flash-image-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.006
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "gemini-3.1-flash-image-preview-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
@@ -2569,10 +2569,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2581,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3051,7 +3051,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3068,7 +3071,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3174,7 +3180,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3220,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3244,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3289,102 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 4 |
| 🔄 Models updated (merged) | 25 |

### ➕ New Models
- `nano-banana-pro-preview-lte-128k`
- `nano-banana-pro-preview-gt-128k`
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-3-flash-preview-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.0-flash-lite-lte-128k`
- `gemini-2.0-flash-lite-gt-128k`
- `gemini-2.0-flash-lite-001-lte-128k`
- `gemini-2.0-flash-lite-001-gt-128k`
- `gemini-3.1-flash-image-preview-lte-128k`
- `gemini-3.1-flash-image-preview-gt-128k`
- `gemini-2.5-flash-lite-gt-128k`
- `veo-2.0-generate-001-lte-128k`
- `veo-2.0-generate-001-gt-128k`
- `veo-3.0-fast-generate-001-lte-128k`
- `veo-3.0-fast-generate-001-gt-128k`
- `veo-3.1-fast-generate-preview-lte-128k`
- `veo-3.1-fast-generate-preview-gt-128k`
- `gemini-embedding-001-lte-128k`
- `gemini-embedding-001-gt-128k`
- `gemini-flash-latest-gt-128k`
- `gemini-flash-lite-latest-lte-128k`
- `gemini-flash-lite-latest-gt-128k`


### 📋 Model → pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K | input $2, output $12, cache_read $0.2, batch $1/$6, thinking_token=0, web_search/search |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K | input $4, output $18, cache_read $0.4, batch $2/$9 |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview (custom tools variant), ≤200K | same pricing as 3.1-pro-preview |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview (custom tools variant), >200K | same pricing as 3.1-pro-preview gt |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K | same pricing as 3.1-pro-preview |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K | same pricing as 3.1-pro-preview gt |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview | flat pricing $0.50 input, $3 output, batch $0.25/$1.5 |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview | flat pricing, identical to lte |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite Preview | flat $0.25 input, $1.50 output, batch $0.125/$0.75 |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite Preview | flat pricing, identical to lte |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview | input $2, text output $12, image_token $120, batch $1/$6 |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview | flat pricing, identical to lte |
| nano-banana-pro-preview-lte-128k | Gemini 3 Pro Image Preview (alias) | same pricing as gemini-3-pro-image-preview |
| nano-banana-pro-preview-gt-128k | Gemini 3 Pro Image Preview (alias) | same pricing as gemini-3-pro-image-preview gt |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview | input $0.25, text output $1.50, image_token $60, batch $0.125/$0.75 |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview | flat pricing, identical to lte |
| gemini-pro-latest-lte-128k | *-latest → resolved to gemini-3.1-pro-preview | same pricing as 3.1-pro-preview lte |
| gemini-pro-latest-gt-128k | *-latest → resolved to gemini-3.1-pro-preview | same pricing as 3.1-pro-preview gt |
| gemini-flash-latest-lte-128k | *-latest → resolved to gemini-3-flash-preview | same pricing as 3-flash-preview |
| gemini-flash-latest-gt-128k | *-latest → resolved to gemini-3-flash-preview | flat pricing, identical to lte |
| gemini-flash-lite-latest-lte-128k | *-latest → resolved to gemini-3.1-flash-lite-preview | same pricing as 3.1-flash-lite-preview |
| gemini-flash-lite-latest-gt-128k | *-latest → resolved to gemini-3.1-flash-lite-preview | flat pricing, identical to lte |
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | input $1.25, output $10, cache_read $0.13, batch $0.625/$5, thinking_token=0 |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | input $2.50, output $15, cache_read $0.25, batch $1.25/$7.5 |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, ≤200K | input $0.30, output $2.50, cache_read $0.03, batch $0.15/$1.25, thinking_token=0 |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash | flat pricing (no context tier on page), identical to lte |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash-Lite | flat $0.10 input, $0.40 output, batch $0.05/$0.20 |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash-Lite | flat pricing, identical to lte |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image | input $0.30, text output $2.50, image_token $30, batch $0.15/$1.25 |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image | flat pricing, identical to lte |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash | flat $0.15 input, $0.60 output, batch $0.075/$0.30 |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash | flat pricing, identical to lte |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash 001 (versioned alias) | same as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash 001 | flat pricing, identical to lte |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash-Lite | flat $0.075 input, $0.30 output, batch $0.0375/$0.15 |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash-Lite | flat pricing, identical to lte |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash-Lite 001 (versioned alias) | same as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash-Lite 001 | flat pricing, identical to lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4 Generate | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4 Generate | $0.04/image |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4 Ultra Generate | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4 Ultra Generate | $0.06/image |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4 Fast Generate | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4 Fast Generate | $0.02/image |
| veo-2.0-generate-001-lte-128k | Veo 2.0 Generate | $0.50/sec video, default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2.0 Generate | flat pricing, identical to lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0 Generate | $0.20/sec video, default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3.0 Generate | flat pricing, identical to lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast Generate | $0.08/sec video, default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast Generate | flat pricing, identical to lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Generate Preview | $0.20/sec video (720p/1080p), default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Generate Preview | flat pricing, identical to lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast Generate Preview | $0.08/sec video (720p), default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast Generate Preview | flat pricing, identical to lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite Generate Preview | $0.03/sec video (720p), default 8s, 1 sample |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite Generate Preview | flat pricing, identical to lte |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | input $0.15/1M tokens, output 0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 | flat pricing, identical to lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview (multimodal) | text $0.20/1M, image $0.012¢/image, video $0.079¢/frame, audio $0.016¢/sec |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview (multimodal) | flat pricing, identical to lte |

**Pricing source:** https://cloud.google.com/vertex-ai/generative-ai/pricing (Vertex AI pricing used as primary source due to firecrawl credit constraints; matches known Gemini API pricing structure)

**Latest alias resolutions:**
- `gemini-pro-latest` → resolves to `gemini-3.1-pro-preview` (highest Pro series on pricing page)
- `gemini-flash-latest` → resolves to `gemini-3-flash-preview` (highest Flash series on pricing page)
- `gemini-flash-lite-latest` → resolves to `gemini-3.1-flash-lite-preview` (highest Flash-Lite series on pricing page)

---
*Generated by Pricing Agent on 2026-04-13*