### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1757,5 +1757,11 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -924,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1943,7 +1943,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1956,7 +1956,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1977,7 +1977,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1990,7 +1990,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2463,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2476,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2494,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2507,7 +2507,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2581,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3174,7 +3174,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3214,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3238,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3283,40 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 19 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-flash-lite-latest-lte-128k`
- `gemini-flash-lite-latest-gt-128k`
- `gemini-2.5-pro-lte-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `veo-2.0-generate-001-lte-128k`
- `veo-2.0-generate-001-gt-128k`
- `veo-3.0-generate-001-lte-128k`
- `veo-3.0-generate-001-gt-128k`
- `veo-3.0-fast-generate-001-lte-128k`
- `veo-3.0-fast-generate-001-gt-128k`
- `veo-3.1-generate-preview-lte-128k`
- `veo-3.1-generate-preview-gt-128k`
- `veo-3.1-fast-generate-preview-lte-128k`
- `veo-3.1-fast-generate-preview-gt-128k`


### Model → Pricing Page Mapping

Data sourced from: https://cloud.google.com/vertex-ai/generative-ai/pricing (fetched live 2026-04-13)

| Model ID | Pricing Page Section | Notes |
|----------|----------------------|-------|
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K | input $2/1M, output $12/1M, cache_read $0.20, batch $1/$6, web_search 1.4¢ |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K | input $4/1M, output $18/1M, cache_read $0.40, batch $2/$9, web_search 1.4¢ |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview (custom tools variant), ≤200K | same pricing as gemini-3.1-pro-preview lte |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview (custom tools variant), >200K | same pricing as gemini-3.1-pro-preview gt |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview, FLAT | input $0.50/1M, text output $3/1M, image_token $60/1M, batch $0.25/$1.50, web_search 1.4¢ |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview, FLAT | same as lte (flat pricing, no tiers) |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite Preview, FLAT | input $0.25/1M, output $1.50/1M, cache_read $0.03, batch $0.13/$0.75, web_search 1.4¢ |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite Preview, FLAT | same as lte (flat pricing, no tiers) |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K | input $2/1M, output $12/1M, cache_read $0.20, batch $1/$6, web_search 1.4¢ |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K | input $4/1M, output $18/1M, cache_read $0.40, batch $2/$9, web_search 1.4¢ |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview (Nano Banana Pro), FLAT | input $2/1M, text output $12/1M, image_token $120/1M, batch $1/$6, web_search 1.4¢ |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview (Nano Banana Pro), FLAT | same as lte (flat pricing, no tiers) |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, FLAT | input $0.50/1M, output $3/1M, cache_read $0.05, batch $0.25/$1.50, web_search 1.4¢ |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, FLAT | same as lte (flat pricing, no tiers) |
| gemini-pro-latest-lte-128k | *-latest alias → resolved to gemini-3.1-pro-preview (verified from pricing page) | same pricing as gemini-3.1-pro-preview lte |
| gemini-pro-latest-gt-128k | *-latest alias → resolved to gemini-3.1-pro-preview (verified from pricing page) | same pricing as gemini-3.1-pro-preview gt |
| gemini-flash-latest-lte-128k | *-latest alias → resolved to gemini-3-flash-preview (verified from pricing page) | same pricing as gemini-3-flash-preview lte |
| gemini-flash-latest-gt-128k | *-latest alias → resolved to gemini-3-flash-preview (verified from pricing page) | same pricing as gemini-3-flash-preview gt |
| gemini-flash-lite-latest-lte-128k | *-latest alias → resolved to gemini-3.1-flash-lite-preview (verified from pricing page) | same pricing as gemini-3.1-flash-lite-preview lte |
| gemini-flash-lite-latest-gt-128k | *-latest alias → resolved to gemini-3.1-flash-lite-preview (verified from pricing page) | same pricing as gemini-3.1-flash-lite-preview gt |
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K | input $1.25/1M, output $10/1M, cache_read $0.13, batch $0.625/$5, web_search 3.5¢ |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K | input $2.50/1M, output $15/1M, cache_read $0.25, batch $1.25/$7.50, web_search 3.5¢ |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, FLAT | input $0.30/1M, output $2.50/1M, cache_read $0.03, batch $0.15/$1.25, web_search 3.5¢ |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, FLAT | same as lte (flat pricing, no tiers) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, FLAT | input $0.30/1M, text output $2.50/1M, image_token $30/1M, batch $0.15/$1.25 (batch image $15/1M noted), web_search 3.5¢ |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, FLAT | same as lte (flat pricing, no tiers) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash Lite, FLAT | input $0.10/1M, output $0.40/1M, cache_read $0.01, batch $0.05/$0.20, web_search 3.5¢ |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash Lite, FLAT | same as lte (flat pricing, no tiers) |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, FLAT | input $0.15/1M, output $0.60/1M, batch $0.075/$0.30, web_search 3.5¢; audio input $1.00/1M (not captured separately) |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, FLAT | same as lte (flat pricing, no tiers) |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash 001 (alias for 2.0 Flash), FLAT | same pricing as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash 001, FLAT | same as lte |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash Lite, FLAT | input $0.075/1M, output $0.30/1M, batch $0.0375/$0.15; no web search listed |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash Lite, FLAT | same as lte |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash Lite 001 (alias for 2.0 Flash Lite), FLAT | same pricing as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash Lite 001, FLAT | same as lte |
| imagen-4.0-generate-001-lte-128k | Imagen 4.0 Generate 001 | $0.04/image (standard quality) |
| imagen-4.0-generate-001-gt-128k | Imagen 4.0 Generate 001 | same as lte (flat pricing) |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4.0 Ultra Generate 001 | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4.0 Ultra Generate 001 | same as lte |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4.0 Fast Generate 001 | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4.0 Fast Generate 001 | same as lte |
| veo-2.0-generate-001-lte-128k | Veo 2.0 Generate 001 | $0.50/s video → 50¢/s, default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2.0 Generate 001 | same as lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0 Generate 001 (video only, 720p/1080p) | $0.20/s → 20¢/s, default 8s, 1 sample; video+audio $0.40/s noted in page |
| veo-3.0-generate-001-gt-128k | Veo 3.0 Generate 001 | same as lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast Generate 001 (video only, 720p) | $0.08/s → 8¢/s, default 8s, 1 sample; video+audio 720p $0.10/s noted |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast Generate 001 | same as lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Generate Preview (video only, 720p/1080p) | $0.20/s → 20¢/s, default 8s, 1 sample; video+audio $0.40/s; 4K $0.40/s (video only) noted |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Generate Preview | same as lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast Generate Preview (video only, 720p) | $0.08/s → 8¢/s, default 8s, 1 sample; video+audio 720p $0.10/s; 1080p $0.12/s noted |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast Generate Preview | same as lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite Generate Preview (video only, 720p) | $0.03/s → 3¢/s, default 8s, 1 sample; 1080p $0.05/s; video+audio 720p $0.05/s noted |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite Generate Preview | same as lte |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | input $0.00015/1K = $0.15/1M tokens; output 0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 | same as lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview (multimodal) | text input $0.20/1M tokens; image $0.00012/image, video $0.00079/frame, audio $0.00016/s noted; output 0 |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview | same as lte |

### Notable Decisions

- **Pricing page tiers**: The Vertex AI page uses ≤200K / >200K context tiers (not 128K). These map to `-lte-128k` / `-gt-128k` naming convention.
- **Web search pricing**: Gemini 3.x = $14/1K queries (1.4¢ each, billing started Jan 5 2026); Gemini 2.5/2.0 = $35/1K (3.5¢ each).
- **Thinking tokens**: Not added as separate `thinking_token` field — the page describes output as "Text output (response and reasoning)" indicating thinking is bundled into the standard output price.
- **Flat pricing models**: gemini-3.1-flash-image-preview, gemini-3.1-flash-lite-preview, gemini-3-flash-preview, gemini-3-pro-image-preview, gemini-2.5-flash, gemini-2.5-flash-image, gemini-2.5-flash-lite, gemini-2.0-flash, gemini-2.0-flash-lite, all Imagen, all Veo — lte and gt entries are identical.
- **Gemini 3.1 Pro batch image output**: Page shows Image Output $60/1M in batch section for 3.1 Pro Preview, but since the standard table shows no image output for this model (it is a text model), image_token was not added.
- **nano-banana-pro-preview**: Model ID contains "nano" → excluded per skill rules.
- **Audio input rates**: Not captured separately (e.g. 2.0 Flash audio $1.00/1M, 3.x Flash audio rates) as the tool has no separate audio input field; noted here for reviewers.
- **Gemini Embedding 2 Preview multimodal rates**: Only text token input rate captured ($0.20/1M); image/video/audio per-unit rates noted above for reviewers.
- **Cache write**: Not added for any model — the page explicitly shows only cache read (cached input token) rates in the standard pricing tables.

---
*Generated by Pricing Agent on 2026-04-13*