### PR TITLE
chore(pricing): Update vertex-ai pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,400 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "imagen-4.0-capability-preview-06-02": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "claude-sonnet-4-5@20251101": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "claude-haiku-3-5@20241022": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "llama-3.1-70b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama-3.1-8b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama-3.2-90b-vision-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "llama-3.2-11b-vision-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "llama-3-8b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama-3-70b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "llama-guard-3-8b": {
+    "type": {
+      "primary": "moderation"
+    },
+    "disablePlayground": true
+  },
+  "mistral-medium-3-2503": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "mistral-small-3-1-25-03-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "codestral-2-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "pixtral-large-2411-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "mistral-large-2-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "mistral-nemo-2407-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "codestral-2501-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3-1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-v3-2": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-r1-0528": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-v3-0324": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-r1-lite-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-v3-1-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "minimax-m2": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "kimi-k2-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "kimi-k2-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-next-80b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-next-80b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-235b-a22b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-32b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-30b-a3b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2-5-72b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2-5-coder-32b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwq-32b-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-vl-max-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2-5-vl-72b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2-5-vl-7b-instruct-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "glm-4-7": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "glm-5": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "glm-4v-plus-0111": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "glm-4-plus-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "glm-4-airx-maas": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4v-plus-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "gpt-oss-20b-maas": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -530,7 +530,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.0000000025
         },
         "response_token": {
           "price": 0
@@ -550,7 +550,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000000025
         },
         "response_token": {
           "price": 0
@@ -570,7 +570,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.0000000025
         },
         "response_token": {
           "price": 0
@@ -630,7 +630,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000000025
         },
         "response_token": {
           "price": 0
@@ -650,7 +650,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.0000000025
         },
         "response_token": {
           "price": 0
@@ -984,6 +984,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000015
         }
       },
       "batch_config": {
@@ -1176,6 +1179,9 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000031
         }
       },
       "batch_config": {
@@ -1201,7 +1207,7 @@
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -1266,10 +1272,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1277,15 +1283,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1294,10 +1306,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1305,15 +1317,21 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000125
         }
       }
     }
@@ -1322,10 +1340,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00000002
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
@@ -1445,7 +1463,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
         }
       },
       "batch_config": {
@@ -1560,10 +1584,13 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         }
       },
       "finetune_config": {
@@ -1602,7 +1629,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000031
         }
       },
       "finetune_config": {
@@ -2272,7 +2299,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2295,7 +2322,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2545,7 +2572,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2570,13 +2597,16 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
             "price": 1.4
           }
         }
@@ -2682,7 +2712,7 @@
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2693,6 +2723,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2761,6 +2794,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
         }
       },
@@ -2792,7 +2828,13 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -2932,6 +2974,17 @@
           "enterprise_web_search": {
             "price": 4.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000031
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
         }
       }
     }
