### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1757,5 +1757,16 @@
   "gemini-2.5-computer-use-preview-10-2025": {
     "type": { "primary": "chat", "supported": ["tools", "image"] },
     "disablePlayground": true
+  },
+  "nano-banana-pro-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -921,10 +921,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -952,6 +955,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1399,6 +1405,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1430,6 +1439,9 @@
           },
           "search": {
             "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1943,7 +1955,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1956,7 +1968,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1977,7 +1989,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1990,7 +2002,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2463,7 +2475,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2476,7 +2488,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2494,7 +2506,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2507,7 +2519,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2581,10 +2593,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2612,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,10 +2624,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2643,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2650,10 +2662,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2678,10 +2690,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2820,7 +2832,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2855,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2878,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2901,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2924,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2947,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2970,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2993,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3016,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3039,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3051,7 +3063,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3068,7 +3083,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3174,7 +3192,7 @@
         }
       }
     }
-  },  
+  },
   "gemini-2.5-pro-preview-tts-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3214,12 +3232,20 @@
         }
       }
     }
-  },  
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
           "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000016
         },
         "response_token": {
           "price": 0
@@ -3236,9 +3262,17 @@
         "response_token": {
           "price": 0
         }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000016
+        },
+        "response_token": {
+          "price": 0
+        }
       }
     }
-  },  
+  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3283,6 +3317,102 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 4 |
| 🔄 Models updated (merged) | 30 |

### ➕ New Models
- `nano-banana-pro-preview-lte-128k`
- `nano-banana-pro-preview-gt-128k`
- `veo-3.1-lite-generate-preview-lte-128k`
- `veo-3.1-lite-generate-preview-gt-128k`

### 🔄 Updated Models
- `gemini-2.5-pro-lte-128k`
- `gemini-2.5-pro-gt-128k`
- `gemini-2.5-flash-lte-128k`
- `gemini-2.5-flash-gt-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.0-flash-lite-lte-128k`
- `gemini-2.0-flash-lite-gt-128k`
- `gemini-2.0-flash-lite-001-lte-128k`
- `gemini-2.0-flash-lite-001-gt-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-flash-lite-latest-lte-128k`
- `gemini-flash-lite-latest-gt-128k`
- `gemini-embedding-001-lte-128k`
- `gemini-embedding-001-gt-128k`
- `gemini-embedding-2-preview-lte-128k`
- `gemini-embedding-2-preview-gt-128k`
- `veo-2.0-generate-001-lte-128k`
- `veo-2.0-generate-001-gt-128k`
- `veo-3.0-generate-001-lte-128k`
- `veo-3.0-generate-001-gt-128k`
- `veo-3.0-fast-generate-001-lte-128k`
- `veo-3.0-fast-generate-001-gt-128k`
- `veo-3.1-generate-preview-lte-128k`
- `veo-3.1-generate-preview-gt-128k`
- `veo-3.1-fast-generate-preview-lte-128k`
- `veo-3.1-fast-generate-preview-gt-128k`


### Model to pricing page mapping

