### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1757,5 +1757,11 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -833,11 +833,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -861,11 +864,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -917,10 +923,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -948,10 +954,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1159,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1187,10 +1193,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1395,10 +1401,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1432,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1533,6 +1539,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1564,6 +1573,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1587,7 +1599,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1608,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1633,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1642,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1693,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1727,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1879,10 +1891,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1922,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1959,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1981,10 +1993,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2080,10 +2092,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2114,10 +2126,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2281,10 +2293,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2312,10 +2324,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2343,10 +2355,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2374,10 +2386,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2405,10 +2417,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2436,10 +2448,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2467,10 +2479,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2498,10 +2510,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2519,29 +2531,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2550,29 +2562,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2591,10 +2603,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2622,10 +2634,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2650,11 +2662,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2678,11 +2693,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -3174,7 +3192,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,7 +3232,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3238,7 +3256,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3301,40 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 0
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 0
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 36 |

### ➕ New Models
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-2.5-pro-lte-128k`
- `gemini-2.5-pro-gt-128k`
- `gemini-2.5-flash-lte-128k`
- `gemini-2.5-flash-gt-128k`
- `gemini-2.5-flash-lite-lte-128k`
- `gemini-2.5-flash-lite-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.0-flash-lite-lte-128k`
- `gemini-2.0-flash-lite-gt-128k`
- `gemini-2.0-flash-lite-001-lte-128k`
- `gemini-2.0-flash-lite-001-gt-128k`
- `gemini-3-pro-preview-lte-128k`
- `gemini-3-pro-preview-gt-128k`
- `gemini-3-flash-preview-lte-128k`
- `gemini-3-flash-preview-gt-128k`
- `gemini-3.1-pro-preview-lte-128k`
- `gemini-3.1-pro-preview-gt-128k`
- `gemini-3.1-pro-preview-customtools-lte-128k`
- `gemini-3.1-pro-preview-customtools-gt-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-2.5-flash-image-lte-128k`
- `gemini-2.5-flash-image-gt-128k`
- `gemini-3.1-flash-image-preview-lte-128k`
- `gemini-3.1-flash-image-preview-gt-128k`
- `gemini-3-pro-image-preview-lte-128k`
- `gemini-3-pro-image-preview-gt-128k`
- ... and 6 more


### Model to pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K tokens | input $1.25/1M, output $10/1M, cache_read $0.125/1M, batch 50%, web_search/search |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K tokens | input $2.50/1M, output $15/1M, cache_read $0.25/1M, batch 50%, web_search/search |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat pricing | input $0.30/1M, output $2.50/1M, cache_read $0.03/1M, web_search/search; reasoning tokens priced same as output |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat pricing | same as lte (flat) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash-Lite, flat pricing | input $0.10/1M, output $0.40/1M, cache_read $0.01/1M, web_search/search |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash-Lite, flat pricing | same as lte (flat) |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat pricing | input $0.10/1M, output $0.40/1M, cache_read $0.025/1M, web_search/search |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat pricing | same as lte (flat) |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash 001, flat pricing | same pricing as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash 001, flat pricing | same as lte (flat) |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash-Lite, flat pricing | input $0.075/1M, output $0.30/1M, cache_read $0.01875/1M, web_search/search |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash-Lite, flat pricing | same as lte (flat) |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash-Lite 001, flat pricing | same pricing as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash-Lite 001, flat pricing | same as lte (flat) |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K tokens | input $2.00/1M, output $12.00/1M, cache_read $0.20/1M, batch 50%, web_search/search |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K tokens | input $4.00/1M, output $18.00/1M, cache_read $0.40/1M, batch 50%, web_search/search |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, flat pricing | input $0.50/1M, output $3.00/1M, cache_read $0.05/1M, web_search/search; reasoning tokens priced same as output |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, flat pricing | same as lte (flat) |
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K tokens | input $2.00/1M, output $12.00/1M, cache_read $0.20/1M, batch 50%, web_search/search |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K tokens | input $4.00/1M, output $18.00/1M, cache_read $0.40/1M, batch 50%, web_search/search |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview (custom tools), ≤200K tokens | same pricing as gemini-3.1-pro-preview lte |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview (custom tools), >200K tokens | same pricing as gemini-3.1-pro-preview gt |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite Preview, flat pricing | input $0.25/1M, output $1.50/1M, cache_read $0.025/1M, web_search/search |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite Preview, flat pricing | same as lte (flat) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat pricing | input $0.30/1M, text output $2.50/1M, image output $30/1M (additional.image_token), batch 50%; no web_search (supports_web_search:false) |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat pricing | same as lte (flat) |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview, flat pricing | input $0.25/1M, text output $1.50/1M, image output $60/1M (additional.image_token), batch 50%, web_search/search |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview, flat pricing | same as lte (flat) |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview, flat pricing | input $2.00/1M, text output $12.00/1M, image output $120/1M (additional.image_token), batch 50%, web_search/search |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview, flat pricing | same as lte (flat) |
| gemini-flash-latest-lte-128k | *-latest alias → resolved to gemini-3-flash-preview | Highest Flash series version; using gemini-3-flash-preview pricing ($0.50/$3.00). Note: litellm shows this alias at $0.30/$2.50 (= 2.5-flash). Resolved per skill rule: highest-version model in series. |
| gemini-flash-latest-gt-128k | *-latest alias → resolved to gemini-3-flash-preview | same as lte (flat) |
| gemini-flash-lite-latest-lte-128k | *-latest alias → resolved to gemini-3.1-flash-lite-preview | Highest Flash-Lite series version; using gemini-3.1-flash-lite-preview pricing ($0.25/$1.50). Note: litellm shows this alias at $0.10/$0.40 (= 2.5-flash-lite). Resolved per skill rule: highest-version model in series. |
| gemini-flash-lite-latest-gt-128k | *-latest alias → resolved to gemini-3.1-flash-lite-preview | same as lte (flat) |
| gemini-pro-latest-lte-128k | *-latest alias → resolved to gemini-3.1-pro-preview | Highest Pro series version; using gemini-3.1-pro-preview pricing ($2.00/$12.00 ≤200k). Note: litellm shows this alias at $1.25/$10.00 (= 2.5-pro). Resolved per skill rule: highest-version model in series. |
| gemini-pro-latest-gt-128k | *-latest alias → resolved to gemini-3.1-pro-preview | >200K tier: input $4.00/1M, output $18.00/1M, same as gemini-3.1-pro-preview gt |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 | input $0.15/1M, output 0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 | same as lte (flat) |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview | input $0.20/1M, output 0 |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview | same as lte (flat) |
| imagen-4.0-generate-001-lte-128k | Imagen 4.0 Generate | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4.0 Generate | same as lte (flat) |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4.0 Ultra Generate | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4.0 Ultra Generate | same as lte (flat) |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4.0 Fast Generate | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4.0 Fast Generate | same as lte (flat) |
| veo-2.0-generate-001-lte-128k | Veo 2.0 Generate | 35¢/second video, default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2.0 Generate | same as lte (flat) |
| veo-3.0-generate-001-lte-128k | Veo 3.0 Generate | 40¢/second video, default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3.0 Generate | same as lte (flat) |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast Generate | 15¢/second video, default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast Generate | same as lte (flat) |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Generate Preview | 40¢/second video, default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Generate Preview | same as lte (flat) |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast Generate Preview | 15¢/second video, default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast Generate Preview | same as lte (flat) |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite Generate Preview | Price not found in litellm or live page (live page inaccessible); video_seconds set to 0 |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite Generate Preview | same as lte (flat) |

### Data source notes

- **Primary source**: litellm `model_prices_and_context_window.json` (https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json) — used because live Google pricing page was inaccessible (firecrawl credits exhausted, WebFetch/WebSearch not approved).
- **Model list**: Google Gemini API (`get_gemini_models`), 50 models returned, filtered to 29 included models.
- **Alias resolution**: Resolved per skill rule "use the highest-version model visible for that series" since live page was unavailable. litellm shows aliases pointing to older model pricing (2.5-series); skill rules resolve to highest-version (3.x-series). Discrepancy noted in table above.
- **veo-3.1-lite-generate-preview**: Present in API model list but absent from litellm — price set to 0.
- **Context tiers**: Models with ≤200k/&gt;200k pricing tiers: gemini-2.5-pro, gemini-3-pro-preview, gemini-3.1-pro-preview, gemini-3.1-pro-preview-customtools, gemini-pro-latest (alias). All others use flat pricing (identical lte/gt values).
- **Thinking tokens**: Reasoning tokens for gemini-2.5-flash, gemini-3-flash-preview, and gemini-3.1-flash-lite-preview are priced the same as regular output tokens in litellm — no separate `thinking_token` additional field added per skill rules ("only when the page lists thinking as a separate line item").
- **Web search**: $3.5/1K calls = 0.35¢/call → `additional: { web_search: 0.35, search: 0.35 }`. Not added for: gemini-2.5-flash-image (supports_web_search:false in litellm), embedding models, imagen models, veo models.

---
*Generated by Pricing Agent on 2026-04-14*