### PR TITLE
chore(pricing): Update openai pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -767,7 +767,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000625
+          "price": 0.000125
         },
         "additional_units": {
           "web_search": {
@@ -849,7 +849,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000625
+          "price": 0.000125
         },
         "additional_units": {
           "web_search": {
@@ -968,7 +968,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000375
+          "price": 0.00075
         },
         "additional_units": {
           "file_search": {
@@ -999,7 +999,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000375
+          "price": 0.00075
         },
         "additional_units": {
           "file_search": {
@@ -1126,7 +1126,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000125
+          "price": 0.00025
         },
         "cache_read_audio_input_token": {
           "price": 0.00025
@@ -1153,7 +1153,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000125
+          "price": 0.00025
         },
         "cache_read_audio_input_token": {
           "price": 0.00025
@@ -1246,7 +1246,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000625
+          "price": 0.000125
         },
         "additional_units": {
           "web_search": {
@@ -1429,10 +1429,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.0005
         },
         "request_audio_token": {
           "price": 0.3
@@ -1464,7 +1464,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000275
+          "price": 0.000055
         },
         "additional_units": {
           "file_search": {
@@ -1487,7 +1487,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000275
+          "price": 0.000055
         },
         "additional_units": {
           "file_search": {
@@ -1580,7 +1580,7 @@
           "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.000075
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -1603,7 +1603,7 @@
           "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.000075
+          "price": 0.00003
         }
       }
     }
@@ -2160,16 +2160,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2194,16 +2194,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2220,16 +2220,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.00011
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.00044
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.0000275
         },
         "additional_units": {
           "web_search": {
@@ -2246,16 +2246,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.00011
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.00044
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.0000275
         },
         "additional_units": {
           "web_search": {
@@ -2289,7 +2289,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.00003
@@ -2316,7 +2316,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.00003
@@ -2730,7 +2730,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000125
+          "price": 0.00025
         },
         "cache_read_audio_input_token": {
           "price": 0.00025
@@ -2757,7 +2757,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000125
+          "price": 0.00025
         },
         "cache_read_audio_input_token": {
           "price": 0.00025
@@ -2775,10 +2775,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "response_audio_token": {
           "price": 0.008
@@ -2819,10 +2819,10 @@
               "price": 1.1
             },
             "1024x1536": {
-              "price": 1.6
+              "price": 25
             },
             "1536x1024": {
-              "price": 1.6
+              "price": 25
             }
           },
           "high": {
@@ -2893,7 +2893,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.004
+          "price": 0
         }
       }
     }
@@ -2909,13 +2909,16 @@
         },
         "additional_units": {
           "video_duration_seconds_720_1280": {
-            "price": 10
+            "price": 4
           },
           "video_duration_seconds_1280_720": {
-            "price": 10
+            "price": 4
           },
           "video_duration_seconds_1080_1920": {
-            "price": 20
+            "price": 8
+          },
+          "video_duration_seconds_1920_1080": {
+            "price": 8
           }
         }
       }
@@ -2932,10 +2935,10 @@
         },
         "additional_units": {
           "video_duration_seconds_720_1280": {
-            "price": 20
+            "price": 8
           },
           "video_duration_seconds_1280_720": {
-            "price": 30
+            "price": 8
           },
           "video_duration_seconds_1024_1792": {
             "price": 50
@@ -2944,7 +2947,10 @@
             "price": 50
           },
           "video_duration_seconds_1080_1920": {
-            "price": 40
+            "price": 16
+          },
+          "video_duration_seconds_1920_1080": {
+            "price": 16
           }
         }
       }
