### PR TITLE
chore(pricing): Update fireworks-ai pricing

### DIFF
--- a/general/fireworks-ai.json
+++ b/general/fireworks-ai.json
@@ -668,5 +668,96 @@
     "name": "qwen3-coder-480b-a35b-instruct",
     "params": [{ "key": "max_tokens", "maxValue": 32768 }],
     "type": { "primary": "chat", "supported": ["tools"] }
+  },
+  "deepseek-v3p1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3p2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4p7": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-5p1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-oss-120b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-oss-20b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-8b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3p6-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "flux-1-dev-fp8": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "flux-1-schnell-fp8": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "flux-kontext-pro": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "flux-kontext-max": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "qwen3-embedding-8b": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
   }
 }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -56,6 +56,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -112,10 +123,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -124,10 +135,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -136,10 +147,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -212,6 +223,17 @@
         },
         "response_token": {
           "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00016
         }
       }
     }
@@ -224,6 +246,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000015
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -236,6 +269,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -248,6 +292,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -284,6 +339,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -308,6 +374,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -320,6 +397,330 @@
         },
         "response_token": {
           "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "deepseek-v3p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "deepseek-v3p2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "glm-4p7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "glm-5p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.000026
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00007
+        },
+        "response_token": {
+          "price": 0.00022
+        }
+      }
+    }
+  },
+  "gpt-oss-120b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.0000035
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00005
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000025
+        }
+      }
+    }
+  },
+  "flux-1-dev-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.05
+          }
+        }
+      }
+    }
+  },
+  "flux-1-schnell-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.035
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 8
+            }
+          }
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: fireworks-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 16 |
| 🔄 Models updated (merged) | 8 |

### ➕ New Models
- `deepseek-v3p1`
- `deepseek-v3p2`
- `glm-4p7`
- `glm-5p1`
- `gpt-oss-120b`
- `gpt-oss-20b`
- `qwen3-vl-30b-a3b-instruct`
- `qwen3-vl-30b-a3b-thinking`
- `llama-v3p3-70b-instruct`
- `qwen3-8b`
- `qwen3p6-plus`
- `flux-1-dev-fp8`
- `flux-1-schnell-fp8`
- `flux-kontext-pro`
- `flux-kontext-max`
- `qwen3-embedding-8b`

### 🔄 Updated Models
- `glm-5`
- `kimi-k2-instruct-0905`
- `kimi-k2-thinking`
- `kimi-k2p5`
- `minimax-m2p1`
- `minimax-m2p5`
- `minimax-m2p7`
- `mixtral-8x22b-instruct`


## Model → Pricing Category Mapping

### Named Families (exact page values)
| Model ID | Input | Cache Read | Output | Notes |
|---|---|---|---|---|
| deepseek-v3p1, deepseek-v3p2 | $0.56 | $0.28 (50%) | $1.68 | DeepSeek V3 family |
| glm-4p7 | $0.60 | $0.30 (50%) | $2.20 | GLM-4.7 |
| glm-5 | $1.00 | $0.20 (explicit) | $3.20 | GLM-5 |
| glm-5p1 | $1.40 | $0.26 (explicit) | $4.40 | GLM-5.1 |
| gpt-oss-120b | $0.15 | $0.075 (50%) | $0.60 | OpenAI GPT-OSS-120B |
| gpt-oss-20b | $0.07 | $0.035 (50%) | $0.30 | OpenAI GPT-OSS-20B |
| kimi-k2-instruct-0905, kimi-k2-thinking | $0.60 | $0.30 (50%) | $2.50 | Kimi K2 |
| kimi-k2p5 | $0.60 | $0.10 (explicit) | $3.00 | Kimi K2.5 |
| qwen3-vl-30b-a3b-instruct, qwen3-vl-30b-a3b-thinking | $0.15 | $0.075 (50%) | $0.60 | Qwen3 VL 30B A3B |
| minimax-m2p1 | $0.30 | $0.15 (50%) | $1.20 | MiniMax M2.1 (tier-based) |
| minimax-m2p5 | $0.30 | $0.03 (explicit) | $1.20 | MiniMax 2.5 |
| minimax-m2p7 | $0.30 | $0.06 (explicit) | $1.20 | MiniMax 2.7 |

### Tier-Based Text/Vision
| Model ID | Tier | Input/Output |
|---|---|---|
| llama-v3p3-70b-instruct | >16B | $0.90 |
| mixtral-8x22b-instruct | MoE 56.1–176B | $1.20 |
| qwen3-8b | 4B–16B | $0.20 |
| qwen3p6-plus | MoE 0–56B (est.) | $0.50 |

### Image Models
| Model ID | Pricing |
|---|---|
| flux-1-dev-fp8 | $0.0005/step |
| flux-1-schnell-fp8 | $0.00035/step |
| flux-kontext-pro | $0.04/image |
| flux-kontext-max | $0.08/image |

### Embedding
| Model ID | Input |
|---|---|
| qwen3-embedding-8b | $0.10/1M tokens |

### Skipped
- qwen3-reranker-8b (reranker, excluded per skill rules)

**Cache rule:** 50% of input price (read only, no write charge), unless named-family row specifies explicitly.
**Batch rule:** 50% of serverless input AND output.

---
*Generated by Pricing Agent on 2026-04-14*