### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -157,6 +157,14 @@
         "response_token": {
           "price": 0.003
         }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0015
+        }
       }
     }
   },
@@ -1269,10 +1277,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1395,7 +1403,7 @@
           "response_audio_token": {
             "price": 0.0012
           }
-        }     
+        }
       }
     }
   },
@@ -1409,7 +1417,7 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.6
+          "price": 0.0006
         },
         "response_audio_token": {
           "price": 0
@@ -1435,7 +1443,7 @@
           "price": 0.0005
         },
         "request_audio_token": {
-          "price": 0.3
+          "price": 0.0003
         },
         "response_audio_token": {
           "price": 0
@@ -1745,7 +1753,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1786,7 +1794,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2217,13 +2225,13 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2283,16 +2291,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2310,16 +2318,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2643,10 +2651,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2793,10 +2801,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2807,16 +2815,16 @@
         "image": {
           "default": {
             "default": {
-              "price": 16.7
+              "price": 1.1
             },
             "1024x1024": {
-              "price": 16.7
+              "price": 1.1
             },
             "1024x1536": {
-              "price": 25
+              "price": 1.6
             },
             "1536x1024": {
-              "price": 25
+              "price": 1.6
             }
           },
           "high": {
@@ -2882,6 +2890,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.004
         }
       }
     }
@@ -3342,16 +3356,16 @@
         "image": {
           "default": {
             "default": {
-              "price": 13.3
+              "price": 0.9
             },
             "1024x1024": {
-              "price": 13.3
+              "price": 0.9
             },
             "1024x1536": {
-              "price": 20
+              "price": 1.3
             },
             "1536x1024": {
-              "price": 20
+              "price": 1.3
             }
           },
           "high": {
@@ -3420,6 +3434,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0032
         }
       }
     }
@@ -3857,6 +3877,64 @@
         },
         "cache_read_image_input_token": {
           "price": 0.0002
+        },
+        "image": {
+          "low": {
+            "default": {
+              "price": 0.9
+            },
+            "1024x1024": {
+              "price": 0.9
+            },
+            "1024x1536": {
+              "price": 1.3
+            },
+            "1536x1024": {
+              "price": 1.3
+            }
+          },
+          "medium": {
+            "default": {
+              "price": 3.4
+            },
+            "1024x1024": {
+              "price": 3.4
+            },
+            "1024x1536": {
+              "price": 5
+            },
+            "1536x1024": {
+              "price": 5
+            }
+          },
+          "high": {
+            "default": {
+              "price": 13.3
+            },
+            "1024x1024": {
+              "price": 13.3
+            },
+            "1024x1536": {
+              "price": 20
+            },
+            "1536x1024": {
+              "price": 20
+            }
+          },
+          "default": {
+            "default": {
+              "price": 0.9
+            },
+            "1024x1024": {
+              "price": 0.9
+            },
+            "1024x1536": {
+              "price": 1.3
+            },
+            "1536x1024": {
+              "price": 1.3
+            }
+          }
         }
       }
     }
@@ -3878,6 +3956,64 @@
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "image": {
+          "low": {
+            "default": {
+              "price": 0.5
+            },
+            "1024x1024": {
+              "price": 0.5
+            },
+            "1024x1536": {
+              "price": 0.6
+            },
+            "1536x1024": {
+              "price": 0.6
+            }
+          },
+          "medium": {
+            "default": {
+              "price": 1.1
+            },
+            "1024x1024": {
+              "price": 1.1
+            },
+            "1024x1536": {
+              "price": 1.5
+            },
+            "1536x1024": {
+              "price": 1.5
+            }
+          },
+          "high": {
+            "default": {
+              "price": 3.6
+            },
+            "1024x1024": {
+              "price": 3.6
+            },
+            "1024x1536": {
+              "price": 5.2
+            },
+            "1536x1024": {
+              "price": 5.2
+            }
+          },
+          "default": {
+            "default": {
+              "price": 0.5
+            },
+            "1024x1024": {
+              "price": 0.5
+            },
+            "1024x1536": {
+              "price": 0.6
+            },
+            "1536x1024": {
+              "price": 0.6
+            }
+          }
         }
       }
     }