@@ -3043,16 +3049,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0002
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -3325,7 +3331,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "cache_read_audio_input_token": {
           "price": 0.00003
@@ -3366,10 +3372,10 @@
               "price": 1.1
             },
             "1024x1536": {
-              "price": 1.6
+              "price": 20
             },
             "1536x1024": {
-              "price": 1.6
+              "price": 20
             }
           },
           "high": {
@@ -3380,10 +3386,10 @@
               "price": 16.7
             },
             "1024x1536": {
-              "price": 25
+              "price": 20
             },
             "1536x1024": {
-              "price": 25
+              "price": 20
             }
           },
           "medium": {
@@ -3394,10 +3400,10 @@
               "price": 4.2
             },
             "1024x1536": {
-              "price": 6.3
+              "price": 5
             },
             "1536x1024": {
-              "price": 6.3
+              "price": 5
             }
           },
           "low": {
@@ -3408,10 +3414,10 @@
               "price": 1.1
             },
             "1024x1536": {
-              "price": 1.6
+              "price": 1.3
             },
             "1536x1024": {
-              "price": 1.6
+              "price": 1.3
             }
           }
         },
@@ -3443,7 +3449,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.004
+          "price": 0
         }
       }
     }
@@ -3540,16 +3546,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.000175
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0014
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.0000175
         },
         "additional_units": {
           "web_search": {
@@ -3566,16 +3572,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.000175
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0014
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.0000175
         },
         "additional_units": {
           "web_search": {
@@ -3598,7 +3604,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3628,7 +3634,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3658,7 +3664,7 @@
           "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.000125
+          "price": 0.00025
         },
         "request_audio_token": {
           "price": 0.004
@@ -3676,10 +3682,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0
@@ -3811,10 +3817,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.0005
         },
         "request_audio_token": {
           "price": 0.0003
@@ -3826,10 +3832,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.0005
         },
         "request_audio_token": {
           "price": 0.0003
@@ -3868,7 +3874,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.004
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -3889,12 +3895,6 @@
             },
             "1024x1024": {
               "price": 1.1
-            },
-            "1024x1536": {
-              "price": 1.6
-            },
-            "1536x1024": {
-              "price": 1.6
             }
           },
           "medium": {
@@ -3903,12 +3903,6 @@
             },
             "1024x1024": {
               "price": 4.2
-            },
-            "1024x1536": {
-              "price": 6.3
-            },
-            "1536x1024": {
-              "price": 6.3
             }
           },
           "high": {
@@ -3917,12 +3911,6 @@
             },
             "1024x1024": {
               "price": 16.7
-            },
-            "1024x1536": {
-              "price": 25
-            },
-            "1536x1024": {
-              "price": 25
             }
           },
           "default": {
@@ -3931,12 +3919,6 @@
             },
             "1024x1024": {
               "price": 1.1
-            },
-            "1024x1536": {
-              "price": 1.6
-            },
-            "1536x1024": {
-              "price": 1.6
             }
           }
         }
@@ -3947,10 +3929,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -4080,7 +4062,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000125
+          "price": 0.00025
         },
         "request_audio_token": {
           "price": 0.004
@@ -4101,10 +4083,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0
@@ -4163,13 +4145,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000175
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0014
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
@@ -4186,13 +4168,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000175
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0014
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
@@ -4209,10 +4191,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0021
+          "price": 0.003
         },
         "response_token": {
-          "price": 0.0168
+          "price": 0.018
         },
         "additional_units": {
           "web_search": {
@@ -4221,6 +4203,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }
@@ -4229,10 +4214,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0021
+          "price": 0.003
         },
         "response_token": {
-          "price": 0.0168
+          "price": 0.018
         },
         "additional_units": {
           "web_search": {
@@ -4241,6 +4226,9 @@
           "file_search": {
             "price": 0.25
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0003
         }
       }
     }
