### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1395,7 +1395,7 @@
           "response_audio_token": {
             "price": 0.0012
           }
-        }     
+        }
       }
     }
   },
@@ -1615,7 +1615,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -1646,7 +1646,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -1745,7 +1745,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1786,7 +1786,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2217,13 +2217,13 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2283,16 +2283,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2310,16 +2310,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2457,16 +2457,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00012
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000015
         },
         "additional_units": {
           "web_search": {
@@ -2494,16 +2494,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00012
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000015
         },
         "additional_units": {
           "web_search": {
@@ -2520,16 +2520,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00012
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000005
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -2549,16 +2549,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00012
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000005
+          "price": 0.000003
         }
       }
     }
@@ -2643,10 +2643,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2715,25 +2715,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.00025
         },
         "cache_read_audio_input_token": {
-          "price": 0.0064
+          "price": 0.00025
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2742,25 +2742,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.00025
         },
         "cache_read_audio_input_token": {
-          "price": 0.0064
+          "price": 0.00025
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2775,10 +2775,10 @@
           "price": 0.001
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2793,10 +2793,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2882,6 +2882,15 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0.000125
         }
       }
     }
@@ -2927,6 +2936,12 @@
           },
           "video_duration_seconds_1792_1024": {
             "price": 50
+          },
+          "video_duration_seconds_1024_1024": {
+            "price": 50
+          },
+          "video_duration_seconds_1080_1920": {
+            "price": 70
           }
         }
       }
@@ -3310,7 +3325,7 @@
           "price": 0.000006
         },
         "cache_read_audio_input_token": {
-          "price": 0.000008
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3419,6 +3434,15 @@
           "price": 0.000125
         },
         "cache_read_text_input_token": {
+          "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
           "price": 0.000125
         }
       }
@@ -3661,10 +3685,10 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         }
       }
     }
@@ -3844,7 +3868,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -3878,6 +3902,9 @@
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "response_image_token": {
+          "price": 0.0008
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 24 |


### 🔄 Updated Models
- `gpt-5-mini`
- `gpt-5-mini-2025-08-07`
- `gpt-5-nano`
- `gpt-5-nano-2025-08-07`
- `gpt-4.1`
- `gpt-4.1-2025-04-14`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `gpt-realtime-mini`
- `gpt-realtime`
- `gpt-realtime-2025-08-28`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-audio-mini`
- `gpt-audio`
- `gpt-audio-2025-08-28`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-image-1.5`
- `gpt-image-1-mini`
- `gpt-image-1`
- `chatgpt-image-latest`
- `sora-2-pro`
- `o4-mini-deep-research-2025-06-26`


## Model-to-Pricing Mapping

### Data Sources
- **Models API**: `GET https://api.openai.com/v1/models` — 128 models returned (ft:* excluded)
- **Pricing Page**: `https://developers.openai.com/api/docs/pricing` (Standard tier) — fetched via HTTP Range headers due to Cloudflare protection on platform.openai.com

### Pricing Tiers Used
- **Text models with short/long context**: Short context pricing used as Standard tier (e.g., gpt-5.4: $2.50/$15.00 short vs $5.00/$22.50 long)
- **Audio/Realtime**: Both text token and audio token prices captured
- **TTS (tts-1, tts-1-hd)**: Per-million-characters pricing
- **Whisper**: Per-minute pricing
- **Sora**: Per-second video pricing by resolution

### Key Model Families
| Family | Input ($/MTok) | Output ($/MTok) |
|--------|---------------|-----------------|
| gpt-5.4 | 2.50 | 15.00 |
| gpt-5.4-mini | 0.75 | 4.50 |
| gpt-5.4-nano | 0.20 | 1.25 |
| gpt-5.4-pro | 30.00 | 180.00 |
| gpt-5.3/gpt-5.2 | 1.75 | 14.00 |
| gpt-5.1/gpt-5 | 1.25 | 10.00 |
| gpt-4.1 | 2.00 | 8.00 |
| gpt-4o | 2.50 | 10.00 |
| o3 | 2.00 | 8.00 |
| o4-mini | 1.10 | 4.40 |

---
*Generated by Pricing Agent on 2026-04-14*