### PR TITLE
chore(pricing): Update dashscope pricing

### DIFF
--- a/general/dashscope.json
+++ b/general/dashscope.json
@@ -632,5 +632,1048 @@
   "qwen-mt-lite": {
     "params": [{ "key": "max_tokens", "maxValue": 8192 }],
     "type": { "primary": "chat" }
+  },
+  "qwen-plus-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen-plus-2025-12-01-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen-flash-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen-flash-2025-07-28-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen3.5-omni-plus-2026-03-15": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen3.5-omni-flash-2026-03-15": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen3-vl-flash-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen3-vl-flash-2026-01-22-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen3-vl-flash-2025-10-15-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen-vl-ocr-2025-08-28": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen-doc-turbo": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen-deep-research": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-27b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-235b-a22b-thinking": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-32b-thinking": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-30b-a3b-thinking": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-14b-thinking": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-8b-thinking": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-4b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-4b-thinking": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-1.7b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-0.6b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-3b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-1.5b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-0.5b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-1m-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qvq-72b-preview": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2-vl-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2-vl-2b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-math-72b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-math-1.5b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-coder-32b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-coder-14b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-coder-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-coder-3b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-coder-1.5b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-v3": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3-0324": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-0528": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshot-v1-8k": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshot-v1-32k": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshot-v1-128k": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "text-embedding-v4": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "text-embedding-v3": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "qwen3-rerank": {
+    "type": {
+      "primary": "embedding"
+    },
+    "disablePlayground": true
+  },
+  "gte-rerank-v2": {
+    "type": {
+      "primary": "embedding"
+    },
+    "disablePlayground": true
+  },
+  "tongyi-intent-detect-v3": {
+    "type": {
+      "primary": "moderation"
+    },
+    "disablePlayground": true
+  },
+  "tongyi-embedding-vision-plus": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "qwen3-vl-embedding": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "qwen-tts-flash": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-latest": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-2025-05-22": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-2025-04-10": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-realtime-latest": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-realtime-2025-07-15": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-instruct-flash-2026-01-26": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-flash": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-flash-2025-11-27": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-flash-2025-09-18": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "cosyvoice-v3-flash": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "cosyvoice-v3.5-plus": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "cosyvoice-v3.5-flash": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "cosyvoice-v2": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "qwen3-asr-flash-filetrans": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-filetrans-2025-11-17": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-2025-09-08": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-us": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-2025-09-08-us": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-2025-11-07": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-2025-08-25": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-mtl": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-realtime-2025-11-07": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-flash-8k-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "paraformer-v2": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "paraformer-8k-v2": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "paraformer-realtime-v2": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-2.0-pro-2026-03-03": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-2.0": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-2.0-2026-03-03": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-max": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-max-2025-12-30": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-plus": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-plus-2026-01-09": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-edit-max": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-edit-max-2026-01-16": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-edit-plus": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-edit": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "z-image-turbo": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-t2i": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.5-t2i-preview": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-t2i-plus": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-t2i-flash": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-t2i-plus": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-t2i-turbo": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-image": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.5-i2i-preview": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-t2v": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-t2v-us": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.5-t2v-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-t2v-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-t2v-turbo": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-t2v-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-i2v": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-i2v-flash": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-i2v-us": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.5-i2v-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-i2v-flash": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-i2v-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-kf2v-flash": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-kf2v-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-r2v": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan.6-r2v-flash": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-vace-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-s2v": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-s2v-detect": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-animate-move": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-animate-mix": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "liveportrait": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "videoretalk": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "video-style-transform": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "animate-anyone-gen2": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "emo-v1": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "emoji-v1": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-voice-enrollment": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "qwen-voice-design": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "qwen3-tts-vd-realtime-2026-01-26": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-vc-realtime-2026-01-22": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
   }
 }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -125,10 +125,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000246
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.000737
+          "price": 0.00024
         }
       }
     }
@@ -137,10 +137,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000016
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.000049
+          "price": 0.00012
         }
       }
     }
@@ -167,10 +167,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.000444
@@ -458,10 +458,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000035
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00014
+          "price": 0.000028
         },
         "reasoning_token": {
           "price": 0.00042
@@ -473,10 +473,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.00024
         },
         "reasoning_token": {
           "price": 0.00084
@@ -488,10 +488,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.00006
         },
         "reasoning_token": {
           "price": 0.00084
@@ -503,10 +503,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000018
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00007
+          "price": 0.000028
         },
         "reasoning_token": {
           "price": 0.00021
@@ -518,10 +518,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.028
         },
         "response_token": {
-          "price": 0.0000035
+          "price": 0
         }
       }
     }
@@ -530,10 +530,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000045
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.000225
+          "price": 0.00015
         }
       }
     }
@@ -542,10 +542,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00015
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.0005
         }
       }
     }