@@ -4249,13 +4237,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000075
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00045
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -4272,13 +4260,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000075
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00045
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -4295,13 +4283,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.0000005
+          "price": 0.000002
         },
         "additional_units": {
           "web_search": {
@@ -4318,13 +4306,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.0000005
+          "price": 0.000002
         },
         "additional_units": {
           "web_search": {

--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -767,7 +767,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000125
+          "price": 0.0000625
         },
         "additional_units": {
           "web_search": {
@@ -849,7 +849,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000125
+          "price": 0.0000625
         },
         "additional_units": {
           "web_search": {
@@ -968,7 +968,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00075
+          "price": 0.000375
         },
         "additional_units": {
           "file_search": {
@@ -999,7 +999,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00075
+          "price": 0.000375
         },
         "additional_units": {
           "file_search": {
@@ -1126,7 +1126,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.000125
         },
         "cache_read_audio_input_token": {
           "price": 0.00025
@@ -1153,7 +1153,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.000125
         },
         "cache_read_audio_input_token": {
           "price": 0.00025
@@ -1246,7 +1246,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000125
+          "price": 0.0000625
         },
         "additional_units": {
           "web_search": {
@@ -1269,10 +1269,10 @@
           "price": 0.001
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.008
         },
         "additional_units": {
           "web_search": {
@@ -1395,7 +1395,7 @@
           "response_audio_token": {
             "price": 0.0012
           }
-        }     
+        }
       }
     }
   },
@@ -1429,10 +1429,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.00006
         },
         "request_audio_token": {
           "price": 0.3
@@ -1464,7 +1464,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000055
+          "price": 0.0000275
         },
         "additional_units": {
           "file_search": {
@@ -1487,7 +1487,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000055
+          "price": 0.0000275
         },
         "additional_units": {
           "file_search": {
@@ -1578,6 +1578,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       },
       "batch_config": {
@@ -1598,6 +1601,9 @@
         },
         "response_token": {
           "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.000075
         }
       }
     }
@@ -1745,7 +1751,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         }
       },
       "finetune_config": {
@@ -1786,7 +1792,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2214,10 +2220,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0
@@ -2240,10 +2246,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0008
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0
@@ -2283,16 +2289,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.000015
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2310,16 +2316,16 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.000015
         },
         "cache_read_audio_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         },
         "response_audio_token": {
-          "price": 0.02
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.01
+          "price": 0.001
         }
       }
     }
@@ -2643,10 +2649,10 @@
           "price": 0.00006
         },
         "response_audio_token": {
-          "price": 0.001
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.002
+          "price": 0.001
         }
       }
     }
@@ -2715,25 +2721,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.000125
         },
         "cache_read_audio_input_token": {
-          "price": 0.0064
+          "price": 0.00025
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2742,25 +2748,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0016
+          "price": 0.000125
         },
         "cache_read_audio_input_token": {
-          "price": 0.0064
+          "price": 0.00025
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2775,10 +2781,10 @@
           "price": 0.001
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         }
       }
     }
@@ -2793,10 +2799,10 @@
           "price": 0.00024
         },
         "response_audio_token": {
-          "price": 0.0002
+          "price": 0.002
         },
         "request_audio_token": {
-          "price": 0.0001
+          "price": 0.001
         }
       }
     }
@@ -2807,16 +2813,16 @@
         "image": {
           "default": {
             "default": {
-              "price": 16.7
+              "price": 1.1
             },
             "1024x1024": {
-              "price": 16.7
+              "price": 1.1
             },
             "1024x1536": {
-              "price": 25
+              "price": 1.6
             },
             "1536x1024": {
-              "price": 25
+              "price": 1.6
             }
           },
           "high": {
@@ -2882,6 +2888,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.004
         }
       }
     }
@@ -2901,6 +2913,9 @@
           },
           "video_duration_seconds_1280_720": {
             "price": 10
+          },
+          "video_duration_seconds_1080_1920": {
+            "price": 20
           }
         }
       }
@@ -2917,7 +2932,7 @@
         },
         "additional_units": {
           "video_duration_seconds_720_1280": {
-            "price": 30
+            "price": 20
           },
           "video_duration_seconds_1280_720": {
             "price": 30
@@ -2927,6 +2942,9 @@
           },
           "video_duration_seconds_1792_1024": {
             "price": 50
+          },
+          "video_duration_seconds_1080_1920": {
+            "price": 40
           }
         }
       }
