### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,41 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "gemini-embedding-2-preview-05-20": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -630,7 +630,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -1082,6 +1082,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
         }
       },
@@ -1145,6 +1148,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1176,6 +1182,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1266,10 +1275,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1277,15 +1286,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1294,10 +1309,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1305,15 +1320,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1322,23 +1343,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
-            "price": 0.01
+            "price": 0.0001
           },
           "input_video_plus": {
-            "price": 0.2
+            "price": 0.002
           },
           "input_video_standard": {
-            "price": 0.1
+            "price": 0.001
           },
           "input_video_essential": {
-            "price": 0.05
+            "price": 0.0005
           }
         }
       },
@@ -1445,7 +1466,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       },
       "batch_config": {
@@ -1560,6 +1587,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1602,7 +1632,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -2295,7 +2325,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2522,7 +2552,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2577,6 +2607,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2693,6 +2726,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2761,6 +2797,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2791,6 +2830,9 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2932,6 +2974,17 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
         }
       }
     }
@@ -3515,6 +3568,166 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-image-generation": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-05-20": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.00012
+          },
+          "input_video_plus": {
+            "price": 0.00079
+          },
+          "input_video_standard": {
+            "price": 0.00079
+          },
+          "input_video_essential": {
+            "price": 0.00016
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 7 |
| 🔄 Models updated (merged) | 17 |

### ➕ New Models
- `gemini-2.5-pro-preview-06-05`
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `gemma-4-26b-a4b-it-maas`
- `gemini-2.0-flash-image-generation`
- `veo-3.1-lite-generate-001`
- `gemini-embedding-2-preview-05-20`

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-2.5-pro-preview-03-25`
- `gemini-2.5-pro-preview-05-06`
- `gemini-2.5-computer-use-preview-10-2025`
- `gemini-2.5-flash-preview-04-17`
- `gemini-2.5-flash-preview-05-20`
- `gemini-2.5-flash-lite-preview-06-17`
- `gemini-2.0-flash-lite`
- `gemini-3-pro-image-preview`
- `gemini-3-flash-preview`
- `gemini-3.1-pro-preview`
- `gemini-3.1-flash-image-preview`
- `gemini-3.1-flash-lite-preview`
- `veo-3.0-fast-generate-001`
- `veo-3.1-fast-generate-001`
- `textembedding-gecko-multilingual@001`
- `multimodalembedding@001`


## Model-to-Pricing-Page Mapping

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Standard tier pricing ≤200K tokens |
| `gemini-2.5-pro-preview-03-25` | Google – Gemini 2.5 | API | Preview alias, same pricing as 2.5 Pro |
| `gemini-2.5-pro-preview-05-06` | Google – Gemini 2.5 | API | Preview alias, same pricing as 2.5 Pro |
| `gemini-2.5-pro-preview-06-05` | Google – Gemini 2.5 | API | Preview alias, same pricing as 2.5 Pro |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 | API | "Gemini 2.5 Pro Computer Use Preview" row |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | Standard tier |
| `gemini-2.5-flash-preview-04-17` | Google – Gemini 2.5 | API | Preview alias, same pricing as 2.5 Flash |
| `gemini-2.5-flash-preview-05-20` | Google – Gemini 2.5 | API | Preview alias, same pricing as 2.5 Flash |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias, same pricing as 2.5 Flash |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | Standard tier |
| `gemini-2.5-flash-lite-preview-06-17` | Google – Gemini 2.5 | API | Preview alias, same pricing as 2.5 Flash Lite |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias, same pricing as 2.5 Flash Lite |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | "Gemini 2.5 Flash Image" row; image_token=$30/1M |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no pricing row on page |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API – price not found | TTS model; no pricing row on page |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | Canonical 2.0 Flash ID |
| `gemini-2.0-flash` | Google – Gemini 2.0 | API | Alias for gemini-2.0-flash-001 |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | Canonical 2.0 Flash Lite ID |
| `gemini-2.0-flash-lite` | Google – Gemini 2.0 | API | Alias for gemini-2.0-flash-lite-001 |
| `gemini-2.0-flash-image-generation` | Google – Gemini 2.0 | API | "Gemini 2.0 Flash Image Generation" row; image_token=$30/1M |
| `gemma-4-26b-a4b-it-maas` | Google – Gemma | API | "Gemma 4 26B" row; $0.15/$0.60 |
| `gemini-3-pro-preview` | Google – Gemini 3 | API | "Gemini 3 Pro Preview" row |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API | "Gemini 3 Pro Image Preview" row; image_token=$120/1M |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | "Gemini 3 Flash Preview" row |
| `gemini-3.1-pro-preview` | Google – Gemini 3 | API | "Gemini 3.1 Pro Preview" row |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3 | API | "Gemini 3.1 Flash Image Preview" row; image_token=$60/1M |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3 | API | "Gemini 3.1 Flash-Lite Preview" row |
| `imagen-4.0-generate-001` | Google – Imagen | API | $0.04/image; row matched via `imagen-4.0-generate` |
| `imagen-4.0-ultra-generate-001` | Google – Imagen | API | $0.06/image; row matched via `imagen-4.0-ultra-generate` |
| `imagen-4.0-fast-generate-001` | Google – Imagen | API | $0.02/image; row matched via `imagen-4.0-fast-generate` |
| `imagen-3.0-generate-002` | Google – Imagen | API | $0.04/image; matches Imagen 3.0 Generate row |
| `imagen-3.0-generate-001` | Google – Imagen | API | $0.04/image; matches Imagen 3.0 Generate row |
| `imagen-3.0-fast-generate-001` | Google – Imagen | API | $0.02/image; matches Imagen 3.0 Fast Generate row |
| `imagen-3.0-capability-001` | Google – Imagen | API | $0.04/image; capability model uses equivalent generate pricing (imagen-3.0-generate) |
| `imagen-3.0-capability-002` | Google – Imagen | API | $0.04/image; capability model uses equivalent generate pricing (imagen-3.0-generate) |
| `veo-2.0-generate-001` | Google – Veo | API | $0.50/sec; Veo 2 row |
| `veo-3.0-generate-001` | Google – Veo | API | $0.20/sec (720p video-only); Veo 3 row |
| `veo-3.0-fast-generate-001` | Google – Veo | API | $0.08/sec (720p video-only); Veo 3 Fast row |
| `veo-3.1-generate-001` | Google – Veo | API | $0.20/sec (720p video-only); Veo 3.1 row |
| `veo-3.1-fast-generate-001` | Google – Veo | API | $0.08/sec (720p video-only); Veo 3.1 Fast row |
| `veo-3.1-lite-generate-001` | Google – Veo | API | $0.03/sec (720p video-only); Veo 3.1 Lite row |
| `gemini-embedding-001` | Google – Embedding | API | $0.00015/1K tokens (Gemini Embedding row) |
| `gemini-embedding-2-preview-05-20` | Google – Embedding | API | "Gemini Embedding 2 Preview"; $0.2/1M tokens text + per-image/video/audio pricing |
| `text-embedding-005` | Google – Embedding | API | $0.000025/1K chars (Text Embedding row) |
| `text-embedding-large-exp-03-07` | Google – Embedding | API | Shares pricing with text-embedding-005; experimental large variant |
| `text-multilingual-embedding-002` | Google – Embedding | API | $0.000025/1K chars (Text Multilingual Embedding row) |
| `textembedding-gecko@003` | Google – Embedding | API | Legacy; $0.000025/1K chars |
| `textembedding-gecko-multilingual@001` | Google – Embedding | API | Legacy; $0.000025/1K chars |
| `multimodalembedding@001` | Google – Embedding | API | $0.0002/1K chars + per-image/video additional pricing |
| `claude-opus-4-6` | Anthropic – Claude | API | @default stripped; "Claude Opus 4.6" row |
| `claude-sonnet-4-6` | Anthropic – Claude | API | @default stripped; "Claude Sonnet 4.6" row |
| `claude-opus-4-5@20251101` | Anthropic – Claude | API | Pinned version; "Claude Opus 4.5" row |
| `claude-haiku-4-5@20251001` | Anthropic – Claude | API | Pinned version; "Claude Haiku 4.5" row |
| `claude-sonnet-4-5@20250929` | Anthropic – Claude | API | Pinned version; "Claude Sonnet 4.5" row |
| `claude-opus-4-1@20250805` | Anthropic – Claude | API | Pinned version; "Claude Opus 4.1" row |
| `claude-sonnet-4@20250514` | Anthropic – Claude | API | Pinned version; "Claude Sonnet 4" row |
| `claude-opus-4@20250514` | Anthropic – Claude | API | Pinned version; "Claude Opus 4" row |
| `gpt-oss-120b-maas` | OpenAI | API | "gpt-oss-120b" row; $0.09/$0.36 |
| `gpt-oss` | OpenAI | Excluded | self-deploy (has_deploy: true, no -maas) |
| `clip-vit-base-patch32` | OpenAI | Excluded | Non-generative (CLIP embedding) |
| `openclip` | OpenAI | Excluded | Non-generative (CLIP embedding) |
| `whisper-large` | OpenAI | Excluded | Audio transcription (not generative inference) |
| `gpt-oss-20b` | OpenAI | Pricing page only | On pricing page but NOT in get_vertex_models |
| `llama-3.3-70b-instruct-maas` | Meta – Llama | API | "Llama 3.3 70B" row; $0.72/$0.72 |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama | API | "Llama 4 Maverick" row; $0.35/$1.15 |
| `faster-r-cnn` | Meta | Excluded | Non-generative CV (object detection) |
| `retinanet` | Meta | Excluded | Non-generative CV (object detection) |
| `mask-r-cnn` | Meta | Excluded | Non-generative CV (segmentation) |
| `segment-anything` | Meta | Excluded | Non-generative CV (segmentation) |
| `xlm-roberta-large` | Meta | Excluded | Non-generative NLP (classification) |
| `roberta-large` | Meta | Excluded | Non-generative NLP (classification) |
| `codellama-7b-hf` | Meta | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `llama2` | Meta | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `nllb` | Meta | Excluded | Self-deploy translation model |
| `imagebind` | Meta | Excluded | Self-deploy multimodal |
| `llama-2-quantized` | Meta | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `llama3` | Meta | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `llama-guard` | Meta | Excluded | Guard model (*guard* pattern) |
| `llama4` | Meta | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `llama3_1` | Meta | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `prompt-guard` | Meta | Excluded | Guard model (*guard* pattern) |
| `llama3-2` | Meta | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `llama3-3` | Meta | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `sam3` | Meta | Excluded | Non-generative CV (Segment Anything Model 3) |
| `llama-4-scout-17b-16e-instruct-maas` | Meta – Llama | Pricing page only | "Llama 4 Scout" on pricing page; not in get_vertex_models |
| `llama-3.1-405b-instruct-maas` | Meta – Llama | Pricing page only | "Llama 3.1 405B" on pricing page; not in get_vertex_models |
| `mistral-small-2503` | Mistral AI | API | "Mistral Small 3.1 (25.03)" row; $0.10/$0.30 |
| `mistral-medium-3` | Mistral AI | API | "Mistral Medium 3" row; $0.40/$2.00 |
| `codestral-2` | Mistral AI | API | "Codestral 2" row; $0.30/$0.90 |
| `mistral` | Mistral AI | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `mixtral` | Mistral AI | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `codestral-2501-self-deploy` | Mistral AI | Excluded | Self-deploy (name contains "self-deploy") |
| `mistral-ocr-2505` | Mistral AI | Excluded | OCR model (excluded per OCR rule) |
| `ministral-3` | Mistral AI | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `mistral-large-3` | Mistral AI | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `deepseek-r1-0528-maas` | DeepSeek | API | "DeepSeek-R1 (0528)" row; $1.35/$5.40 |
| `deepseek-v3.1-maas` | DeepSeek | API | "DeepSeek-V3.1" row; $0.60/$1.70 |
| `deepseek-v3.2-maas` | DeepSeek | API | "DeepSeek-V3.2" row; $0.56/$1.68 |
| `deepseek-r1` | DeepSeek | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `deepseek-v3` | DeepSeek | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `deepseek-ocr-2` | DeepSeek | Excluded | Self-deploy + OCR model |
| `deepseek-v3-1` | DeepSeek | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `deepseek-v3-2` | DeepSeek | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `deepseek-ocr` | DeepSeek | Excluded | Self-deploy + OCR model |
| `deepseek-ocr-maas` | DeepSeek | Excluded | OCR model (excluded per OCR rule even with -maas suffix) |
| `qwen3-235b-a22b-instruct-2507-maas` | Qwen | API | "Qwen3-235B-A22B-Instruct-2507" row; $0.22/$0.88 |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen | API | "Qwen3-Coder-480B-A35B-Instruct" row; $0.22/$1.80 |
| `qwen3-next-80b-a3b-instruct-maas` | Qwen | API | "Qwen3-Next-80B-Instruct" row; $0.15/$1.20 |
| `qwen3-next-80b-a3b-thinking-maas` | Qwen | API | "Qwen3-Next-80B-Thinking" row; $0.15/$1.20 |
| `qwq` | Qwen | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `qwen3` | Qwen | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `qwen3-embedding` | Qwen | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `qwen3-5` | Qwen | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `qwen2` | Qwen | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `qwen3-coder-next` | Qwen | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `qwen3-coder` | Qwen | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `qwen-image` | Qwen | Excluded | Policy exclusion (qwen-image excluded from Vertex AI pricing) |
| `qwen3-next` | Qwen | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `qwen3-vl` | Qwen | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `kimi-k2-thinking-maas` | Moonshot / Kimi | API | "Kimi-K2-Thinking" row; $0.60/$2.50 |
| `kimi-k2-5` | Moonshot / Kimi | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `kimi-k2` | Moonshot / Kimi | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `minimax-m2-maas` | MiniMax | API | "MiniMax-M2" row; $0.30/$1.20 |
| `minimax-m2` | MiniMax | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `glm-4.7-maas` | ZAI.org / GLM | API | "GLM-4.7" row; $0.60/$2.20 |
| `glm-5-maas` | ZAI.org / GLM | API | "GLM-5" row; $1.00/$3.20 |
| `glm-4.7` | ZAI.org / GLM | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `glm-5` | ZAI.org / GLM | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `glm-ocr` | ZAI.org / GLM | Excluded | Self-deploy + OCR model |
| `glm-4.5` | ZAI.org / GLM | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `glm-image` | ZAI.org / GLM | Excluded | Policy exclusion (glm-image excluded from Vertex AI pricing) |
| `jamba-large-1.6` | AI21 | Excluded | Self-deploy (has_deploy: true, no -maas) |
| `Grok 4.20 Non-Reasoning` | xAI / Grok | Pricing page only | On pricing page but NOT in get_vertex_models |
| `Grok 4.1 Fast Reasoning` | xAI / Grok | Pricing page only | On pricing page but NOT in get_vertex_models |
| `Grok 4.1 Fast Non-Reasoning` | xAI / Grok | Pricing page only | On pricing page but NOT in get_vertex_models |

## Excluded model categories (global rules)
- **Self-deploy (non-maas)**: Models with `has_deploy: true` and no `-maas` suffix — customer-managed infrastructure, not priced on Vertex AI generative AI pricing page
- **Guard models**: `llama-guard`, `prompt-guard` — safety classifiers, not generative
- **OCR models**: `mistral-ocr-2505`, `deepseek-ocr`, `deepseek-ocr-2`, `deepseek-ocr-maas`, `glm-ocr` — excluded per OCR rule across all publishers
- **Non-generative CV/NLP**: `faster-r-cnn`, `retinanet`, `mask-r-cnn`, `segment-anything`, `sam3`, `xlm-roberta-large`, `roberta-large` — object detection, segmentation, classification
- **Audio transcription**: `whisper-large` — not generative inference
- **Non-generative embedding**: `clip-vit-base-patch32`, `openclip` — CLIP models, not generative
- **Policy exclusions**: `glm-image`, `qwen-image` — image generation excluded from Vertex AI pricing per policy
- **Lyria / Live / Model-Optimizer**: Excluded per global rules (music generation, streaming, meta-endpoint)

## Web search pricing notes
- **Gemini 2.5 and 2.0**: Grounding with Google Search = $35/1,000 → 3.5 cents/search; Web Grounding for Enterprise = $45/1,000 → 4.5 cents/search
- **Gemini 3**: Combined "Grounding with Google Web Search and Image Search, & Web Grounding for Enterprise" = $14/1,000 → 1.4 cents/search for all search keys

## Veo pricing notes
- All Veo models use 720p video-only as the base `video_seconds` price (lowest tier)
- Veo 2: $0.50/sec (single tier); Veo 3/3.1: $0.20/sec; Veo 3/3.1 Fast: $0.08/sec; Veo 3.1 Lite: $0.03/sec

## Cache pricing notes
- Anthropic Claude: cache_write uses **5-minute** price where both 5m and 1h options are listed
- DeepSeek / Qwen / Kimi / MiniMax / ZAI: cache_read only (where listed on pricing page)

---
*Generated by Pricing Agent on 2026-04-14*