### PR TITLE
chore(pricing): Update cohere pricing

### DIFF
--- a/general/cohere.json
+++ b/general/cohere.json
@@ -194,5 +194,70 @@
     "type": {
       "primary": "chat"
     }
+  },
+  "command-r7b-arabic-02-2025": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "command-r-plus-04-2024": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "command-r-03-2024": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-earth": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-fire": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-global": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-water": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "cohere-transcribe-03-2026": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "embed-english-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
   }
 }

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -263,5 +263,293 @@
         }
       }
     }
+  },
+  "command-a-03-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-reasoning-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-translate-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-vision-07-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-plus-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "command-r7b-12-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00000375
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r7b-arabic-02-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00000375
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-expanse-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-vision-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-earth": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-fire": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-global": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-water": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "cohere-transcribe-03-2026": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-v4.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## 🔄 Pricing Update: cohere

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 24 |
| 🔄 Models updated (merged) | 0 |

### ➕ New Models
- `command-a-03-2025`
- `command-a-reasoning-08-2025`
- `command-a-translate-08-2025`
- `command-a-vision-07-2025`
- `command-r-plus-08-2024`
- `command-r-08-2024`
- `command-r7b-12-2024`
- `command-r7b-arabic-02-2025`
- `command-r-plus-04-2024`
- `command-r-03-2024`
- `c4ai-aya-expanse-32b`
- `c4ai-aya-vision-32b`
- `tiny-aya-earth`
- `tiny-aya-fire`
- `tiny-aya-global`
- `tiny-aya-water`
- `cohere-transcribe-03-2026`
- `embed-v4.0`
- `embed-english-v3.0-image`
- `embed-multilingual-v3.0-image`
- ... and 4 more



## Model-to-Pricing Mapping

### Generative Models ($2.50/$10.00 per 1M tokens — Command A tier)
- `command-a-03-2025` → Command A
- `command-a-reasoning-08-2025` → Command A (assumed same tier)
- `command-a-translate-08-2025` → Command A (assumed same tier)
- `command-a-vision-07-2025` → Command A (assumed same tier)
- `command-r-plus-08-2024` → Command R+ 08-2024

### Generative Models ($0.15/$0.60 per 1M tokens — Command R tier)
- `command-r-08-2024` → Command R 08-2024

### Generative Models ($0.0375/$0.15 per 1M tokens — Command R7B tier)
- `command-r7b-12-2024` → Command R7B 12-2024
- `command-r7b-arabic-02-2025` → Command R7B (assumed same tier)

### Legacy Models
- `command-r-plus-04-2024` → $3.00/$15.00 (from FAQ)
- `command-r-03-2024` → $0.50/$1.50 (from FAQ)

### Aya / Tiny-Aya Models ($0.50/$1.50 per 1M tokens)
- `c4ai-aya-expanse-32b`, `c4ai-aya-vision-32b` → Aya Expanse pricing
- `tiny-aya-earth`, `tiny-aya-fire`, `tiny-aya-global`, `tiny-aya-water` → Aya pricing (not on public page, assumed same family)

### Transcription
- `cohere-transcribe-03-2026` → No public pricing found; set to $0

### Embed Models
- `embed-v4.0` → $0.12/1M tokens (text), image variants at same rate
- `embed-*-v3.0` and light variants → $0.10/1M tokens

### Rerank Models (per-search pricing)
- `rerank-v3.5`, `rerank-english-v3.0`, `rerank-multilingual-v3.0`, `rerank-v4.0-fast` → $2.00/1K searches ($0.002/search)
- `rerank-v4.0-pro` → $2.50/1K searches ($0.0025/search)

## Notes
- Firecrawl was unavailable (insufficient credits); raw HTML was fetched via `http_request` tool and pricing was extracted from the embedded Next.js RSC JSON payload in cohere.com/pricing
- Command R7B price on page shows $0.0375 (not $0.037 as in reference table)
- `tiny-aya-*` models and `c4ai-aya-vision-32b` have no explicit public pricing; assigned Aya Expanse pricing as closest family match
- `cohere-transcribe-03-2026` has no public token pricing; set to $0 pending future update

---
*Generated by Pricing Agent on 2026-04-14*