@@ -3025,16 +3043,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
@@ -3307,10 +3325,10 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.000015
         },
         "cache_read_audio_input_token": {
-          "price": 0.000008
+          "price": 0.00003
         },
         "request_audio_token": {
           "price": 0.001
@@ -3342,58 +3360,58 @@
         "image": {
           "default": {
             "default": {
-              "price": 13.3
+              "price": 1.1
             },
             "1024x1024": {
-              "price": 13.3
+              "price": 1.1
             },
             "1024x1536": {
-              "price": 20
+              "price": 1.6
             },
             "1536x1024": {
-              "price": 20
+              "price": 1.6
             }
           },
           "high": {
             "default": {
-              "price": 13.3
+              "price": 16.7
             },
             "1024x1024": {
-              "price": 13.3
+              "price": 16.7
             },
             "1024x1536": {
-              "price": 20
+              "price": 25
             },
             "1536x1024": {
-              "price": 20
+              "price": 25
             }
           },
           "medium": {
             "default": {
-              "price": 3.4
+              "price": 4.2
             },
             "1024x1024": {
-              "price": 3.4
+              "price": 4.2
             },
             "1024x1536": {
-              "price": 5
+              "price": 6.3
             },
             "1536x1024": {
-              "price": 5
+              "price": 6.3
             }
           },
           "low": {
             "default": {
-              "price": 0.9
+              "price": 1.1
             },
             "1024x1024": {
-              "price": 0.9
+              "price": 1.1
             },
             "1024x1536": {
-              "price": 1.3
+              "price": 1.6
             },
             "1536x1024": {
-              "price": 1.3
+              "price": 1.6
             }
           }
         },
@@ -3420,6 +3438,12 @@
         },
         "cache_read_text_input_token": {
           "price": 0.000125
+        },
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.004
         }
       }
     }
@@ -3516,16 +3540,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000175
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0014
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
@@ -3542,16 +3566,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000175
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0014
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
@@ -3574,7 +3598,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.000015
         },
         "request_audio_token": {
           "price": 0.001
@@ -3604,7 +3628,7 @@
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.000015
         },
         "request_audio_token": {
           "price": 0.001
@@ -3634,7 +3658,7 @@
           "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.000125
         },
         "request_audio_token": {
           "price": 0.004
@@ -3661,10 +3685,10 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         }
       }
     }
@@ -3787,10 +3811,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.00006
         },
         "request_audio_token": {
           "price": 0.0003
@@ -3802,10 +3826,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.00006
         },
         "request_audio_token": {
           "price": 0.0003
@@ -3844,7 +3868,7 @@
           "price": 0.0005
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.004
         },
         "cache_read_input_token": {
           "price": 0.000125
@@ -3857,6 +3881,64 @@
         },
         "cache_read_image_input_token": {
           "price": 0.0002
+        },
+        "image": {
+          "low": {
+            "default": {
+              "price": 1.1
+            },
+            "1024x1024": {
+              "price": 1.1
+            },
+            "1024x1536": {
+              "price": 1.6
+            },
+            "1536x1024": {
+              "price": 1.6
+            }
+          },
+          "medium": {
+            "default": {
+              "price": 4.2
+            },
+            "1024x1024": {
+              "price": 4.2
+            },
+            "1024x1536": {
+              "price": 6.3
+            },
+            "1536x1024": {
+              "price": 6.3
+            }
+          },
+          "high": {
+            "default": {
+              "price": 16.7
+            },
+            "1024x1024": {
+              "price": 16.7
+            },
+            "1024x1536": {
+              "price": 25
+            },
+            "1536x1024": {
+              "price": 25
+            }
+          },
+          "default": {
+            "default": {
+              "price": 1.1
+            },
+            "1024x1024": {
+              "price": 1.1
+            },
+            "1024x1536": {
+              "price": 1.6
+            },
+            "1536x1024": {
+              "price": 1.6
+            }
+          }
         }
       }
     }
@@ -3865,10 +3947,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0
+          "price": 0.0005
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -3878,6 +3960,40 @@
         },
         "cache_read_image_input_token": {
           "price": 0.000025
+        },
+        "image": {
+          "low": {
+            "default": {
+              "price": 0.3
+            },
+            "1024x1024": {
+              "price": 0.3
+            }
+          },
+          "medium": {
+            "default": {
+              "price": 0.7
+            },
+            "1024x1024": {
+              "price": 0.7
+            }
+          },
+          "high": {
+            "default": {
+              "price": 2
+            },
+            "1024x1024": {
+              "price": 2
+            }
+          },
+          "default": {
+            "default": {
+              "price": 0.3
+            },
+            "1024x1024": {
+              "price": 0.3
+            }
+          }
         }
       }
     }
