### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,16 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -630,7 +630,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -1192,26 +1192,26 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.000013
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           },
           "enterprise_web_search": {
-            "price": 1.4
+            "price": 4.5
           },
           "image_token": {
             "price": 0.012
@@ -1220,10 +1220,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -1322,10 +1322,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
@@ -1602,7 +1602,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2295,7 +2295,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2522,7 +2522,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2561,32 +2561,35 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -2673,35 +2676,38 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.000013
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2744,32 +2750,35 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.000025
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2778,29 +2787,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "image_token": {
-            "price": 0.006
+            "price": 0.003
           },
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -3003,7 +3015,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
@@ -3515,6 +3527,69 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 4 |
| 🔄 Models updated (merged) | 11 |

### ➕ New Models
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `gemma-4-26b-a4b-it-maas`
- `veo-3.1-lite-generate-001`

### 🔄 Updated Models
- `gemini-2.5-pro`
- `veo-3.1-fast-generate-001`
- `veo-3.0-fast-generate-001`
- `textembedding-gecko-multilingual@001`
- `multimodalembedding@001`
- `gemini-3-pro-preview`
- `gemini-3-flash-preview`
- `gemini-3.1-flash-lite-preview`
- `gemini-3.1-flash-image-preview`
- `gemini-3.1-pro-preview`
- `multimodalembedding`


## Model-to-Pricing-Page Mapping

### Google – Gemini (text/multimodal)

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Standard ≤200K pricing; batch from Flex/Batch table |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | Standard pricing; batch from Flex/Batch table |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | Standard pricing; batch from Flex/Batch table |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 | API | Maps to Gemini 2.5 Pro pricing row |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 | API | Maps to gemini-2.5-flash pricing row |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 | API | Maps to gemini-2.5-flash-lite pricing row |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | Standard pricing; batch from Flex/Batch table |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | Standard pricing; batch from Flex/Batch table |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | Image output model; image_token $30/M additional |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no dedicated row on pricing page |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no dedicated row on pricing page |
| `gemini-3-pro-preview` | Google – Gemini 3 | API | Maps to Gemini 3 Pro pricing row |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | Maps to Gemini 3 Flash pricing row |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API – price not found | No dedicated pricing row found |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3.1 | API | Maps to Gemini 3.1 Flash Lite pricing |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3.1 | API | Image output model; maps to flash image pricing |
| `gemini-3.1-pro-preview` | Google – Gemini 3.1 | API | Maps to Gemini 3.1 Pro pricing row |
| `gemma-4-26b-a4b-it-maas` | Google – Gemma (MaaS) | API | $0.15/$0.60 per 1M tokens; free until Apr 16 2026 |

### Google – Imagen

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `imagen-4.0-generate-001` | Google – Imagen 4 | API | $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4 Fast | API | $0.02/image |
| `imagen-4.0-ultra-generate-001` | Google – Imagen 4 Ultra | API | $0.06/image |
| `imagen-3.0-generate-002` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-capability-001` | Google – Imagen 3 | API | Capability model; uses imagen-3.0-generate-002 price ($0.04/image) |
| `imagen-3.0-capability-002` | Google – Imagen 3 | API | Capability model; uses imagen-3.0-generate-002 price ($0.04/image) |

### Google – Veo

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | $0.20/sec (720p/1080p video-only) |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | $0.08/sec (720p video-only) |
| `veo-3.1-lite-generate-001` | Google – Veo 3.1 Lite | API | $0.03/sec (720p) |
| `veo-3.0-generate-001` | Google – Veo 3 | API | $0.20/sec |
| `veo-3.0-fast-generate-001` | Google – Veo 3 Fast | API | $0.08/sec (720p) |
| `veo-2.0-generate-001` | Google – Veo 2 | API | $0.50/sec |

### Google – Embeddings

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-embedding-001` | Google – Gemini Embedding | API | $0.00015/1K tokens online |
| `gemini-embedding-2-preview` | Google – Gemini Embedding | API – price not found | No dedicated row; added with price 0 |
| `text-embedding-005` | Google – Text Embedding | API | $0.000025/1K chars |
| `text-embedding-large-exp-03-07` | Google – Text Embedding | API | Experimental; uses text-embedding pricing ($0.000025/1K chars) |
| `text-multilingual-embedding-002` | Google – Text Multilingual Embedding | API | $0.000025/1K chars |
| `textembedding-gecko` | Google – Text Embedding (legacy) | API | Legacy; $0.000025/1K chars |
| `textembedding-gecko@003` | Google – Text Embedding (legacy) | API | Legacy; $0.000025/1K chars |
| `textembedding-gecko-multilingual@001` | Google – Text Embedding (legacy) | API | Legacy; $0.000025/1K chars |
| `multimodalembedding` | Google – Multimodal Embedding | API | Text $0.0002/1K chars + per-image/video additional |
| `multimodalembedding@001` | Google – Multimodal Embedding | API | Text $0.0002/1K chars + per-image/video additional |

### Google – Excluded

| Model ID | Reason |
|----------|--------|
| `gemini-live-2.5-flash-native-audio` | Excluded: `*-live-*` streaming (separate product) |
| `virtual-try-on-001` | Excluded: `virtual-try-on-*` per google.md |
| `imagegeneration` | Excluded: legacy, superseded by imagen-3.0+ |
| `lyria-*` (`lyria-002`, `lyria-3-pro-preview`, `lyria-3-clip-preview`) | Excluded: music generation, no inference endpoint |
| All non-generative CV/NLP/traditional ML models | Excluded: not on generative AI pricing page |
| All `*self-deploy*` / `has_deploy:true` (no -maas) | Excluded: customer-managed infrastructure |
| `shieldgemma2` | Excluded: guard/safety model |
| `pretrained-ocr` | Excluded: OCR model |

### Anthropic – Claude

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `claude-opus-4-6` | Anthropic – Claude | API | Stripped @default; $5/$25 input/output; cache write 5m $6.25/M |
| `claude-sonnet-4-6` | Anthropic – Claude | API | Stripped @default; $3/$15; cache write 5m $3.75/M |
| `claude-opus-4-5@20251101` | Anthropic – Claude | API | Pinned version; $5/$25 |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude | API | Pinned version; $3/$15 (≤200K standard) |
| `claude-haiku-4-5@20251001` | Anthropic – Claude | API | Pinned version; $1/$5 |
| `claude-opus-4-1@20250805` | Anthropic – Claude | API | Pinned version; $15/$75 |
| `claude-opus-4@20250514` | Anthropic – Claude | API | Pinned version; $15/$75 |
| `claude-sonnet-4@20250514` | Anthropic – Claude | API | Pinned version; $3/$15 |

### OpenAI – GPT

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gpt-oss-120b-maas` | OpenAI – GPT OSS | API | $0.09/$0.36; batch $0.045/$0.18 |
| `openclip` | OpenAI | Excluded | Non-generative (CLIP embedding model) |
| `clip-vit-base-patch32` | OpenAI | Excluded | Self-deploy + non-generative |
| `whisper-large` | OpenAI | Excluded | Audio transcription, not generative inference |
| `gpt-oss` | OpenAI | Excluded | Self-deploy only |

### DeepSeek

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `deepseek-r1-0528-maas` | DeepSeek | API | $1.35/$5.40; batch $0.675/$2.70 |
| `deepseek-v3.1-maas` | DeepSeek | API | $0.60/$1.70; cache read $0.06/M; batch $0.30/$0.85 |
| `deepseek-v3.2-maas` | DeepSeek | API | $0.56/$1.68; cache read $0.056/M; batch $0.28/$0.84 |
| `deepseek-ocr-maas` | DeepSeek | Excluded | OCR model per global exclude rules |
| All self-deploy (`deepseek-r1`, `deepseek-v3`, etc.) | DeepSeek | Excluded | Self-deploy only |

### MiniMax

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `minimax-m2-maas` | MiniMax | API | $0.30/$1.20; cache read $0.03/M |
| `minimax-m2` | MiniMax | Excluded | Self-deploy only |

### Moonshot / Kimi

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `kimi-k2-thinking-maas` | Moonshot/Kimi | API | $0.60/$2.50; cache read $0.06/M |
| `kimi-k2`, `kimi-k2-5` | Moonshot/Kimi | Excluded | Self-deploy only |

### Qwen

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen | API | $0.22/$0.88; batch $0.11/$0.44 |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen | API | $0.22/$1.80; cache read $0.022/M; batch $0.11/$0.90 |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen | API | $0.15/$1.20 |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen | API | $0.15/$1.20 |
| `qwen-image` | Qwen | Excluded | Explicit policy exception per partners.md |
| All other self-deploy qwen models | Qwen | Excluded | Self-deploy only |

### ZAI.org / GLM

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `glm-4.7-maas` | ZAI.org – GLM | API | $0.60/$2.20 |
| `glm-5-maas` | ZAI.org – GLM | API | $1.00/$3.20; cache read $0.10/M; free until Feb 19 2026 |
| `glm-image` | ZAI.org | Excluded | Explicit policy exception per partners.md |
| `glm-ocr` | ZAI.org | Excluded | OCR model + self-deploy |
| All other self-deploy glm models | ZAI.org | Excluded | Self-deploy only |

### Meta – Llama

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `llama-3.3-70b-instruct-maas` | Meta – Llama | API | $0.72/$0.72; batch $0.36/$0.36 |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama | API | $0.35/$1.15; batch $0.175/$0.575 |
| `llama-guard`, `prompt-guard` | Meta | Excluded | Guard/safety models |
| `sam3` | Meta | Excluded | Non-generative (segmentation model) |
| `faster-r-cnn`, `retinanet`, `mask-r-cnn` | Meta | Excluded | Non-generative CV models |
| `roberta-large`, `xlm-roberta-large` | Meta | Excluded | Non-generative NLP + self-deploy |
| All other self-deploy llama models | Meta | Excluded | Self-deploy only |

### Mistral

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `mistral-small-2503` | Mistral | API | $0.10/$0.30 |
| `mistral-medium-3` | Mistral | API | $0.40/$2.00 |
| `codestral-2` | Mistral | API | $0.30/$0.90 |
| `mistral-ocr-2505` | Mistral | Excluded | OCR model per global exclude rules |
| `codestral-2501-self-deploy` | Mistral | Excluded | Self-deploy (name contains self-deploy) |
| `ministral-3`, `mistral-large-3` | Mistral | Excluded | Self-deploy only |
| `mistral`, `mixtral` (mistral-ai publisher) | Mistral-ai | Excluded | Self-deploy only |

### AI21

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `jamba-large-1.6` | AI21 | Excluded | Self-deploy only (has_deploy: true, no -maas) |

---

**All web search prices sourced from Vertex AI Generative AI pricing page (Global tab) Feature tables.**  
**Pricing page URL:** https://cloud.google.com/vertex-ai/generative-ai/pricing#global

---
*Generated by Pricing Agent on 2026-04-13*