@@ -602,10 +602,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0005
         },
         "request_audio_token": {
           "price": 0.001
@@ -692,10 +692,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000052
+          "price": 0.000043
         },
         "response_token": {
-          "price": 0.000199
+          "price": 0.000166
         },
         "request_audio_token": {
           "price": 0.000457
@@ -721,7 +721,6 @@
       }
     }
   },
-
   "qwen3-vl-30b-a3b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -792,10 +791,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000573
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.000258
+          "price": 0.00024
         }
       }
     }
@@ -804,10 +803,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000304
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0001213
+          "price": 0.00016
         }
       }
     }
@@ -840,10 +839,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.000058
+          "price": 0.0000861
         }
       }
     }
@@ -852,10 +851,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.0000861
         }
       }
     }
@@ -864,10 +863,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 0.000023
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0000574
         }
       }
     }
@@ -876,10 +875,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 0.000023
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0000574
         }
       }
     }
@@ -948,10 +947,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0005
         }
       }
     }
@@ -960,10 +959,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.00006
         },
         "reasoning_token": {
           "price": 0.00084
@@ -1023,10 +1022,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000861
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.0003441
+          "price": 0.0006
         }
       }
     }
@@ -1320,10 +1319,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000043
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000072
+          "price": 0.000016
         }
       }
     }
@@ -1332,10 +1331,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.0004
+          "price": 0.00024
         }
       }
     }
@@ -1344,10 +1343,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.00016
+          "price": 0.00024
         }
       }
     }
@@ -1356,10 +1355,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000016
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.000064
+          "price": 0.00006
         }
       }
     }
@@ -1368,10 +1367,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000016
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.000064
+          "price": 0.00006
         }
       }
     }
@@ -1380,10 +1379,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.00006
         }
       }
     }
@@ -1392,10 +1391,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00008
+          "price": 0.00006
         }
       }
     }
@@ -1404,10 +1403,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000018
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00021
+          "price": 0.000028
         }
       }
     }
@@ -1416,10 +1415,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000018
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00007
+          "price": 0.000028
         }
       }
     }
@@ -1452,10 +1451,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002294
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0006881
+          "price": 0.00012
         }
       }
     }
@@ -1500,10 +1499,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000058
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000023
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.0003584
@@ -1518,10 +1517,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.000444
@@ -1536,10 +1535,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.000444
@@ -1857,10 +1856,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000016
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.000049
+          "price": 0.00006
         }
       }
     }
@@ -1869,10 +1868,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000036
+          "price": 0.00002
         }
       }
     }
@@ -1881,10 +1880,1906 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000574
+          "price": 0.000055
         },
         "response_token": {
-          "price": 0.0002294
+          "price": 0.000219
+        }
+      }
+    }
+  },
+  "qwen-plus-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen-plus-2025-12-01-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen-flash-2025-07-28-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2026-01-22-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2025-10-15-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-vl-ocr-2025-08-28": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000016
+        }
+      }
+    }
+  },
+  "qwen-doc-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000087
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "qwen-deep-research": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0007742
+        },
+        "response_token": {
+          "price": 0.0023367
+        }
+      }
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00016
+        }
+      }
+    }
+  },
+  "qwen3.5-27b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3-32b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3-14b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen3-8b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen3-4b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "qwen3-4b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "qwen3-1.7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "qwen3-0.6b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen2.5-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "qwen2.5-1.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "qwen2.5-0.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "qwen2.5-1m-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qvq-72b-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001721
+        },
+        "response_token": {
+          "price": 0.0005161
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "qwen2-vl-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen2-vl-2b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen2.5-math-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen2.5-math-1.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-1.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
+  "deepseek-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000027
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "deepseek-v3-0324": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000027
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "deepseek-r1-0528": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000055
+        },
+        "response_token": {
+          "price": 0.000219
+        }
+      }
+    }
+  },
+  "moonshot-v1-8k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0003
+        }
+      }
+    }
+  },
+  "moonshot-v1-32k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "moonshot-v1-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
+  "text-embedding-v4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-rerank": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gte-rerank-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000058
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-vl-embedding": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen-tts-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen-tts-2025-05-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen-tts-2025-04-10": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime-2025-07-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-09-18": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3.5-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3.5-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.028
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans-2025-11-17": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.028
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.028
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.028
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.028
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.028
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0144
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0144
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-2025-08-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0144
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-mtl": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0144
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0144
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-realtime-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0144
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-flash-8k-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0144
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0144
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0144
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-realtime-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0144
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0144
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-2.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-max-2025-12-30": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-plus-2026-01-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max-2026-01-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "z-image-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-t2i": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-t2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-i2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-t2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-t2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-i2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-kf2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-kf2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-r2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan.6-r2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-vace-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-s2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-s2v-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-animate-move": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-animate-mix": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "liveportrait": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "videoretalk": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "video-style-transform": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "animate-anyone-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "emo-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 14
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "emoji-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-voice-enrollment": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-voice-design": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 20
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-realtime-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: dashscope

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 158 |
| 🔄 Models updated (merged) | 37 |