@@ -3955,25 +4071,25 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000125
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         },
         "cache_read_audio_input_token": {
-          "price": 0.00004
+          "price": 0.00025
         },
         "request_image_token": {
           "price": 0.0005
@@ -3997,10 +4113,10 @@
           "price": 0
         },
         "request_audio_token": {
-          "price": 0.0032
+          "price": 0.004
         },
         "response_audio_token": {
-          "price": 0.0064
+          "price": 0.008
         }
       }
     }
@@ -4047,13 +4163,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.000175
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0014
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000175
         },
         "additional_units": {
           "web_search": {
@@ -4070,13 +4186,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.000175
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0014
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000175
         },
         "additional_units": {
           "web_search": {
@@ -4093,10 +4209,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.003
+          "price": 0.0021
         },
         "response_token": {
-          "price": 0.018
+          "price": 0.0168
         },
         "additional_units": {
           "web_search": {
@@ -4113,10 +4229,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.003
+          "price": 0.0021
         },
         "response_token": {
-          "price": 0.018
+          "price": 0.0168
         },
         "additional_units": {
           "web_search": {
@@ -4133,13 +4249,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00045
+          "price": 0.0002
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -4156,13 +4272,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00045
+          "price": 0.0002
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -4179,13 +4295,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.0000005
         },
         "additional_units": {
           "web_search": {
@@ -4202,13 +4318,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 0.0000005
         },
         "additional_units": {
           "web_search": {


### PR DESCRIPTION
## 🔄 Pricing Update: openai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 0 |
| 🔄 Models updated (merged) | 30 |


### 🔄 Updated Models
- `gpt-5.4-pro`
- `gpt-5.4-pro-2026-03-05`
- `gpt-4.1-nano`
- `gpt-4.1-nano-2025-04-14`
- `o4-mini-deep-research`
- `o4-mini-deep-research-2025-06-26`
- `o3-deep-research`
- `o3-deep-research-2025-06-26`
- `computer-use-preview`
- `computer-use-preview-2025-03-11`
- `gpt-realtime`
- `gpt-realtime-2025-08-28`
- `gpt-realtime-1.5`
- `gpt-realtime-mini`
- `gpt-realtime-mini-2025-10-06`
- `gpt-realtime-mini-2025-12-15`
- `gpt-audio`
- `gpt-audio-2025-08-28`
- `gpt-audio-1.5`
- `gpt-audio-mini`
- `gpt-4o-audio-preview`
- `gpt-4o-mini-realtime-preview`
- `gpt-4o-mini-realtime-preview-2024-12-17`
- `gpt-4o-mini-audio-preview-2024-12-17`
- `gpt-image-1`
- `gpt-image-1-mini`
- `gpt-image-1.5`
- `chatgpt-image-latest`
- `sora-2`
- `sora-2-pro`


## Data Sources

| Source | Details |
|--------|---------|
| Models API | `get_openai_models` — 128 models returned (ft:* excluded) |
| Pricing | LiteLLM model prices JSON (`https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`) — used as fallback because OpenAI pricing page was inaccessible (Firecrawl insufficient credits + Cloudflare 403 on direct HTTP) |

## Batch Summary

| Batch | Models | Families |
|-------|--------|----------|
| 1 | 22 | gpt-5.4, gpt-5.3, gpt-5.2, gpt-5.1 families |
| 2 | 24 | gpt-5 base, gpt-4.1, gpt-4o families |
| 3 | 24 | O-series (o1/o3/o4), search/computer-use, gpt-4 legacy |
| 4 | 24 | Realtime/Audio models (gpt-realtime, gpt-audio, gpt-4o-realtime/audio) |
| 5 | 24 | Transcribe, TTS, Whisper, Embeddings, Moderation, Legacy |
| 6 | 10 | Image (DALL-E, gpt-image), Video (Sora), Legacy (babbage/davinci) |
| **Total** | **128** | All models from API |

---
*Generated by Pricing Agent on 2026-04-15*