@@ -3961,10 +4097,10 @@
           "price": 0.0016
         },
         "cache_write_input_token": {
-          "price": 0
+          "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0016
         },
         "request_audio_token": {
           "price": 0.0032
@@ -3973,7 +4109,7 @@
           "price": 0.0064
         },
         "cache_read_audio_input_token": {
-          "price": 0.00004
+          "price": 0.0064
         },
         "request_image_token": {
           "price": 0.0005
@@ -4047,13 +4183,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.000175
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0014
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000175
         },
         "additional_units": {
           "web_search": {
@@ -4070,13 +4206,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.000175
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0014
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000175
         },
         "additional_units": {
           "web_search": {
@@ -4093,10 +4229,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.003
+          "price": 0.0021
         },
         "response_token": {
-          "price": 0.018
+          "price": 0.0168
         },
         "additional_units": {
           "web_search": {
@@ -4113,10 +4249,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.003
+          "price": 0.0021
         },
         "response_token": {
-          "price": 0.018
+          "price": 0.0168
         },
         "additional_units": {
           "web_search": {
@@ -4133,13 +4269,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00045
+          "price": 0.0002
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -4156,13 +4292,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00045
+          "price": 0.0002
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -4179,13 +4315,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.0000005
         },
         "additional_units": {
           "web_search": {
@@ -4202,13 +4338,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.0000005
         },
         "additional_units": {
           "web_search": {


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 24 |


### 🔄 Updated Models
- `gpt-5.4`
- `gpt-5.4-2026-03-05`
- `gpt-5.4-mini`
- `gpt-5.4-mini-2026-03-17`
- `gpt-5.4-nano`
- `gpt-5.4-nano-2026-03-17`
- `gpt-5.4-pro`
- `gpt-5.4-pro-2026-03-05`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `o4-mini-deep-research-2025-06-26`
- `gpt-4-turbo`
- `gpt-realtime-1.5`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-audio-mini`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe`
- `gpt-image-1`
- `gpt-image-1.5`
- `gpt-image-1-mini`
- `chatgpt-image-latest`


## Model Coverage (128 models from API)

| Family | Models |
|--------|--------|
| GPT-5.4 | gpt-5.4, gpt-5.4-2026-03-05, gpt-5.4-mini, gpt-5.4-mini-2026-03-17, gpt-5.4-nano, gpt-5.4-nano-2026-03-17, gpt-5.4-pro, gpt-5.4-pro-2026-03-05 |
| GPT-5.3 | gpt-5.3-chat-latest, gpt-5.3-codex |
| GPT-5.2 | gpt-5.2, gpt-5.2-2025-12-11, gpt-5.2-chat-latest, gpt-5.2-codex, gpt-5.2-pro, gpt-5.2-pro-2025-12-11 |
| GPT-5.1 | gpt-5.1, gpt-5.1-2025-11-13, gpt-5.1-chat-latest, gpt-5.1-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max |
| GPT-5 | gpt-5, gpt-5-2025-08-07, gpt-5-chat-latest, gpt-5-mini, gpt-5-mini-2025-08-07, gpt-5-nano, gpt-5-nano-2025-08-07, gpt-5-pro, gpt-5-pro-2025-10-06, gpt-5-codex, gpt-5-search-api, gpt-5-search-api-2025-10-14 |
| GPT-4.1 | gpt-4.1, gpt-4.1-2025-04-14, gpt-4.1-mini, gpt-4.1-mini-2025-04-14, gpt-4.1-nano, gpt-4.1-nano-2025-04-14 |
| GPT-4o | gpt-4o, gpt-4o-2024-05-13, gpt-4o-2024-08-06, gpt-4o-2024-11-20, gpt-4o-mini, gpt-4o-mini-2024-07-18 |
| O-series | o4-mini, o4-mini-2025-04-16, o4-mini-deep-research, o4-mini-deep-research-2025-06-26, o3, o3-2025-04-16, o3-pro, o3-pro-2025-06-10, o3-mini, o3-mini-2025-01-31, o3-deep-research, o3-deep-research-2025-06-26, o1, o1-2024-12-17, o1-pro, o1-pro-2025-03-19 |
| Realtime | gpt-realtime, gpt-realtime-2025-08-28, gpt-realtime-1.5, gpt-realtime-mini, gpt-realtime-mini-2025-10-06, gpt-realtime-mini-2025-12-15, gpt-4o-realtime-preview, gpt-4o-realtime-preview-2024-12-17, gpt-4o-realtime-preview-2025-06-03, gpt-4o-mini-realtime-preview, gpt-4o-mini-realtime-preview-2024-12-17 |
| Audio | gpt-audio, gpt-audio-2025-08-28, gpt-audio-1.5, gpt-audio-mini, gpt-audio-mini-2025-10-06, gpt-audio-mini-2025-12-15, gpt-4o-audio-preview, gpt-4o-audio-preview-2024-12-17, gpt-4o-audio-preview-2025-06-03, gpt-4o-mini-audio-preview, gpt-4o-mini-audio-preview-2024-12-17 |
| TTS/Transcribe | gpt-4o-mini-tts, gpt-4o-mini-tts-2025-03-20, gpt-4o-mini-tts-2025-12-15, gpt-4o-transcribe, gpt-4o-transcribe-diarize, gpt-4o-mini-transcribe, gpt-4o-mini-transcribe-2025-03-20, gpt-4o-mini-transcribe-2025-12-15, tts-1, tts-1-hd, tts-1-1106, tts-1-hd-1106, whisper-1 |
| Search | gpt-4o-search-preview, gpt-4o-search-preview-2025-03-11, gpt-4o-mini-search-preview, gpt-4o-mini-search-preview-2025-03-11 |
| Image/Video | dall-e-2, dall-e-3, gpt-image-1, gpt-image-1.5, gpt-image-1-mini, chatgpt-image-latest, sora-2, sora-2-pro |
| Computer Use | computer-use-preview, computer-use-preview-2025-03-11 |
| Embeddings | text-embedding-3-small, text-embedding-3-large, text-embedding-ada-002 |
| Moderation | omni-moderation-latest, omni-moderation-2024-09-26 |
| Legacy | gpt-4-turbo, gpt-4-turbo-2024-04-09, gpt-4, gpt-4-0613, gpt-3.5-turbo, gpt-3.5-turbo-0125, gpt-3.5-turbo-1106, gpt-3.5-turbo-16k, gpt-3.5-turbo-instruct, gpt-3.5-turbo-instruct-0914, babbage-002, davinci-002 |

**Pricing source:** https://platform.openai.com/docs/pricing (Standard tier)

---
*Generated by Pricing Agent on 2026-04-14*