| Model ID | Pricing page section | Notes |
|----------|---------------------|-------|
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200k tokens | input $1.25/1M, output $10/1M, cache_read $0.13/1M; batch $0.625/$5; web_search/search 3.5¢ |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200k tokens | input $2.50/1M, output $15/1M, cache_read $0.25/1M; batch $1.25/$7.50; web_search/search 3.5¢ |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat pricing | input $0.30/1M text, output $2.50/1M, cache_read $0.03/1M; batch $0.15/$1.25; thinking_token included; web_search/search 3.5¢ |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat pricing | same as lte (flat rate, no context tier) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat pricing | input $0.30/1M, text output $2.50/1M, image_token 30¢/1M; batch $0.15/$1.25; web_search/search 3.5¢ |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat pricing | same as lte (flat rate) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash Lite, flat pricing | input $0.10/1M, output $0.40/1M, cache_read $0.01/1M; batch $0.05/$0.20; web_search/search 3.5¢ |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash Lite, flat pricing | same as lte (flat rate) |
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat token pricing | input $0.15/1M, output $0.60/1M; batch $0.075/$0.30; web_search/search 3.5¢ |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat token pricing | same as lte (flat rate) |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash 001, flat token pricing | same as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash 001, flat token pricing | same as lte (flat rate) |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash Lite, flat pricing | input $0.075/1M, output $0.30/1M; batch $0.0375/$0.15; web_search/search 3.5¢ |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash Lite, flat pricing | same as lte (flat rate) |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash Lite 001, flat pricing | same as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash Lite 001, flat pricing | same as lte (flat rate) |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200k tokens | input $2/1M, output $12/1M, cache_read $0.20/1M; batch $1/$6; web_search/search 1.4¢ ($14/1K) |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200k tokens | input $4/1M, output $18/1M, cache_read $0.40/1M; batch $2/$9; web_search/search 1.4¢ |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, flat pricing | input $0.50/1M text, output $3/1M, cache_read $0.05/1M; batch $0.25/$1.50; web_search/search 1.4¢ |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, flat pricing | same as lte (flat rate) |
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200k tokens | input $2/1M, output $12/1M, cache_read $0.20/1M; batch $1/$6; web_search/search 1.4¢ |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200k tokens | input $4/1M, output $18/1M, cache_read $0.40/1M; batch $2/$9; web_search/search 1.4¢ |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash Lite Preview, flat pricing | input $0.25/1M, output $1.50/1M, cache_read $0.03/1M; batch $0.13/$0.75; web_search/search 1.4¢ |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash Lite Preview, flat pricing | same as lte (flat rate) |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview, flat pricing | input $0.50/1M, text output $3/1M, image_token 60¢/1M; batch $0.25/$1.50; web_search/search 1.4¢ |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview, flat pricing | same as lte (flat rate) |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview, flat pricing | input $2/1M, text output $12/1M, image_token 120¢/1M; batch $1/$6; web_search/search 1.4¢ |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview, flat pricing | same as lte (flat rate) |
| nano-banana-pro-preview-lte-128k | Gemini 3 Pro Image Preview (nano-banana-pro alias), flat pricing | same pricing as gemini-3-pro-image-preview; input $2/1M, text output $12/1M, image_token 120¢/1M |
| nano-banana-pro-preview-gt-128k | Gemini 3 Pro Image Preview (nano-banana-pro alias), flat pricing | same as lte (flat rate) |
| gemini-pro-latest-lte-128k | *-latest → resolved to gemini-3.1-pro-preview (verified from pricing page) | input $2/1M, output $12/1M ≤200k tier |
| gemini-pro-latest-gt-128k | *-latest → resolved to gemini-3.1-pro-preview (verified from pricing page) | input $4/1M, output $18/1M >200k tier |
| gemini-flash-latest-lte-128k | *-latest → resolved to gemini-3-flash-preview (highest Flash visible on pricing page) | input $0.50/1M, output $3/1M flat |
| gemini-flash-latest-gt-128k | *-latest → resolved to gemini-3-flash-preview | same as lte (flat rate) |
| gemini-flash-lite-latest-lte-128k | *-latest → resolved to gemini-3.1-flash-lite-preview (highest Flash Lite visible) | input $0.25/1M, output $1.50/1M flat |
| gemini-flash-lite-latest-gt-128k | *-latest → resolved to gemini-3.1-flash-lite-preview | same as lte (flat rate) |
| gemini-embedding-001-lte-128k | Gemini Embedding 001 (text) | input $0.15/1M tokens ($0.00015/1K); batch input $0.12/1M; output 0 |
| gemini-embedding-001-gt-128k | Gemini Embedding 001 (text) | same as lte (flat rate) |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Preview (multimodal) | input $0.20/1M tokens; batch input $0.16/1M; output 0 |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Preview (multimodal) | same as lte (flat rate) |
| imagen-4.0-generate-001-lte-128k | Imagen 4.0 Generate | $0.04/image (image_pricing); input/output 0 |
| imagen-4.0-generate-001-gt-128k | Imagen 4.0 Generate | same as lte |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4.0 Ultra Generate | $0.06/image (image_pricing); input/output 0 |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4.0 Ultra Generate | same as lte |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4.0 Fast Generate | $0.02/image (image_pricing); input/output 0 |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4.0 Fast Generate | same as lte |
| veo-2.0-generate-001-lte-128k | Veo 2.0 Generate (video only, 720p) | video_seconds: 50¢/s ($0.50/s); default_duration_seconds:8, default_sample_count:1 |
| veo-2.0-generate-001-gt-128k | Veo 2.0 Generate | same as lte |
| veo-3.0-generate-001-lte-128k | Veo 3.0 Generate (video only, 720p/1080p) | video_seconds: 20¢/s ($0.20/s); default_duration_seconds:8, default_sample_count:1 |
| veo-3.0-generate-001-gt-128k | Veo 3.0 Generate | same as lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3.0 Fast Generate (video only, 720p) | video_seconds: 8¢/s ($0.08/s); default_duration_seconds:8, default_sample_count:1 |
| veo-3.0-fast-generate-001-gt-128k | Veo 3.0 Fast Generate | same as lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 Generate Preview (video only, 720p/1080p) | video_seconds: 20¢/s ($0.20/s); default_duration_seconds:8, default_sample_count:1 |
| veo-3.1-generate-preview-gt-128k | Veo 3.1 Generate Preview | same as lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast Generate Preview (video only, 720p) | video_seconds: 8¢/s ($0.08/s); default_duration_seconds:8, default_sample_count:1 |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast Generate Preview | same as lte |
| veo-3.1-lite-generate-preview-lte-128k | Veo 3.1 Lite Generate Preview (video only, 720p) | video_seconds: 3¢/s ($0.03/s); default_duration_seconds:8, default_sample_count:1 |
| veo-3.1-lite-generate-preview-gt-128k | Veo 3.1 Lite Generate Preview | same as lte |

### Data source notes

- Pricing sourced from Google Cloud Vertex AI Generative AI pricing page: https://cloud.google.com/vertex-ai/generative-ai/pricing
- Context tier breakpoints on source page are **200k tokens** (≤200k / >200k); mapped to skill's -lte-128k / -gt-128k suffix convention
- Models with flat pricing (Gemini 2.0, 2.5 Flash/Lite, 3 Flash, 3.1 Flash Lite, all image/Veo/Imagen models) have identical prices for both lte and gt entries
- Gemini 2.5 Pro and Gemini 3.x Pro models have explicit context-length tiered pricing
- *-latest alias resolution: gemini-pro-latest → gemini-3.1-pro-preview; gemini-flash-latest → gemini-3-flash-preview; gemini-flash-lite-latest → gemini-3.1-flash-lite-preview (all resolved from live pricing page)
- nano-banana-pro-preview is treated as an alias for gemini-3-pro-image-preview with identical pricing
- Web search grounding: Gemini 2.0/2.5 models: $35/1K prompts = 3.5¢/prompt; Gemini 3.x models: $14/1K queries = 1.4¢/query
- Batch pricing (batch_config) included for all eligible models where the page lists batch rates
- Veo pricing uses video-only 720p rates as the baseline (most conservative/standard tier)

---
*Generated by Pricing Agent on 2026-04-15*