### PR TITLE
chore(pricing): Update fireworks-ai pricing

### DIFF
--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -56,6 +56,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -112,10 +123,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0
         }
       }
     }
@@ -124,10 +135,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -136,10 +147,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -208,10 +219,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.00032
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00011
         }
       }
     }
@@ -224,6 +246,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -236,6 +269,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -248,6 +292,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -284,6 +339,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -308,6 +374,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -320,6 +397,318 @@
         },
         "response_token": {
           "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "deepseek-v3p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "deepseek-v3p2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "glm-4p7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "glm-5p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "gpt-oss-120b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.0000025
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "flux-1-dev-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.025
+          }
+        }
+      }
+    }
+  },
+  "flux-1-schnell-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.025
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 8
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: fireworks-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 15 |
| 🔄 Models updated (merged) | 9 |

### ➕ New Models
- `deepseek-v3p1`
- `deepseek-v3p2`
- `glm-4p7`
- `glm-5p1`
- `gpt-oss-120b`
- `gpt-oss-20b`
- `llama-v3p3-70b-instruct`
- `qwen3-8b`
- `qwen3p6-plus`
- `qwen3-vl-30b-a3b-instruct`
- `qwen3-vl-30b-a3b-thinking`
- `flux-1-dev-fp8`
- `flux-1-schnell-fp8`
- `flux-kontext-pro`
- `flux-kontext-max`

### 🔄 Updated Models
- `glm-5`
- `kimi-k2-instruct-0905`
- `kimi-k2p5`
- `kimi-k2-thinking`
- `minimax-m2p1`
- `minimax-m2p5`
- `minimax-m2p7`
- `mixtral-8x22b-instruct`
- `nomic-ai/nomic-embed-text-v1.5`


## Pricing Sources

- **Models list**: `get_fireworks_models` API (25 serverless models returned)
- **Pricing data**: LiteLLM `model_prices_and_context_window.json` (live-fetched from GitHub) used as fallback since `fireworks.ai/pricing` is a JavaScript SPA that cannot be scraped via static HTTP fetch and Firecrawl credits were exhausted.

## Model → Pricing Mapping

| Model | Source | Input $/M | Output $/M | Notes |
|-------|--------|-----------|------------|-------|
| deepseek-v3p1 | litellm | $0.56 | $1.68 | named family, cache $0.28 |
| deepseek-v3p2 | litellm | $0.56 | $1.68 | named family, cache $0.28 |
| glm-4p7 | litellm | $0.60 | $2.20 | named family, cache $0.30 |
| glm-5 | tier estimate (same as glm-4p7) | $0.60 | $2.20 | not in litellm |
| glm-5p1 | tier estimate (same as glm-4p7) | $0.60 | $2.20 | not in litellm |
| gpt-oss-120b | litellm | $0.15 | $0.60 | named family |
| gpt-oss-20b | litellm | $0.05 | $0.20 | named family |
| kimi-k2-instruct-0905 | litellm | $0.60 | $2.50 | named family |
| kimi-k2p5 | litellm | $0.60 | $3.00 | named family, cache $0.10 |
| kimi-k2-thinking | litellm | $0.60 | $2.50 | named family |
| llama-v3p3-70b-instruct | litellm | $0.90 | $0.90 | >16B tier |
| minimax-m2p1 | litellm | $0.30 | $1.20 | named family, cache $0.03 |
| minimax-m2p5 | tier estimate (same as m2p1) | $0.30 | $1.20 | not in litellm |
| minimax-m2p7 | tier estimate (same as m2p1) | $0.30 | $1.20 | not in litellm |
| mixtral-8x22b-instruct | litellm | $1.20 | $1.20 | MoE 56.1-176B tier |
| qwen3-8b | litellm | $0.20 | $0.20 | 4B-16B tier |
| qwen3p6-plus | tier estimate | $0.20 | $0.20 | <4B tier |
| qwen3-vl-30b-a3b-instruct | litellm | $0.15 | $0.60 | named family |
| qwen3-vl-30b-a3b-thinking | litellm | $0.15 | $0.60 | named family |
| flux-1-dev-fp8 | skill reference | per-step $0.00025 | image generation |
| flux-1-schnell-fp8 | skill reference | per-step $0.00025 | image generation |
| flux-kontext-pro | litellm | $0.04/image | per-image |
| flux-kontext-max | litellm | $0.08/image | per-image |
| nomic-ai/nomic-embed-text-v1.5 | litellm | $0.008 | embedding |

**Skipped**: `qwen3-reranker-8b` (reranker — excluded per skill rules)

---
*Generated by Pricing Agent on 2026-04-13*