### ➕ New Models
- `qwen-plus-us`
- `qwen-plus-2025-12-01-us`
- `qwen-flash-us`
- `qwen-flash-2025-07-28-us`
- `qwen3.5-omni-plus`
- `qwen3.5-omni-plus-2026-03-15`
- `qwen3.5-omni-flash`
- `qwen3.5-omni-flash-2026-03-15`
- `qwen3-vl-flash-us`
- `qwen3-vl-flash-2026-01-22-us`
- `qwen3-vl-flash-2025-10-15-us`
- `qwen-vl-ocr-2025-08-28`
- `qwen-doc-turbo`
- `qwen-deep-research`
- `qwen3.5-397b-a17b`
- `qwen3.5-122b-a10b`
- `qwen3.5-27b`
- `qwen3.5-35b-a3b`
- `qwen3-235b-a22b-thinking`
- `qwen3-235b-a22b-instruct-2507`
- ... and 138 more

### 🔄 Updated Models
- `qwen3-max-2025-09-23`
- `qwq-plus-latest`
- `qwq-plus-2025-03-05`
- `qwen-omni-turbo-2025-01-19`
- `qwen-vl-ocr-latest`
- `qwen3-coder-next`
- `qwen-mt-plus`
- `qwen-mt-flash`
- `qwen-mt-lite`
- `qwen-mt-turbo`
- `qwen3-235b-a22b`
- `qwen3-32b`
- `qwen3-30b-a3b`
- `qwen3-14b`
- `qwen3-8b`
- `qwq-32b`
- `qwq-32b-preview`
- `qwen3-vl-235b-a22b-thinking`
- `qwen3-vl-235b-a22b-instruct`
- `qwen3-vl-32b-thinking`
- `qwen3-vl-32b-instruct`
- `qwen3-vl-30b-a3b-thinking`
- `qwen3-vl-30b-a3b-instruct`
- `qwen3-vl-8b-thinking`
- `qwen3-vl-8b-instruct`
- `qwen2-vl-72b-instruct`
- `qwen3-coder-480b-a35b-instruct`
- `qwen3-coder-30b-a3b-instruct`
- `deepseek-r1`
- `glm-5`
- ... and 7 more


## Model-to-Pricing-Page Mapping

### Source 1: `/models` (commercial Qwen + tiered pricing)
- **qwen3-max / qwen3.5-plus / qwen3.5-flash** — International
- **qwen-max / qwen-plus / qwen-flash / qwen-turbo** — International (with US-region variants)
- **qwq-plus** — International ($0.8/$2.4); snapshots Chinese Mainland only
- **qwen-long** — Chinese Mainland only
- **qwen3-coder-plus/flash** — International (tiered; lowest tier used)
- **qwen3-vl-plus/flash** — International (tiered; lowest tier used)
- **qvq-max** — International; **qvq-plus** — Chinese Mainland only
- **qwen3-omni-flash / qwen-omni-turbo** — International
- **qwen3.5-omni-plus/flash** — Free preview ($0)

### Source 2: `/model-pricing` (open-source, speech, video, image, third-party)
- **Open-source Qwen3.5 / Qwen3 / Qwen2.5 / Qwen2** — International/Global
- **qwq-32b / qvq-72b-preview** — Chinese Mainland
- **Qwen3-VL / Qwen2.5-VL / Qwen2-VL open-source** — International/Global
- **Qwen2.5-Math / Qwen2.5-Coder open-source** — International/Global
- **qwen-math-plus/turbo** — Chinese Mainland only
- **qwen-coder-plus/turbo** — Chinese Mainland only
- **qwen-mt-plus/flash/lite/turbo** — International
- **qwen-doc-turbo** — Chinese Mainland only
- **qwen-deep-research** — Chinese Mainland only; EXCEPTION: per_thousand_tokens
- **DeepSeek (v3, r1)** — International/Global
- **Kimi/Moonshot** — International/Global
- **GLM-5 / MiniMax-M2.5** — International/Global
- **Image gen (qwen-image, wan t2i/i2i)** — per_image
- **Video gen (wan t2v/i2v/kf2v/r2v/vace/s2v/animate/emo/emoji/liveportrait/videoretalk)** — per_second
- **TTS qwen3-tts-* / cosyvoice** — per_million_characters (10K char billing)
- **TTS qwen-tts-* / qwen-tts-realtime** — per_million_tokens
- **ASR qwen3-asr / fun-asr / paraformer** — per_second
- **LiveTranslate** — per_million_tokens (multimodal)
- **Embeddings: text-embedding-v3/v4, tongyi-embedding-vision** — per_million_tokens (input only)
- **Rerank: qwen3-rerank, gte-rerank-v2** — per_million_tokens (input only)
- **Domain: tongyi-intent-detect-v3, qwen-*-character** — per_million_tokens
- **Voice: qwen-voice-enrollment ($0.01/voice), qwen-voice-design ($0.2/voice)** — per_request

---
*Generated by Pricing Agent on 2026-04-14*