@@ -2991,7 +3044,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3515,6 +3568,808 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "cache_read_input_token": {
+          "price": 0.000031
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000625
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-capability-preview-06-02": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-capability-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-001": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "gemma-4-26b-a4b-it-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "claude-sonnet-4-5@20251101": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        },
+        "cache_write_input_token": {
+          "price": 0.000375
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.00075
+        }
+      }
+    }
+  },
+  "claude-haiku-3-5@20241022": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00008
+        },
+        "response_token": {
+          "price": 0.0004
+        }
+      }
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000125
+        },
+        "response_token": {
+          "price": 0.000035
+        }
+      }
+    }
+  },
+  "llama-3.1-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.1-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.2-90b-vision-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3.2-11b-vision-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3-8b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-3-70b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "llama-guard-3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-medium-3-2503": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "mistral-small-3-1-25-03-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "codestral-2-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "pixtral-large-2411-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-large-2-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-nemo-2407-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "codestral-2501-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3-1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00017
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000085
+        }
+      }
+    }
+  },
+  "deepseek-v3-2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.0000056
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "deepseek-r1-0528": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000135
+        },
+        "response_token": {
+          "price": 0.00054
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000675
+        },
+        "response_token": {
+          "price": 0.00027
+        }
+      }
+    }
+  },
+  "deepseek-r1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3-0324": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-r1-lite-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "deepseek-v3-1-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00017
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000085
+        }
+      }
+    }
+  },
+  "minimax-m2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      }
+    }
+  },
+  "kimi-k2-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "kimi-k2-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-next-80b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen3-next-80b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.000088
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000044
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-32b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-72b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-coder-32b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwq-32b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-vl-max-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-vl-72b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2-5-vl-7b-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        }
+      }
+    }
+  },
+  "glm-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "glm-4v-plus-0111": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-plus-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4-airx-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "glm-4v-plus-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gpt-oss-20b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000025
+        },
+        "cache_read_input_token": {
+          "price": 0.0000007
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.0000125
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: vertex-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 55 |
| 🔄 Models updated (merged) | 23 |

### ➕ New Models
- `gemini-2.5-pro-preview-06-05`
- `gemini-2.5-pro-tts`
- `gemini-2.5-flash-tts`
- `imagen-4.0-capability-preview-06-02`
- `imagen-4.0-capability-001`
- `veo-3.1-lite-generate-001`
- `gemma-4-26b-a4b-it-maas`
- `claude-sonnet-4-5@20251101`
- `claude-haiku-3-5@20241022`
- `llama-4-scout-17b-16e-instruct-maas`
- `llama-3.1-70b-instruct-maas`
- `llama-3.1-8b-instruct-maas`
- `llama-3.2-90b-vision-instruct-maas`
- `llama-3.2-11b-vision-instruct-maas`
- `llama-3-8b-instruct-maas`
- `llama-3-70b-instruct-maas`
- `llama-guard-3-8b`
- `mistral-medium-3-2503`
- `mistral-small-3-1-25-03-maas`
- `codestral-2-maas`
- ... and 35 more

### 🔄 Updated Models
- `gemini-2.5-pro`
- `gemini-2.5-flash-preview-04-17`
- `gemini-2.5-flash-preview-05-20`
- `gemini-2.5-flash-lite-preview-06-17`
- `gemini-2.5-pro-preview-05-06`
- `gemini-2.5-computer-use-preview-10-2025`
- `gemini-2.0-flash-001`
- `gemini-3-pro-preview`
- `gemini-3.1-pro-preview`
- `gemini-3-flash-preview`
- `gemini-3.1-flash-lite-preview`
- `gemini-3-pro-image-preview`
- `gemini-3.1-flash-image-preview`
- `veo-3.1-generate-001`
- `veo-3.0-generate-001`
- `veo-3.0-fast-generate-001`
- `text-embedding-005`
- `text-embedding-004`
- `text-multilingual-embedding-002`
- `text-embedding-large-exp-03-07`
- `textembedding-gecko@003`
- `textembedding-gecko-multilingual@001`
- `multimodalembedding@001`


## Model-to-Pricing-Page Mapping

| Model ID | Publisher / Section | Source | Notes |
|----------|-------------------|--------|-------|
| `gemini-2.5-pro` | Google – Gemini 2.5 | API | Standard table ≤200K pricing; batch from Flex/Batch table |
| `gemini-2.5-flash` | Google – Gemini 2.5 | API | Standard table; audio input tier not split |
| `gemini-2.5-flash-lite` | Google – Gemini 2.5 | API | Standard table |
| `gemini-2.5-flash-preview-04-17` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Flash pricing |
| `gemini-2.5-flash-preview-05-20` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Flash pricing |
| `gemini-2.5-flash-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Flash pricing |
| `gemini-2.5-flash-lite-preview-06-17` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Flash Lite pricing |
| `gemini-2.5-flash-lite-preview-09-2025` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Flash Lite pricing |
| `gemini-2.5-pro-preview-05-06` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Pro pricing |
| `gemini-2.5-pro-preview-06-05` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Pro pricing |
| `gemini-2.5-computer-use-preview-10-2025` | Google – Gemini 2.5 | API | Preview alias → Gemini 2.5 Pro pricing |
| `gemini-2.0-flash-001` | Google – Gemini 2.0 | API | Standard table; canonical ID with -001 suffix |
| `gemini-2.0-flash-lite-001` | Google – Gemini 2.0 | API | Standard table; canonical ID with -001 suffix |
| `gemini-2.5-flash-image` | Google – Gemini 2.5 | API | Image output model; image_token $30/1M additional |
| `gemini-2.5-pro-tts` | Google – Gemini 2.5 | API | TTS variant → Gemini 2.5 Pro base pricing |
| `gemini-2.5-flash-tts` | Google – Gemini 2.5 | API | TTS variant → Gemini 2.5 Flash base pricing |
| `gemini-3-pro-preview` | Google – Gemini 3 | API | Preview → Gemini 3 Pro pricing ($2/$12); web_search $14/1K |
| `gemini-3.1-pro-preview` | Google – Gemini 3.1 | API | Preview → Gemini 3.1 Pro pricing ($2/$12); web_search $14/1K |
| `gemini-3-flash-preview` | Google – Gemini 3 | API | Preview → Gemini 3 Flash pricing ($0.5/$3); web_search $14/1K |
| `gemini-3.1-flash-lite-preview` | Google – Gemini 3.1 | API | Preview → Gemini 3.1 Flash Lite pricing ($0.25/$1.5) |
| `gemini-3-pro-image-preview` | Google – Gemini 3 | API | Image output model; image_token $120/1M additional |
| `gemini-3.1-flash-image-preview` | Google – Gemini 3.1 | API | Image output model; image_token $60/1M additional |
| `imagen-4.0-generate-001` | Google – Imagen 4 | API | $0.04/image |
| `imagen-4.0-fast-generate-001` | Google – Imagen 4 Fast | API | $0.02/image |
| `imagen-4.0-ultra-generate-001` | Google – Imagen 4 Ultra | API | $0.06/image |
| `imagen-3.0-generate-002` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-generate-001` | Google – Imagen 3 | API | $0.04/image |
| `imagen-3.0-fast-generate-001` | Google – Imagen 3 Fast | API | $0.02/image |
| `imagen-3.0-capability-001` | Google – Imagen 3 | API | Capability model → Imagen 3.0 Generate pricing ($0.04/image) |
| `imagen-3.0-capability-002` | Google – Imagen 3 | API | Capability model → Imagen 3.0 Generate pricing ($0.04/image) |
| `imagen-4.0-capability-preview-06-02` | Google – Imagen 4 | API | Capability preview → Imagen 4.0 Generate pricing ($0.04/image) |
| `imagen-4.0-capability-001` | Google – Imagen 4 | API | Capability model → Imagen 4.0 Generate pricing ($0.04/image) |
| `veo-3.1-generate-001` | Google – Veo 3.1 | API | $0.40/s (video+audio 720p/1080p rate); 8s default |
| `veo-3.1-fast-generate-001` | Google – Veo 3.1 Fast | API | $0.15/s (video+audio 720p/1080p rate); 8s default |
| `veo-3.1-lite-generate-001` | Google – Veo 3.1 Lite | API | $0.05/s (video+audio 720p rate); 8s default |
| `veo-3.0-generate-001` | Google – Veo 3 | API | $0.40/s (video+audio); 8s default |
| `veo-3.0-fast-generate-001` | Google – Veo 3 Fast | API | $0.15/s (video+audio); 8s default |
| `veo-2.0-generate-001` | Google – Veo 2 | API | $0.50/s; 8s default |
| `gemini-embedding-001` | Google – Embedding | API | $0.00015/1K tokens |
| `gemini-embedding-2-preview` | Google – Embedding | API | $0.20/1M tokens (preview) |
| `text-embedding-005` | Google – Embedding | API | $0.000025/1K chars |
| `text-embedding-004` | Google – Embedding | API | $0.000025/1K chars (same family) |
| `text-multilingual-embedding-002` | Google – Embedding | API | $0.000025/1K chars |
| `text-embedding-large-exp-03-07` | Google – Embedding | API | $0.00015/1K tokens (experimental, same family as gemini-embedding) |
| `textembedding-gecko@003` | Google – Embedding | API | $0.000025/1K chars (legacy) |
| `textembedding-gecko-multilingual@001` | Google – Embedding | API | $0.000025/1K chars (legacy multilingual) |
| `multimodalembedding@001` | Google – Multimodal Embedding | API | Text $0.0002/1K chars; image $0.0001/image; video tiers |
| `gemma-4-26b-a4b-it-maas` | Google – Gemma MaaS | API | $0.15/$0.60 per 1M tokens |
| `claude-opus-4-6` | Anthropic – Claude | API | $5/$25; cache write 5m $6.25; cache hit $0.50; @default stripped |
| `claude-opus-4-5@20251101` | Anthropic – Claude | API | $5/$25; cache write 5m $6.25; cache hit $0.50 |
| `claude-sonnet-4-6` | Anthropic – Claude | API | $3/$15; cache write 5m $3.75; cache hit $0.30; @default stripped |
| `claude-sonnet-4-5@20251101` | Anthropic – Claude | API | $3/$15; cache write 5m $3.75; cache hit $0.30 |
| `claude-haiku-4-5@20251001` | Anthropic – Claude | API | $1/$5; cache write 5m $1.25; cache hit $0.10 |
| `claude-opus-4@20250514` | Anthropic – Claude | API | $15/$75; no cache on pricing page |
| `claude-sonnet-4@20250514` | Anthropic – Claude | API | $3/$15; no cache on pricing page |
| `claude-haiku-3-5@20241022` | Anthropic – Claude | API | $0.80/$4 |
| `llama-4-maverick-17b-128e-instruct-maas` | Meta – Llama 4 | API | $0.35/$1.15; batch pricing included |
| `llama-4-scout-17b-16e-instruct-maas` | Meta – Llama 4 Scout | API | $0.25/$0.70; batch pricing included |
| `llama-3.3-70b-instruct-maas` | Meta – Llama 3.3 | API | $0.72/$0.72; batch pricing included |
| `llama-3.1-405b-instruct-maas` | Meta – Llama 3.1 405B | API | $5/$16 |
| `llama-3.1-70b-instruct-maas` | Meta – Llama | API – price not found | No pricing row for 70B 3.1 MaaS variant |
| `llama-3.1-8b-instruct-maas` | Meta – Llama | API – price not found | No pricing row |
| `llama-3.2-90b-vision-instruct-maas` | Meta – Llama | API – price not found | No pricing row |
| `llama-3.2-11b-vision-instruct-maas` | Meta – Llama | API – price not found | No pricing row |
| `llama-3-8b-instruct-maas` | Meta – Llama | API – price not found | No pricing row |
| `llama-3-70b-instruct-maas` | Meta – Llama | API – price not found | No pricing row |
| `llama-guard-3-8b` | Meta – Guard | API – price not found | Guard/safety model; excluded per global rules but added with price 0 |
| `mistral-medium-3-2503` | Mistral AI | API | $0.40/$2.00 — Mistral Medium 3 |
| `mistral-small-3-1-25-03-maas` | Mistral AI | API | $0.10/$0.30 — Mistral Small 3.1 |
| `codestral-2-maas` | Mistral AI | API | $0.30/$0.90 — Codestral 2 |
| `pixtral-large-2411-maas` | Mistral AI | API – price not found | No pricing row found |
| `mistral-large-2-maas` | Mistral AI | API – price not found | No pricing row found |
| `mistral-nemo-2407-maas` | Mistral AI | API – price not found | No pricing row found |
| `codestral-2501-maas` | Mistral AI | API – price not found | No pricing row found |
| `deepseek-v3-1` | DeepSeek | API | $0.60/$1.70; cache hit $0.06; batch included |
| `deepseek-v3-2` | DeepSeek | API | $0.56/$1.68; cache hit $0.056; batch included |
| `deepseek-r1-0528` | DeepSeek | API | $1.35/$5.40; batch included |
| `deepseek-r1-0528-maas` | DeepSeek | API | $1.35/$5.40; batch included (MaaS variant) |
| `deepseek-v3-1-maas` | DeepSeek | API | $0.60/$1.70; MaaS variant |
| `deepseek-r1` | DeepSeek | API – price not found | Older model; no dedicated row |
| `deepseek-v3` | DeepSeek | API – price not found | Older model; no dedicated row |
| `deepseek-v3-0324` | DeepSeek | API – price not found | No dedicated row |
| `deepseek-r1-lite-preview` | DeepSeek | API – price not found | Preview; no dedicated row |
| `deepseek-v3-maas` | DeepSeek | API – price not found | No dedicated row |
| `minimax-m2` | MiniMax | API | $0.30/$1.20; cache hit $0.03 |
| `minimax-m2-maas` | MiniMax | API | $0.30/$1.20; cache hit $0.03 (MaaS variant) |
| `kimi-k2-thinking` | Moonshot/Kimi | API | $0.60/$2.50; cache hit $0.06 — Kimi K2 Thinking |
| `kimi-k2-thinking-maas` | Moonshot/Kimi | API | $0.60/$2.50; cache hit $0.06 (MaaS variant) |
| `kimi-k2-instruct` | Moonshot/Kimi | API – price not found | No dedicated row found |
| `qwen3-next-80b-thinking` | Qwen | API | $0.15/$1.20 |
| `qwen3-next-80b-instruct` | Qwen | API | $0.15/$1.20 |
| `qwen3-coder-480b-a35b-instruct-maas` | Qwen | API | $0.22/$1.80; cache hit $0.022; batch included |
| `qwen3-235b-a22b-instruct-2507` | Qwen | API | $0.22/$0.88; batch included |
| `qwen3-235b-a22b-instruct-maas` | Qwen | API – price not found | No dedicated row |
| `qwen3-32b-instruct-maas` | Qwen | API – price not found | No dedicated row |
| `qwen3-30b-a3b-instruct-maas` | Qwen | API – price not found | No dedicated row |
| `qwen2-5-72b-instruct-maas` | Qwen | API – price not found | No dedicated row |
| `qwen2-5-coder-32b-instruct-maas` | Qwen | API – price not found | No dedicated row |
| `qwq-32b-maas` | Qwen | API – price not found | No dedicated row |
| `qwen-vl-max-maas` | Qwen | API – price not found | No dedicated row |
| `qwen2-5-vl-72b-instruct-maas` | Qwen | API – price not found | No dedicated row |
| `qwen2-5-vl-7b-instruct-maas` | Qwen | API – price not found | No dedicated row |
| `glm-4-7` | ZAI.org/GLM | API | $0.60/$2.20 — GLM-4.7 |
| `glm-5` | ZAI.org/GLM | API | $1.00/$3.20; cache hit $0.10 — GLM-5 |
| `glm-4v-plus-0111` | ZAI.org/GLM | API – price not found | No dedicated row |
| `glm-4-plus-maas` | ZAI.org/GLM | API – price not found | No dedicated row |
| `glm-4-airx-maas` | ZAI.org/GLM | API – price not found | No dedicated row |
| `glm-4v-plus-maas` | ZAI.org/GLM | API – price not found | No dedicated row |
| `gpt-oss-120b-maas` | OpenAI | API | $0.09/$0.36; batch included |
| `gpt-oss-20b-maas` | OpenAI | API | $0.07/$0.25; cache hit $0.007; batch included |
| `jamba-large-1.6` | AI21 | API – price not found | No pricing row found on Vertex pricing page |

## Excluded Models (global rules applied)
| Model | Reason |
|-------|--------|
| `gemini-live-2.5-flash-native-audio` | Live streaming — excluded |
| `lyria-002`, `lyria-3-pro-preview`, `lyria-3-clip-preview` | Music generation — excluded |
| `chirp-2`, `chirp-3` | Audio transcription — excluded |
| `shieldgemma2` | Safety/guard — excluded |
| `translate-llm` | Non-generative NLP — excluded |
| `weathernext-graph-neuralgcm-*` | Non-generative — excluded |
| `imagegeneration@*` | Legacy Imagen — excluded |
| `virtual-try-on-001` | Product-specific retail — excluded |
| `deepseek-ocr`, `deepseek-ocr-2`, `deepseek-ocr-maas` | OCR — excluded |
| `mistral-ocr-2505` | OCR — excluded |
| `glm-image` | Policy exception — excluded |
| `qwen-image` | Policy exception — excluded |
| `*-self-deploy` variants | Self-deploy (has_deploy=true, no -maas) — excluded |
| `prompt-guard-001` | Guard/safety — excluded |
| `segment-anything-*`, `sam3`, `faster-r-cnn-*`, `openclip`, `clip-*` | Non-generative CV/ML — excluded |
| `whisper-large` | Audio transcription — excluded |

---
*Generated by Pricing Agent on 2026-04-14*