### PR TITLE
Add multi-layer custom_pricing for Vertex AI models

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -3260,32 +3260,5 @@
         "tools"
       ]
     }
-  },
-  "claude-sonnet-4-5@20250929": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
-  },
-  "claude-haiku-4-5@20251001": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
-  },
-  "claude-opus-4-5@20251101": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
   }
 }

--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -3,20 +3,61 @@
   "description": "",
   "default": {
     "params": [
-      { "key": "max_tokens", "defaultValue": 256, "minValue": 1, "maxValue": 32768 },
-      { "key": "temperature", "defaultValue": 0.7, "minValue": 0, "maxValue": 2 },
-      { "key": "top_p", "defaultValue": 1, "minValue": 0, "maxValue": 1 },
-      { "key": "n", "defaultValue": 1, "minValue": 1, "maxValue": 10 },
-      { "key": "stop", "defaultValue": null, "type": "array-of-strings", "skipValues": [null, []] },
-      { "key": "stream", "defaultValue": true, "type": "boolean" },
+      {
+        "key": "max_tokens",
+        "defaultValue": 256,
+        "minValue": 1,
+        "maxValue": 32768
+      },
+      {
+        "key": "temperature",
+        "defaultValue": 0.7,
+        "minValue": 0,
+        "maxValue": 2
+      },
+      {
+        "key": "top_p",
+        "defaultValue": 1,
+        "minValue": 0,
+        "maxValue": 1
+      },
+      {
+        "key": "n",
+        "defaultValue": 1,
+        "minValue": 1,
+        "maxValue": 10
+      },
+      {
+        "key": "stop",
+        "defaultValue": null,
+        "type": "array-of-strings",
+        "skipValues": [
+          null,
+          []
+        ]
+      },
+      {
+        "key": "stream",
+        "defaultValue": true,
+        "type": "boolean"
+      },
       {
         "key": "tool_choice",
         "type": "non-view-manage-data",
         "defaultValue": null,
         "options": [
-          { "value": "none", "name": "None" },
-          { "value": "auto", "name": "Auto" },
-          { "value": "required", "name": "Required" },
+          {
+            "value": "none",
+            "name": "None"
+          },
+          {
+            "value": "auto",
+            "name": "Auto"
+          },
+          {
+            "value": "required",
+            "name": "Required"
+          },
           {
             "value": "custom",
             "name": "Custom",
@@ -25,7 +66,10 @@
             }
           }
         ],
-        "skipValues": [null, []],
+        "skipValues": [
+          null,
+          []
+        ],
         "rule": {
           "default": {
             "condition": "tools",
@@ -35,67 +79,168 @@
         }
       }
     ],
-    "messages": { "options": ["system", "user", "assistant"] },
-    "type": { "primary": "chat", "supported": ["mime_type"] }
+    "messages": {
+      "options": [
+        "system",
+        "user",
+        "assistant"
+      ]
+    },
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "mime_type"
+      ]
+    }
   },
-
   "gemma-7b-it": {
     "name": "gemma-7b-it",
-    "params": [{ "key": "max_tokens", "maxValue": 4096 }],
-    "type": { "primary": "chat" }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 4096
+      }
+    ],
+    "type": {
+      "primary": "chat"
+    }
   },
   "llama3-8b-8192": {
     "name": "llama3-8b-8192",
-    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
-    "type": { "primary": "chat" }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      }
+    ],
+    "type": {
+      "primary": "chat"
+    }
   },
   "llama3-70b-8192": {
     "name": "llama3-70b-8192",
-    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
-    "type": { "primary": "chat" }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      }
+    ],
+    "type": {
+      "primary": "chat"
+    }
   },
-
   "anthropic.claude-3-haiku@20240307": {
     "name": "claude-3-haiku@20240307",
-    "params": [{ "key": "max_tokens", "maxValue": 4096 }],
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 4096
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "anthropic.claude-3-sonnet@20240229": {
     "name": "claude-3-sonnet@20240229",
-    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "anthropic.claude-3-opus@20240229": {
     "name": "claude-3-opus@20240229",
-    "params": [{ "key": "max_tokens", "maxValue": 32768 }],
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "anthropic.claude-3-5-sonnet@20240620": {
     "name": "claude-3-5-sonnet@20240620",
-    "params": [{ "key": "max_tokens", "maxValue": 16384 }],
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 16384
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
-
   "anthropic.claude-3-5-sonnet-v2@20241022": {
     "name": "claude-3-5-sonnet-v2@20241022",
-    "params": [{ "key": "max_tokens", "maxValue": 16384 }],
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 16384
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "anthropic.claude-3-5-haiku@20241022": {
     "name": "claude-3-5-haiku@20241022",
-    "params": [{ "key": "max_tokens", "maxValue": 4096 }],
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 4096
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "anthropic.claude-3-7-sonnet@20250219": {
     "name": "claude-3-7-sonnet@20250219",
     "params": [
-      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -104,37 +249,82 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": ["top_k", "top_p"],
-        "skipValues": ["disabled", null]
+        "withdrawParams": [
+          "top_k",
+          "top_p"
+        ],
+        "skipValues": [
+          "disabled",
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
-
   "meta.llama-3.1-405b-instruct-maas": {
     "name": "llama-3.1-405b-instruct-maas",
-    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
-    "type": { "primary": "chat" }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      }
+    ],
+    "type": {
+      "primary": "chat"
+    }
   },
   "meta.llama-3.1-70b-instruct-maas": {
     "name": "llama-3.1-70b-instruct-maas",
-    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
-    "type": { "primary": "chat" }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      }
+    ],
+    "type": {
+      "primary": "chat"
+    }
   },
   "meta.llama-3.1-8b-instruct-maas": {
     "name": "llama-3.1-8b-instruct-maas",
-    "params": [{ "key": "max_tokens", "maxValue": 4096 }],
-    "type": { "primary": "chat" }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 4096
+      }
+    ],
+    "type": {
+      "primary": "chat"
+    }
   },
   "meta.llama-3.2-90b-vision-instruct-maas": {
     "name": "llama-3.2-90b-vision-instruct-maas",
-    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
-    "type": { "primary": "chat", "supported": ["image"] }
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
   },
   "gemini-1.5-flash-001": {
     "name": "gemini-1.5-flash-001",
     "params": [
-      { "key": "max_tokens", "maxValue": 4096 },
+      {
+        "key": "max_tokens",
+        "maxValue": 4096
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -149,7 +339,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -159,23 +352,48 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-1.5-flash-preview-0514": {
     "name": "gemini-1.5-flash-preview-0514",
     "params": [
-      { "key": "max_tokens", "maxValue": 8192 },
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -190,7 +408,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -200,23 +421,48 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-1.5-flash-002": {
     "name": "gemini-1.5-flash-002",
     "params": [
-      { "key": "max_tokens", "maxValue": 8192 },
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -231,7 +477,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -241,23 +490,48 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-1.5-pro-001": {
     "name": "gemini-1.5-pro-001",
     "params": [
-      { "key": "max_tokens", "maxValue": 4096 },
+      {
+        "key": "max_tokens",
+        "maxValue": 4096
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -272,7 +546,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -282,23 +559,48 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-1.5-pro-preview-0514": {
     "name": "gemini-1.5-pro-preview-0514",
     "params": [
-      { "key": "max_tokens", "maxValue": 4096 },
+      {
+        "key": "max_tokens",
+        "maxValue": 4096
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -313,7 +615,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -323,23 +628,48 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-1.5-pro-preview-0409": {
     "name": "gemini-1.5-pro-preview-0409",
     "params": [
-      { "key": "max_tokens", "maxValue": 4096 },
+      {
+        "key": "max_tokens",
+        "maxValue": 4096
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -354,7 +684,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -364,23 +697,48 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-1.5-pro-002": {
     "name": "gemini-1.5-pro-002",
     "params": [
-      { "key": "max_tokens", "maxValue": 8192 },
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -395,7 +753,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -405,22 +766,47 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.5-pro-exp-03-25": {
     "params": [
-      { "key": "max_tokens", "maxValue": 8192 },
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -435,7 +821,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -445,23 +834,48 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.0-flash-exp": {
     "name": "gemini-2.0-flash-exp",
     "params": [
-      { "key": "max_tokens", "maxValue": 8192 },
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -476,7 +890,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -486,23 +903,48 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.0-flash-001": {
     "name": "gemini-2.0-flash-001",
     "params": [
-      { "key": "max_tokens", "maxValue": 8192 },
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -517,7 +959,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -527,40 +972,105 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.0-flash-thinking-exp-01-21": {
-    "removeParams": ["temperature", "top_p", "n", "stop", "stream", "max_tokens"],
-    "type": { "primary": "chat" },
-    "params": [{ "key": "max_completion_tokens", "defaultValue": 1000, "minValue": 1, "maxValue": 8192 }]
+    "removeParams": [
+      "temperature",
+      "top_p",
+      "n",
+      "stop",
+      "stream",
+      "max_tokens"
+    ],
+    "type": {
+      "primary": "chat"
+    },
+    "params": [
+      {
+        "key": "max_completion_tokens",
+        "defaultValue": 1000,
+        "minValue": 1,
+        "maxValue": 8192
+      }
+    ]
   },
   "gemini-2.0-flash-lite-preview-02-05": {
     "name": "gemini-2.0-flash-lite-preview-02-05",
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.0-flash-lite-001": {
     "name": "gemini-2.0-flash-lite-001",
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.0-flash-lite": {
     "name": "gemini-2.0-flash-lite",
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.5-pro-preview-03-25": {
     "name": "gemini-2.5-pro-preview-03-25",
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -575,7 +1085,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -585,23 +1098,48 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.5-flash-preview-04-17": {
     "name": "gemini-2.5-flash-preview-04-17",
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -616,7 +1154,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -626,14 +1167,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -641,7 +1196,10 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -650,21 +1208,37 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "anthropic.claude-opus-4@20250514": {
     "name": "claude-opus-4@20250514",
     "params": [
-      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -673,22 +1247,40 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": ["top_k", "top_p"],
-        "skipValues": ["disabled", null]
+        "withdrawParams": [
+          "top_k",
+          "top_p"
+        ],
+        "skipValues": [
+          "disabled",
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "anthropic.claude-sonnet-4@20250514": {
     "name": "claude-sonnet-4@20250514",
     "params": [
-      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -697,15 +1289,30 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": ["top_k", "top_p"],
-        "skipValues": ["disabled", null]
+        "withdrawParams": [
+          "top_k",
+          "top_p"
+        ],
+        "skipValues": [
+          "disabled",
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "gemini-2.5-pro-preview-05-06": {
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -720,7 +1327,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -730,14 +1340,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -745,7 +1369,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled"]
+            "enum": [
+              "enabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -754,14 +1380,27 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.5-flash-preview-05-20": {
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -776,7 +1415,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -786,14 +1428,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -801,7 +1457,10 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -810,14 +1469,27 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.5-pro": {
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -832,7 +1504,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -842,14 +1517,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -857,7 +1546,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled"]
+            "enum": [
+              "enabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -866,15 +1557,28 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.5-flash": {
     "name": "gemini-2.5-flash",
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -889,7 +1593,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -899,14 +1606,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -914,7 +1635,10 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -923,42 +1647,69 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.5-flash-tts": {
-    "type": { "primary": "audio" },
+    "type": {
+      "primary": "audio"
+    },
     "disablePlayground": true
   },
   "gemini-2.5-flash-lite-preview-tts": {
-    "type": { "primary": "audio" },
+    "type": {
+      "primary": "audio"
+    },
     "disablePlayground": true
   },
   "gemini-2.5-pro-tts": {
-    "type": { "primary": "audio" },
+    "type": {
+      "primary": "audio"
+    },
     "disablePlayground": true
   },
   "imagen-4.0-fast-generate-001": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": {
+      "primary": "text"
+    }
   },
   "imagen-4.0-generate-001": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": {
+      "primary": "text"
+    }
   },
   "imagen-4.0-ultra-generate-001": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": {
+      "primary": "text"
+    }
   },
   "imagen-3.0-generate-002": {
     "disablePlayground": true,
-    "type": { "primary": "text" }
+    "type": {
+      "primary": "text"
+    }
   },
   "gemini-2.5-flash-lite-preview-06-17": {
     "params": [
-      { "key": "max_tokens", "maxValue": 64000 },
+      {
+        "key": "max_tokens",
+        "maxValue": 64000
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -973,7 +1724,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -983,14 +1737,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -998,7 +1766,10 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1007,14 +1778,27 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.5-flash-lite": {
     "params": [
-      { "key": "max_tokens", "maxValue": 64000 },
+      {
+        "key": "max_tokens",
+        "maxValue": 64000
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1029,7 +1813,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -1039,14 +1826,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -1054,7 +1855,10 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1063,21 +1867,37 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "anthropic.claude-opus-4-1@20250805": {
     "name": "claude-opus-4-1@20250805",
     "params": [
-      { "key": "max_tokens", "maxValue": 32000 },
+      {
+        "key": "max_tokens",
+        "maxValue": 32000
+      },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1086,34 +1906,58 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": ["top_k", "top_p"],
-        "skipValues": ["disabled", null]
+        "withdrawParams": [
+          "top_k",
+          "top_p"
+        ],
+        "skipValues": [
+          "disabled",
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "gemini-embedding-001": {
-    "type": { "primary": "embedding" },
+    "type": {
+      "primary": "embedding"
+    },
     "disablePlayground": true
   },
   "gemini-2.5-flash-image-preview": {
-    "type": { "primary": "chat" },
+    "type": {
+      "primary": "chat"
+    },
     "disablePlayground": true
   },
   "gemini-3.1-flash-image-preview": {
-    "type": { "primary": "chat" },
+    "type": {
+      "primary": "chat"
+    },
     "disablePlayground": true
   },
   "anthropic.claude-sonnet-4-5@20250929": {
     "name": "claude-sonnet-4-5@20250929",
     "params": [
-      { "key": "max_tokens", "maxValue": 64000 },
+      {
+        "key": "max_tokens",
+        "maxValue": 64000
+      },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1122,22 +1966,42 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": ["top_k", "top_p"],
-        "skipValues": ["disabled", null]
+        "withdrawParams": [
+          "top_k",
+          "top_p"
+        ],
+        "skipValues": [
+          "disabled",
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["top_p"]
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "removeParams": [
+      "top_p"
+    ]
   },
   "anthropic.claude-haiku-4-5@20251001": {
     "params": [
-      { "key": "max_tokens", "maxValue": 64000 },
+      {
+        "key": "max_tokens",
+        "maxValue": 64000
+      },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1146,16 +2010,33 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": ["top_k", "top_p"],
-        "skipValues": ["disabled", null]
+        "withdrawParams": [
+          "top_k",
+          "top_p"
+        ],
+        "skipValues": [
+          "disabled",
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["top_p"]
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "removeParams": [
+      "top_p"
+    ]
   },
   "gemini-3-pro-preview": {
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1170,7 +2051,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -1180,14 +2064,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -1195,7 +2093,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled"]
+            "enum": [
+              "enabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1204,14 +2104,27 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-3-pro-preview-02-05": {
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1226,7 +2139,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -1236,14 +2152,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -1251,7 +2181,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled"]
+            "enum": [
+              "enabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1260,20 +2192,36 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "anthropic.claude-opus-4-5@20251101": {
     "params": [
-      { "key": "max_tokens", "maxValue": 64000 },
+      {
+        "key": "max_tokens",
+        "maxValue": 64000
+      },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1282,15 +2230,32 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": ["top_k", "top_p"],
-        "skipValues": ["disabled", null]
+        "withdrawParams": [
+          "top_k",
+          "top_p"
+        ],
+        "skipValues": [
+          "disabled",
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["temperature", "top_p"]
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "removeParams": [
+      "temperature",
+      "top_p"
+    ]
   },
   "gemini-3-pro-image-preview": {
-    "type": { "primary": "chat" },
+    "type": {
+      "primary": "chat"
+    },
     "disablePlayground": true
   },
   "claude-3-7-sonnet-v2@20250219": {
@@ -1536,7 +2501,10 @@
   "gemini-3-flash-preview": {
     "name": "gemini-3-flash-preview",
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1551,7 +2519,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -1561,14 +2532,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -1576,7 +2561,10 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1585,10 +2573,20 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "anthropic.claude-opus-4-6": {
     "params": [
@@ -1601,7 +2599,10 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1610,15 +2611,27 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": ["top_k", "top_p"],
-        "skipValues": ["disabled", null]
+        "withdrawParams": [
+          "top_k",
+          "top_p"
+        ],
+        "skipValues": [
+          "disabled",
+          null
+        ]
       }
     ],
     "type": {
       "primary": "chat",
-      "supported": ["image", "tools"]
+      "supported": [
+        "image",
+        "tools"
+      ]
     },
-    "removeParams": ["temperature", "top_p"]
+    "removeParams": [
+      "temperature",
+      "top_p"
+    ]
   },
   "anthropic.claude-sonnet-4-6": {
     "params": [
@@ -1631,7 +2644,10 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled", "disabled"]
+            "enum": [
+              "enabled",
+              "disabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1640,19 +2656,34 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": ["top_k", "top_p"],
-        "skipValues": ["disabled", null]
+        "withdrawParams": [
+          "top_k",
+          "top_p"
+        ],
+        "skipValues": [
+          "disabled",
+          null
+        ]
       }
     ],
     "type": {
       "primary": "chat",
-      "supported": ["image", "tools"]
+      "supported": [
+        "image",
+        "tools"
+      ]
     },
-    "removeParams": ["temperature", "top_p"]
+    "removeParams": [
+      "temperature",
+      "top_p"
+    ]
   },
   "gemini-3.1-pro-preview": {
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1667,7 +2698,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -1677,14 +2711,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -1692,7 +2740,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled"]
+            "enum": [
+              "enabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1701,15 +2751,28 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-3.1-flash-lite-preview": {
     "name": "gemini-3.1-flash-lite-preview",
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1724,7 +2787,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -1734,22 +2800,47 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-3.1-pro-preview-customtools": {
     "params": [
-      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1764,7 +2855,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
               }
             }
           },
@@ -1774,14 +2868,28 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": { "type": "string", "value": "json_schema" },
-                "json_schema": { "type": "object" }
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
               }
             },
-            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [
+                null
+              ]
+            }
           }
         ],
-        "skipValues": [null],
+        "skipValues": [
+          null
+        ],
         "type": "string"
       },
       {
@@ -1789,7 +2897,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["enabled"]
+            "enum": [
+              "enabled"
+            ]
           },
           "budget_tokens": {
             "type": "number",
@@ -1798,28 +2908,47 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [null]
+        "skipValues": [
+          null
+        ]
       }
     ],
-    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "pdf",
+        "doc",
+        "tools"
+      ]
+    }
   },
   "gemini-2.5-flash-preview-09-2025": {
     "type": {
       "primary": "chat",
-      "supported": ["tools", "image"]
+      "supported": [
+        "tools",
+        "image"
+      ]
     }
   },
   "gemini-2.5-flash-lite-preview-09-2025": {
     "type": {
       "primary": "chat",
-      "supported": ["tools", "image"]
+      "supported": [
+        "tools",
+        "image"
+      ]
     }
   },
   "gemini-2.5-computer-use-preview-10-2025": {
     "disablePlayground": true,
     "type": {
       "primary": "chat",
-      "supported": ["tools", "image"]
+      "supported": [
+        "tools",
+        "image"
+      ]
     }
   },
   "gemini-embedding-2-preview": {
@@ -1855,37 +2984,50 @@
   "gpt-oss-120b-maas": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "llama-3.3-70b-instruct-maas": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "llama-4-maverick-17b-128e-instruct-maas": {
     "type": {
       "primary": "chat",
-      "supported": ["tools", "image"]
+      "supported": [
+        "tools",
+        "image"
+      ]
     }
   },
   "mistral-small-2503": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "mistral-medium-3": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "codestral-2": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "deepseek-r1-0528-maas": {
@@ -1896,37 +3038,49 @@
   "deepseek-v3.1-maas": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "deepseek-v3.2-maas": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "jamba-large-1.6": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "qwen3-235b-a22b-instruct-2507-maas": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "qwen3-coder-480b-a35b-instruct-maas": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "qwen3-next-80b-a3b-instruct-maas": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "qwen3-next-80b-a3b-thinking-maas": {
@@ -1937,7 +3091,9 @@
   "minimax-m2-maas": {
     "type": {
       "primary": "chat",
-      "supported": ["tools"]
+      "supported": [
+        "tools"
+      ]
     }
   },
   "kimi-k2-thinking-maas": {
@@ -1956,65 +3112,180 @@
     }
   },
   "claude-opus-4-1-20250805": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "claude-opus-4-20250514": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "claude-sonnet-4-20250514": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "claude-haiku-4-5": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "claude-opus-4-5": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "claude-sonnet-4-5": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "gemini-2.0-flash-preview-image-generation": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
     "disablePlayground": true
   },
   "gemma-4-26b-it": {
-    "type": { "primary": "chat" }
+    "type": {
+      "primary": "chat"
+    }
   },
   "gpt-oss-20b-maas": {
-    "type": { "primary": "chat" }
+    "type": {
+      "primary": "chat"
+    }
   },
   "grok-4.20-maas": {
-    "type": { "primary": "chat" }
+    "type": {
+      "primary": "chat"
+    }
   },
   "grok-4.1-fast-maas": {
-    "type": { "primary": "chat" }
+    "type": {
+      "primary": "chat"
+    }
   },
   "deepseek-ocr-maas": {
-    "type": { "primary": "chat" }
+    "type": {
+      "primary": "chat"
+    }
   },
   "mistral-ocr-2505": {
-    "type": { "primary": "chat" }
+    "type": {
+      "primary": "chat"
+    }
   },
   "llama-4-scout-17b-16e-instruct-maas": {
-    "type": { "primary": "chat" }
+    "type": {
+      "primary": "chat"
+    }
   },
   "veo-3.1-lite-generate-preview": {
-    "type": { "primary": "image" },
+    "type": {
+      "primary": "image"
+    },
     "disablePlayground": true
   },
   "claude-opus-4-6": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "claude-sonnet-4-6": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "claude-opus-4-5-20251101": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "claude-sonnet-4-5-20250929": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   },
   "claude-haiku-4-5-20251001": {
-    "type": { "primary": "chat", "supported": ["image", "tools"] }
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
+  },
+  "claude-sonnet-4-5@20250929": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
+  },
+  "claude-haiku-4-5@20251001": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
+  },
+  "claude-opus-4-5@20251101": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
   }
 }

--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1976,5 +1976,45 @@
   "gemini-2.0-flash-preview-image-generation": {
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
+  },
+  "gemma-4-26b-it": {
+    "type": { "primary": "chat" }
+  },
+  "gpt-oss-20b-maas": {
+    "type": { "primary": "chat" }
+  },
+  "grok-4.20-maas": {
+    "type": { "primary": "chat" }
+  },
+  "grok-4.1-fast-maas": {
+    "type": { "primary": "chat" }
+  },
+  "deepseek-ocr-maas": {
+    "type": { "primary": "chat" }
+  },
+  "mistral-ocr-2505": {
+    "type": { "primary": "chat" }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "type": { "primary": "chat" }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": { "primary": "image" },
+    "disablePlayground": true
+  },
+  "claude-opus-4-6": {
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
+  },
+  "claude-sonnet-4-6": {
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
+  },
+  "claude-opus-4-5-20251101": {
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
+  },
+  "claude-sonnet-4-5-20250929": {
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
+  },
+  "claude-haiku-4-5-20251001": {
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   }
 }

--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -3,61 +3,20 @@
   "description": "",
   "default": {
     "params": [
-      {
-        "key": "max_tokens",
-        "defaultValue": 256,
-        "minValue": 1,
-        "maxValue": 32768
-      },
-      {
-        "key": "temperature",
-        "defaultValue": 0.7,
-        "minValue": 0,
-        "maxValue": 2
-      },
-      {
-        "key": "top_p",
-        "defaultValue": 1,
-        "minValue": 0,
-        "maxValue": 1
-      },
-      {
-        "key": "n",
-        "defaultValue": 1,
-        "minValue": 1,
-        "maxValue": 10
-      },
-      {
-        "key": "stop",
-        "defaultValue": null,
-        "type": "array-of-strings",
-        "skipValues": [
-          null,
-          []
-        ]
-      },
-      {
-        "key": "stream",
-        "defaultValue": true,
-        "type": "boolean"
-      },
+      { "key": "max_tokens", "defaultValue": 256, "minValue": 1, "maxValue": 32768 },
+      { "key": "temperature", "defaultValue": 0.7, "minValue": 0, "maxValue": 2 },
+      { "key": "top_p", "defaultValue": 1, "minValue": 0, "maxValue": 1 },
+      { "key": "n", "defaultValue": 1, "minValue": 1, "maxValue": 10 },
+      { "key": "stop", "defaultValue": null, "type": "array-of-strings", "skipValues": [null, []] },
+      { "key": "stream", "defaultValue": true, "type": "boolean" },
       {
         "key": "tool_choice",
         "type": "non-view-manage-data",
         "defaultValue": null,
         "options": [
-          {
-            "value": "none",
-            "name": "None"
-          },
-          {
-            "value": "auto",
-            "name": "Auto"
-          },
-          {
-            "value": "required",
-            "name": "Required"
-          },
+          { "value": "none", "name": "None" },
+          { "value": "auto", "name": "Auto" },
+          { "value": "required", "name": "Required" },
           {
             "value": "custom",
             "name": "Custom",
@@ -66,10 +25,7 @@
             }
           }
         ],
-        "skipValues": [
-          null,
-          []
-        ],
+        "skipValues": [null, []],
         "rule": {
           "default": {
             "condition": "tools",
@@ -79,168 +35,67 @@
         }
       }
     ],
-    "messages": {
-      "options": [
-        "system",
-        "user",
-        "assistant"
-      ]
-    },
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "mime_type"
-      ]
-    }
+    "messages": { "options": ["system", "user", "assistant"] },
+    "type": { "primary": "chat", "supported": ["mime_type"] }
   },
+
   "gemma-7b-it": {
     "name": "gemma-7b-it",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 4096
-      }
-    ],
-    "type": {
-      "primary": "chat"
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 4096 }],
+    "type": { "primary": "chat" }
   },
   "llama3-8b-8192": {
     "name": "llama3-8b-8192",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      }
-    ],
-    "type": {
-      "primary": "chat"
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
+    "type": { "primary": "chat" }
   },
   "llama3-70b-8192": {
     "name": "llama3-70b-8192",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      }
-    ],
-    "type": {
-      "primary": "chat"
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
+    "type": { "primary": "chat" }
   },
+
   "anthropic.claude-3-haiku@20240307": {
     "name": "claude-3-haiku@20240307",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 4096
-      }
-    ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 4096 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "anthropic.claude-3-sonnet@20240229": {
     "name": "claude-3-sonnet@20240229",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      }
-    ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "anthropic.claude-3-opus@20240229": {
     "name": "claude-3-opus@20240229",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 32768
-      }
-    ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 32768 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "anthropic.claude-3-5-sonnet@20240620": {
     "name": "claude-3-5-sonnet@20240620",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 16384
-      }
-    ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 16384 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
+
   "anthropic.claude-3-5-sonnet-v2@20241022": {
     "name": "claude-3-5-sonnet-v2@20241022",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 16384
-      }
-    ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 16384 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "anthropic.claude-3-5-haiku@20241022": {
     "name": "claude-3-5-haiku@20241022",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 4096
-      }
-    ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 4096 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "anthropic.claude-3-7-sonnet@20250219": {
     "name": "claude-3-7-sonnet@20250219",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 128000
-      },
+      { "key": "max_tokens", "maxValue": 128000 },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -249,82 +104,37 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": [
-          "top_k",
-          "top_p"
-        ],
-        "skipValues": [
-          "disabled",
-          null
-        ]
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
+
   "meta.llama-3.1-405b-instruct-maas": {
     "name": "llama-3.1-405b-instruct-maas",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      }
-    ],
-    "type": {
-      "primary": "chat"
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
+    "type": { "primary": "chat" }
   },
   "meta.llama-3.1-70b-instruct-maas": {
     "name": "llama-3.1-70b-instruct-maas",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      }
-    ],
-    "type": {
-      "primary": "chat"
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
+    "type": { "primary": "chat" }
   },
   "meta.llama-3.1-8b-instruct-maas": {
     "name": "llama-3.1-8b-instruct-maas",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 4096
-      }
-    ],
-    "type": {
-      "primary": "chat"
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 4096 }],
+    "type": { "primary": "chat" }
   },
   "meta.llama-3.2-90b-vision-instruct-maas": {
     "name": "llama-3.2-90b-vision-instruct-maas",
-    "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      }
-    ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image"
-      ]
-    }
+    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
+    "type": { "primary": "chat", "supported": ["image"] }
   },
   "gemini-1.5-flash-001": {
     "name": "gemini-1.5-flash-001",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 4096
-      },
+      { "key": "max_tokens", "maxValue": 4096 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -339,10 +149,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -352,48 +159,23 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-1.5-flash-preview-0514": {
     "name": "gemini-1.5-flash-preview-0514",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      },
+      { "key": "max_tokens", "maxValue": 8192 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -408,10 +190,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -421,48 +200,23 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-1.5-flash-002": {
     "name": "gemini-1.5-flash-002",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      },
+      { "key": "max_tokens", "maxValue": 8192 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -477,10 +231,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -490,48 +241,23 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-1.5-pro-001": {
     "name": "gemini-1.5-pro-001",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 4096
-      },
+      { "key": "max_tokens", "maxValue": 4096 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -546,10 +272,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -559,48 +282,23 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-1.5-pro-preview-0514": {
     "name": "gemini-1.5-pro-preview-0514",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 4096
-      },
+      { "key": "max_tokens", "maxValue": 4096 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -615,10 +313,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -628,48 +323,23 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-1.5-pro-preview-0409": {
     "name": "gemini-1.5-pro-preview-0409",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 4096
-      },
+      { "key": "max_tokens", "maxValue": 4096 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -684,10 +354,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -697,48 +364,23 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-1.5-pro-002": {
     "name": "gemini-1.5-pro-002",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      },
+      { "key": "max_tokens", "maxValue": 8192 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -753,10 +395,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -766,47 +405,22 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.5-pro-exp-03-25": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      },
+      { "key": "max_tokens", "maxValue": 8192 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -821,10 +435,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -834,48 +445,23 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.0-flash-exp": {
     "name": "gemini-2.0-flash-exp",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      },
+      { "key": "max_tokens", "maxValue": 8192 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -890,10 +476,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -903,48 +486,23 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.0-flash-001": {
     "name": "gemini-2.0-flash-001",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 8192
-      },
+      { "key": "max_tokens", "maxValue": 8192 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -959,10 +517,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -972,105 +527,40 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.0-flash-thinking-exp-01-21": {
-    "removeParams": [
-      "temperature",
-      "top_p",
-      "n",
-      "stop",
-      "stream",
-      "max_tokens"
-    ],
-    "type": {
-      "primary": "chat"
-    },
-    "params": [
-      {
-        "key": "max_completion_tokens",
-        "defaultValue": 1000,
-        "minValue": 1,
-        "maxValue": 8192
-      }
-    ]
+    "removeParams": ["temperature", "top_p", "n", "stop", "stream", "max_tokens"],
+    "type": { "primary": "chat" },
+    "params": [{ "key": "max_completion_tokens", "defaultValue": 1000, "minValue": 1, "maxValue": 8192 }]
   },
   "gemini-2.0-flash-lite-preview-02-05": {
     "name": "gemini-2.0-flash-lite-preview-02-05",
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.0-flash-lite-001": {
     "name": "gemini-2.0-flash-lite-001",
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.0-flash-lite": {
     "name": "gemini-2.0-flash-lite",
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.5-pro-preview-03-25": {
     "name": "gemini-2.5-pro-preview-03-25",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1085,10 +575,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -1098,48 +585,23 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.5-flash-preview-04-17": {
     "name": "gemini-2.5-flash-preview-04-17",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1154,10 +616,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -1167,28 +626,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -1196,10 +641,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -1208,37 +650,21 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "anthropic.claude-opus-4@20250514": {
     "name": "claude-opus-4@20250514",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 128000
-      },
+      { "key": "max_tokens", "maxValue": 128000 },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -1247,40 +673,22 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": [
-          "top_k",
-          "top_p"
-        ],
-        "skipValues": [
-          "disabled",
-          null
-        ]
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "anthropic.claude-sonnet-4@20250514": {
     "name": "claude-sonnet-4@20250514",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 128000
-      },
+      { "key": "max_tokens", "maxValue": 128000 },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -1289,30 +697,15 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": [
-          "top_k",
-          "top_p"
-        ],
-        "skipValues": [
-          "disabled",
-          null
-        ]
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "gemini-2.5-pro-preview-05-06": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1327,10 +720,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -1340,28 +730,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -1369,9 +745,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled"
-            ]
+            "enum": ["enabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -1380,27 +754,14 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.5-flash-preview-05-20": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1415,10 +776,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -1428,28 +786,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -1457,10 +801,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -1469,27 +810,14 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.5-pro": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1504,10 +832,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -1517,28 +842,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -1546,9 +857,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled"
-            ]
+            "enum": ["enabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -1557,28 +866,15 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.5-flash": {
     "name": "gemini-2.5-flash",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1593,10 +889,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -1606,28 +899,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -1635,10 +914,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -1647,69 +923,42 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.5-flash-tts": {
-    "type": {
-      "primary": "audio"
-    },
+    "type": { "primary": "audio" },
     "disablePlayground": true
   },
   "gemini-2.5-flash-lite-preview-tts": {
-    "type": {
-      "primary": "audio"
-    },
+    "type": { "primary": "audio" },
     "disablePlayground": true
   },
   "gemini-2.5-pro-tts": {
-    "type": {
-      "primary": "audio"
-    },
+    "type": { "primary": "audio" },
     "disablePlayground": true
   },
   "imagen-4.0-fast-generate-001": {
     "disablePlayground": true,
-    "type": {
-      "primary": "text"
-    }
+    "type": { "primary": "text" }
   },
   "imagen-4.0-generate-001": {
     "disablePlayground": true,
-    "type": {
-      "primary": "text"
-    }
+    "type": { "primary": "text" }
   },
   "imagen-4.0-ultra-generate-001": {
     "disablePlayground": true,
-    "type": {
-      "primary": "text"
-    }
+    "type": { "primary": "text" }
   },
   "imagen-3.0-generate-002": {
     "disablePlayground": true,
-    "type": {
-      "primary": "text"
-    }
+    "type": { "primary": "text" }
   },
   "gemini-2.5-flash-lite-preview-06-17": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 64000
-      },
+      { "key": "max_tokens", "maxValue": 64000 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1724,10 +973,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -1737,28 +983,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -1766,10 +998,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -1778,27 +1007,14 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.5-flash-lite": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 64000
-      },
+      { "key": "max_tokens", "maxValue": 64000 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -1813,10 +1029,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -1826,28 +1039,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -1855,10 +1054,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -1867,37 +1063,21 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "anthropic.claude-opus-4-1@20250805": {
     "name": "claude-opus-4-1@20250805",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 32000
-      },
+      { "key": "max_tokens", "maxValue": 32000 },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -1906,58 +1086,34 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": [
-          "top_k",
-          "top_p"
-        ],
-        "skipValues": [
-          "disabled",
-          null
-        ]
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "gemini-embedding-001": {
-    "type": {
-      "primary": "embedding"
-    },
+    "type": { "primary": "embedding" },
     "disablePlayground": true
   },
   "gemini-2.5-flash-image-preview": {
-    "type": {
-      "primary": "chat"
-    },
+    "type": { "primary": "chat" },
     "disablePlayground": true
   },
   "gemini-3.1-flash-image-preview": {
-    "type": {
-      "primary": "chat"
-    },
+    "type": { "primary": "chat" },
     "disablePlayground": true
   },
   "anthropic.claude-sonnet-4-5@20250929": {
     "name": "claude-sonnet-4-5@20250929",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 64000
-      },
+      { "key": "max_tokens", "maxValue": 64000 },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -1966,42 +1122,22 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": [
-          "top_k",
-          "top_p"
-        ],
-        "skipValues": [
-          "disabled",
-          null
-        ]
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    },
-    "removeParams": [
-      "top_p"
-    ]
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["top_p"]
   },
   "anthropic.claude-haiku-4-5@20251001": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 64000
-      },
+      { "key": "max_tokens", "maxValue": 64000 },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -2010,33 +1146,16 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": [
-          "top_k",
-          "top_p"
-        ],
-        "skipValues": [
-          "disabled",
-          null
-        ]
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    },
-    "removeParams": [
-      "top_p"
-    ]
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["top_p"]
   },
   "gemini-3-pro-preview": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -2051,10 +1170,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -2064,28 +1180,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -2093,9 +1195,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled"
-            ]
+            "enum": ["enabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -2104,27 +1204,14 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-3-pro-preview-02-05": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -2139,10 +1226,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -2152,28 +1236,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -2181,9 +1251,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled"
-            ]
+            "enum": ["enabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -2192,36 +1260,20 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "anthropic.claude-opus-4-5@20251101": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 64000
-      },
+      { "key": "max_tokens", "maxValue": 64000 },
       {
         "key": "thinking",
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -2230,32 +1282,15 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": [
-          "top_k",
-          "top_p"
-        ],
-        "skipValues": [
-          "disabled",
-          null
-        ]
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    },
-    "removeParams": [
-      "temperature",
-      "top_p"
-    ]
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["temperature", "top_p"]
   },
   "gemini-3-pro-image-preview": {
-    "type": {
-      "primary": "chat"
-    },
+    "type": { "primary": "chat" },
     "disablePlayground": true
   },
   "claude-3-7-sonnet-v2@20250219": {
@@ -2501,10 +1536,7 @@
   "gemini-3-flash-preview": {
     "name": "gemini-3-flash-preview",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -2519,10 +1551,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -2532,28 +1561,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -2561,10 +1576,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -2573,20 +1585,10 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "anthropic.claude-opus-4-6": {
     "params": [
@@ -2599,10 +1601,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -2611,27 +1610,15 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": [
-          "top_k",
-          "top_p"
-        ],
-        "skipValues": [
-          "disabled",
-          null
-        ]
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
       }
     ],
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
-    "removeParams": [
-      "temperature",
-      "top_p"
-    ]
+    "removeParams": ["temperature", "top_p"]
   },
   "anthropic.claude-sonnet-4-6": {
     "params": [
@@ -2644,10 +1631,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled",
-              "disabled"
-            ]
+            "enum": ["enabled", "disabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -2656,34 +1640,19 @@
           }
         },
         "defaultValue": null,
-        "withdrawParams": [
-          "top_k",
-          "top_p"
-        ],
-        "skipValues": [
-          "disabled",
-          null
-        ]
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
       }
     ],
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
-    "removeParams": [
-      "temperature",
-      "top_p"
-    ]
+    "removeParams": ["temperature", "top_p"]
   },
   "gemini-3.1-pro-preview": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -2698,10 +1667,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -2711,28 +1677,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -2740,9 +1692,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled"
-            ]
+            "enum": ["enabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -2751,28 +1701,15 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-3.1-flash-lite-preview": {
     "name": "gemini-3.1-flash-lite-preview",
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -2787,10 +1724,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -2800,47 +1734,22 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-3.1-pro-preview-customtools": {
     "params": [
-      {
-        "key": "max_tokens",
-        "maxValue": 65536
-      },
+      { "key": "max_tokens", "maxValue": 65536 },
       {
         "key": "response_format",
         "defaultValue": null,
@@ -2855,10 +1764,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_object"
-                }
+                "type": { "type": "string", "value": "json_object" }
               }
             }
           },
@@ -2868,28 +1774,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string",
-                  "value": "json_schema"
-                },
-                "json_schema": {
-                  "type": "object"
-                }
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
               }
             },
-            "params": {
-              "key": "json_schema",
-              "defaultValue": null,
-              "type": "json",
-              "skipValues": [
-                null
-              ]
-            }
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
           }
         ],
-        "skipValues": [
-          null
-        ],
+        "skipValues": [null],
         "type": "string"
       },
       {
@@ -2897,9 +1789,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "enabled"
-            ]
+            "enum": ["enabled"]
           },
           "budget_tokens": {
             "type": "number",
@@ -2908,47 +1798,28 @@
           }
         },
         "defaultValue": null,
-        "skipValues": [
-          null
-        ]
+        "skipValues": [null]
       }
     ],
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "pdf",
-        "doc",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
   "gemini-2.5-flash-preview-09-2025": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools",
-        "image"
-      ]
+      "supported": ["tools", "image"]
     }
   },
   "gemini-2.5-flash-lite-preview-09-2025": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools",
-        "image"
-      ]
+      "supported": ["tools", "image"]
     }
   },
   "gemini-2.5-computer-use-preview-10-2025": {
     "disablePlayground": true,
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools",
-        "image"
-      ]
+      "supported": ["tools", "image"]
     }
   },
   "gemini-embedding-2-preview": {
@@ -2984,50 +1855,37 @@
   "gpt-oss-120b-maas": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "llama-3.3-70b-instruct-maas": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "llama-4-maverick-17b-128e-instruct-maas": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools",
-        "image"
-      ]
+      "supported": ["tools", "image"]
     }
   },
   "mistral-small-2503": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "mistral-medium-3": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "codestral-2": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "deepseek-r1-0528-maas": {
@@ -3038,49 +1896,37 @@
   "deepseek-v3.1-maas": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "deepseek-v3.2-maas": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "jamba-large-1.6": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "qwen3-235b-a22b-instruct-2507-maas": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "qwen3-coder-480b-a35b-instruct-maas": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "qwen3-next-80b-a3b-instruct-maas": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "qwen3-next-80b-a3b-thinking-maas": {
@@ -3091,9 +1937,7 @@
   "minimax-m2-maas": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "kimi-k2-thinking-maas": {
@@ -3112,153 +1956,65 @@
     }
   },
   "claude-opus-4-1-20250805": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "claude-opus-4-20250514": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "claude-sonnet-4-20250514": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "claude-haiku-4-5": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "claude-opus-4-5": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "claude-sonnet-4-5": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "gemini-2.0-flash-preview-image-generation": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    },
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
     "disablePlayground": true
   },
   "gemma-4-26b-it": {
-    "type": {
-      "primary": "chat"
-    }
+    "type": { "primary": "chat" }
   },
   "gpt-oss-20b-maas": {
-    "type": {
-      "primary": "chat"
-    }
+    "type": { "primary": "chat" }
   },
   "grok-4.20-maas": {
-    "type": {
-      "primary": "chat"
-    }
+    "type": { "primary": "chat" }
   },
   "grok-4.1-fast-maas": {
-    "type": {
-      "primary": "chat"
-    }
+    "type": { "primary": "chat" }
   },
   "deepseek-ocr-maas": {
-    "type": {
-      "primary": "chat"
-    }
+    "type": { "primary": "chat" }
   },
   "mistral-ocr-2505": {
-    "type": {
-      "primary": "chat"
-    }
+    "type": { "primary": "chat" }
   },
   "llama-4-scout-17b-16e-instruct-maas": {
-    "type": {
-      "primary": "chat"
-    }
+    "type": { "primary": "chat" }
   },
   "veo-3.1-lite-generate-preview": {
-    "type": {
-      "primary": "image"
-    },
+    "type": { "primary": "image" },
     "disablePlayground": true
   },
   "claude-opus-4-6": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "claude-sonnet-4-6": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "claude-opus-4-5-20251101": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "claude-sonnet-4-5-20250929": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "claude-haiku-4-5-20251001": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
-    }
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -1805,7 +1805,13 @@
                     },
                     "maps": {
                       "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.012
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -1897,7 +1903,13 @@
                     },
                     "maps": {
                       "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.012
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -1986,7 +1998,13 @@
                     },
                     "maps": {
                       "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.006
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -2115,6 +2133,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -2207,6 +2228,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -2296,6 +2320,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -2933,6 +2960,9 @@
                     },
                     "maps": {
                       "price": 2.5
+                    },
+                    "image_token": {
+                      "price": 0.003
                     }
                   }
                 }
@@ -2965,6 +2995,9 @@
                     },
                     "maps": {
                       "price": 2.5
+                    },
+                    "image_token": {
+                      "price": 0.003
                     }
                   }
                 }
@@ -2994,6 +3027,9 @@
                     },
                     "maps": {
                       "price": 2.5
+                    },
+                    "image_token": {
+                      "price": 0.0015
                     }
                   }
                 }
@@ -4281,6 +4317,46 @@
               }
             }
           }
+        },
+        "asia-east1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000033
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0004125
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -4466,6 +4542,46 @@
                   },
                   "cache_write_input_token": {
                     "price": 0.000206
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-east1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000033
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0004125
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
                   }
                 }
               }
@@ -5368,6 +5484,46 @@
               }
             }
           }
+        },
+        "asia-east1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -5553,6 +5709,46 @@
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-east1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
                   }
                 }
               }
@@ -5782,6 +5978,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00005
                   }
                 }
               }
@@ -5814,6 +6013,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00005
                   }
                 }
               }
@@ -5843,6 +6045,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00005
                   }
                 }
               }
@@ -6038,6 +6243,46 @@
               }
             }
           }
+        },
+        "asia-east1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -6223,6 +6468,46 @@
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-east1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
                   }
                 }
               }
@@ -6418,6 +6703,46 @@
               }
             }
           }
+        },
+        "asia-east1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000033
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0004125
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -6486,7 +6811,13 @@
                     },
                     "maps": {
                       "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.012
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -6578,7 +6909,13 @@
                     },
                     "maps": {
                       "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.012
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -6667,7 +7004,13 @@
                     },
                     "maps": {
                       "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.006
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -6796,6 +7139,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -6888,6 +7234,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -6977,6 +7326,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00002
                   }
                 }
               },
@@ -7108,6 +7460,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000025
                   }
                 }
               }
@@ -7140,6 +7495,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000025
                   }
                 }
               }
@@ -7169,6 +7527,9 @@
                     "maps": {
                       "price": 1.4
                     }
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000025
                   }
                 }
               }
@@ -7385,6 +7746,9 @@
                     },
                     "maps": {
                       "price": 2.5
+                    },
+                    "image_token": {
+                      "price": 0.003
                     }
                   }
                 }
@@ -7417,6 +7781,9 @@
                     },
                     "maps": {
                       "price": 2.5
+                    },
+                    "image_token": {
+                      "price": 0.003
                     }
                   }
                 }
@@ -7446,6 +7813,9 @@
                     },
                     "maps": {
                       "price": 2.5
+                    },
+                    "image_token": {
+                      "price": 0.0015
                     }
                   }
                 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -1843,7 +1843,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.012
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -1872,7 +1878,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.012
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -1941,7 +1953,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.012
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -1970,7 +1988,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.012
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -2033,7 +2057,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.006
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -2059,7 +2089,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.006
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -2168,6 +2204,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -2197,6 +2236,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -2263,6 +2305,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -2292,6 +2337,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -2352,6 +2400,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -2378,6 +2429,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -4213,7 +4267,7 @@
                     "price": 0.000033
                   },
                   "cache_write_input_token": {
-                    "price": 0.000413
+                    "price": 0.0004125
                   }
                 }
               }
@@ -4228,10 +4282,10 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 0.000017
+                    "price": 0.0000165
                   },
                   "cache_write_input_token": {
-                    "price": 0.000206
+                    "price": 0.00020625
                   }
                 }
               }
@@ -4253,7 +4307,7 @@
                     "price": 0.000033
                   },
                   "cache_write_input_token": {
-                    "price": 0.000413
+                    "price": 0.0004125
                   }
                 }
               }
@@ -4268,10 +4322,10 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 0.000017
+                    "price": 0.0000165
                   },
                   "cache_write_input_token": {
-                    "price": 0.000206
+                    "price": 0.00020625
                   }
                 }
               }
@@ -4293,7 +4347,7 @@
                     "price": 0.000033
                   },
                   "cache_write_input_token": {
-                    "price": 0.000413
+                    "price": 0.0004125
                   }
                 }
               }
@@ -4308,10 +4362,10 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 0.000017
+                    "price": 0.0000165
                   },
                   "cache_write_input_token": {
-                    "price": 0.000206
+                    "price": 0.00020625
                   }
                 }
               }
@@ -4443,7 +4497,7 @@
                     "price": 0.000033
                   },
                   "cache_write_input_token": {
-                    "price": 0.000413
+                    "price": 0.0004125
                   }
                 }
               }
@@ -4458,10 +4512,10 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 0.000017
+                    "price": 0.0000165
                   },
                   "cache_write_input_token": {
-                    "price": 0.000206
+                    "price": 0.00020625
                   }
                 }
               }
@@ -4483,7 +4537,7 @@
                     "price": 0.000033
                   },
                   "cache_write_input_token": {
-                    "price": 0.000413
+                    "price": 0.0004125
                   }
                 }
               }
@@ -4498,10 +4552,10 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 0.000017
+                    "price": 0.0000165
                   },
                   "cache_write_input_token": {
-                    "price": 0.000206
+                    "price": 0.00020625
                   }
                 }
               }
@@ -4523,7 +4577,7 @@
                     "price": 0.000033
                   },
                   "cache_write_input_token": {
-                    "price": 0.000413
+                    "price": 0.0004125
                   }
                 }
               }
@@ -4538,10 +4592,10 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 0.000017
+                    "price": 0.0000165
                   },
                   "cache_write_input_token": {
-                    "price": 0.000206
+                    "price": 0.00020625
                   }
                 }
               }
@@ -4691,7 +4745,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 0.00006875
                   }
                 }
               }
@@ -4731,7 +4785,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 0.00006875
                   }
                 }
               }
@@ -4771,7 +4825,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 0.00006875
                   }
                 }
               }
@@ -4921,7 +4975,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 0.00006875
                   }
                 }
               }
@@ -4961,7 +5015,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 0.00006875
                   }
                 }
               }
@@ -5001,7 +5055,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 0.00006875
                   }
                 }
               }
@@ -5398,7 +5452,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -5438,7 +5492,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -5478,7 +5532,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -5628,7 +5682,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -5668,7 +5722,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -5708,7 +5762,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -6157,7 +6211,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -6197,7 +6251,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -6237,7 +6291,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -6387,7 +6441,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -6427,7 +6481,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -6467,7 +6521,7 @@
                     "price": 0.0000275
                   },
                   "cache_write_input_token": {
-                    "price": 0.0003438
+                    "price": 0.00034375
                   }
                 }
               }
@@ -6599,7 +6653,7 @@
                     "price": 0.000033
                   },
                   "cache_write_input_token": {
-                    "price": 0.000413
+                    "price": 0.0004125
                   }
                 }
               }
@@ -6614,10 +6668,10 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 0.000017
+                    "price": 0.0000165
                   },
                   "cache_write_input_token": {
-                    "price": 0.000206
+                    "price": 0.00020625
                   }
                 }
               }
@@ -6639,7 +6693,7 @@
                     "price": 0.000033
                   },
                   "cache_write_input_token": {
-                    "price": 0.000413
+                    "price": 0.0004125
                   }
                 }
               }
@@ -6654,10 +6708,10 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 0.000017
+                    "price": 0.0000165
                   },
                   "cache_write_input_token": {
-                    "price": 0.000206
+                    "price": 0.00020625
                   }
                 }
               }
@@ -6679,7 +6733,7 @@
                     "price": 0.000033
                   },
                   "cache_write_input_token": {
-                    "price": 0.000413
+                    "price": 0.0004125
                   }
                 }
               }
@@ -6694,10 +6748,10 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 0.000017
+                    "price": 0.0000165
                   },
                   "cache_write_input_token": {
-                    "price": 0.000206
+                    "price": 0.00020625
                   }
                 }
               }
@@ -6849,7 +6903,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.012
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -6878,7 +6938,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.012
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -6947,7 +7013,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.012
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -6976,7 +7048,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.012
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -7039,7 +7117,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.006
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -7065,7 +7149,13 @@
                         },
                         "maps": {
                           "price": 1.4
+                        },
+                        "image_token": {
+                          "price": 0.006
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -7174,6 +7264,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -7203,6 +7296,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -7269,6 +7365,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -7298,6 +7397,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -7358,6 +7460,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }
@@ -7384,6 +7489,9 @@
                         "maps": {
                           "price": 1.4
                         }
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00002
                       }
                     }
                   }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -2028,7 +2028,7 @@
                     }
                   },
                   "cache_write_input_token": {
-                    "price": 0.00002
+                    "price": 0.00001
                   }
                 }
               },
@@ -2063,7 +2063,7 @@
                         }
                       },
                       "cache_write_input_token": {
-                        "price": 0.00002
+                        "price": 0.00001
                       }
                     }
                   }
@@ -2095,7 +2095,7 @@
                         }
                       },
                       "cache_write_input_token": {
-                        "price": 0.00002
+                        "price": 0.00001
                       }
                     }
                   }
@@ -2370,7 +2370,7 @@
                     }
                   },
                   "cache_write_input_token": {
-                    "price": 0.00002
+                    "price": 0.00001
                   }
                 }
               },
@@ -2402,7 +2402,7 @@
                         }
                       },
                       "cache_write_input_token": {
-                        "price": 0.00002
+                        "price": 0.00001
                       }
                     }
                   }
@@ -2431,7 +2431,7 @@
                         }
                       },
                       "cache_write_input_token": {
-                        "price": 0.00002
+                        "price": 0.00001
                       }
                     }
                   }
@@ -6161,7 +6161,7 @@
                     }
                   },
                   "cache_write_input_token": {
-                    "price": 0.00005
+                    "price": 0.000025
                   }
                 }
               }
@@ -7148,7 +7148,7 @@
                     }
                   },
                   "cache_write_input_token": {
-                    "price": 0.00002
+                    "price": 0.00001
                   }
                 }
               },
@@ -7183,7 +7183,7 @@
                         }
                       },
                       "cache_write_input_token": {
-                        "price": 0.00002
+                        "price": 0.00001
                       }
                     }
                   }
@@ -7215,7 +7215,7 @@
                         }
                       },
                       "cache_write_input_token": {
-                        "price": 0.00002
+                        "price": 0.00001
                       }
                     }
                   }
@@ -7490,7 +7490,7 @@
                     }
                   },
                   "cache_write_input_token": {
-                    "price": 0.00002
+                    "price": 0.00001
                   }
                 }
               },
@@ -7522,7 +7522,7 @@
                         }
                       },
                       "cache_write_input_token": {
-                        "price": 0.00002
+                        "price": 0.00001
                       }
                     }
                   }
@@ -7551,7 +7551,7 @@
                         }
                       },
                       "cache_write_input_token": {
-                        "price": 0.00002
+                        "price": 0.00001
                       }
                     }
                   }
@@ -7697,7 +7697,7 @@
                     }
                   },
                   "cache_write_input_token": {
-                    "price": 0.000025
+                    "price": 0.0000125
                   }
                 }
               }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -4865,7 +4865,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 0.00006875
                   }
                 }
               }
@@ -5095,7 +5095,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 0.00006875
                   }
                 }
               }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -59,7 +59,7 @@
           "price": 0.000025
         },
         "response_token": {
-          "price": 0.00007499999999999999
+          "price": 0.000075
         }
       }
     }
@@ -87,7 +87,7 @@
           "price": 0.000025
         },
         "response_token": {
-          "price": 0.00007499999999999999
+          "price": 0.000075
         }
       }
     }
@@ -143,7 +143,7 @@
           "price": 0.000025
         },
         "response_token": {
-          "price": 0.00007499999999999999
+          "price": 0.000075
         }
       }
     }
@@ -171,7 +171,7 @@
           "price": 0.000025
         },
         "response_token": {
-          "price": 0.00007499999999999999
+          "price": 0.000075
         }
       }
     }
@@ -199,7 +199,7 @@
           "price": 0.000025
         },
         "response_token": {
-          "price": 0.00007499999999999999
+          "price": 0.000075
         }
       }
     }
@@ -314,7 +314,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008000000000000001
+          "price": 0.00008
         },
         "response_token": {
           "price": 0.0004
@@ -3073,6 +3073,9 @@
                     },
                     "maps": {
                       "price": 2.5
+                    },
+                    "image_token": {
+                      "price": 0.003
                     }
                   }
                 }
@@ -3102,6 +3105,9 @@
                     },
                     "maps": {
                       "price": 2.5
+                    },
+                    "image_token": {
+                      "price": 0.0015
                     }
                   }
                 }
@@ -3178,6 +3184,9 @@
                     },
                     "maps": {
                       "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.012
                     }
                   }
                 }
@@ -3207,6 +3216,9 @@
                     },
                     "maps": {
                       "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.006
                     }
                   }
                 }
@@ -4563,7 +4575,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.00006880000000000001
+                    "price": 0.0000688
                   }
                 }
               }
@@ -4603,7 +4615,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.00006880000000000001
+                    "price": 0.0000688
                   }
                 }
               }
@@ -4643,7 +4655,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.00006880000000000001
+                    "price": 0.0000688
                   }
                 }
               }
@@ -4683,7 +4695,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.00006880000000000001
+                    "price": 0.0000688
                   }
                 }
               }
@@ -4793,7 +4805,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.00006880000000000001
+                    "price": 0.0000688
                   }
                 }
               }
@@ -4833,7 +4845,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.00006880000000000001
+                    "price": 0.0000688
                   }
                 }
               }
@@ -4873,7 +4885,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.00006880000000000001
+                    "price": 0.0000688
                   }
                 }
               }
@@ -4913,7 +4925,7 @@
                     "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 0.00006880000000000001
+                    "price": 0.0000688
                   }
                 }
               }
@@ -5614,6 +5626,9 @@
                     },
                     "maps": {
                       "price": 2.5
+                    },
+                    "image_token": {
+                      "price": 0.003
                     }
                   }
                 }
@@ -5643,6 +5658,9 @@
                     },
                     "maps": {
                       "price": 2.5
+                    },
+                    "image_token": {
+                      "price": 0.0015
                     }
                   }
                 }
@@ -5772,7 +5790,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00009000000000000001
+                    "price": 0.00009
                   },
                   "response_token": {
                     "price": 0.00054
@@ -7054,7 +7072,7 @@
           "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00007499999999999999
+          "price": 0.000075
         }
       }
     },
@@ -7107,7 +7125,7 @@
                     "price": 0.000005
                   },
                   "request_audio_token": {
-                    "price": 0.00009000000000000001
+                    "price": 0.00009
                   },
                   "additional_units": {
                     "web_search": {
@@ -7133,7 +7151,7 @@
                     "price": 0.000013
                   },
                   "response_token": {
-                    "price": 0.00007499999999999999
+                    "price": 0.000075
                   },
                   "request_audio_token": {
                     "price": 0.000025
@@ -7218,6 +7236,9 @@
                     },
                     "maps": {
                       "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.006
                     }
                   }
                 }
@@ -7247,6 +7268,9 @@
                     },
                     "maps": {
                       "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.003
                     }
                   }
                 }
@@ -7861,7 +7885,7 @@
           "price": 0.00003
         },
         "response_token": {
-          "price": 0.00009000000000000001
+          "price": 0.00009
         }
       }
     }
@@ -7904,7 +7928,7 @@
           "price": 0.00003
         },
         "response_token": {
-          "price": 0.00008500000000000001
+          "price": 0.000085
         }
       }
     }
@@ -7982,7 +8006,7 @@
           "price": 0.000011
         },
         "response_token": {
-          "price": 0.00009000000000000001
+          "price": 0.00009
         }
       }
     }
@@ -8283,7 +8307,7 @@
           "price": 0.000025
         },
         "response_token": {
-          "price": 0.00006999999999999999
+          "price": 0.00007
         }
       },
       "batch_config": {

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -40,7 +40,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00015
@@ -56,10 +56,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "response_token": {
-          "price": 7.5e-05
+          "price": 0.00007499999999999999
         }
       }
     }
@@ -68,7 +68,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00015
@@ -84,10 +84,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "response_token": {
-          "price": 7.5e-05
+          "price": 0.00007499999999999999
         }
       }
     }
@@ -124,7 +124,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00015
@@ -140,10 +140,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "response_token": {
-          "price": 7.5e-05
+          "price": 0.00007499999999999999
         }
       }
     }
@@ -152,7 +152,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00015
@@ -168,10 +168,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "response_token": {
-          "price": 7.5e-05
+          "price": 0.00007499999999999999
         }
       }
     }
@@ -180,7 +180,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00015
@@ -196,10 +196,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "response_token": {
-          "price": 7.5e-05
+          "price": 0.00007499999999999999
         }
       }
     }
@@ -208,24 +208,24 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "response_token": {
           "price": 0.000125
         },
         "cache_write_input_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 3e-06
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 1.25e-05
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 6.25e-05
+          "price": 0.0000625
         }
       }
     }
@@ -314,7 +314,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-05
+          "price": 0.00008000000000000001
         },
         "response_token": {
           "price": 0.0004
@@ -323,12 +323,12 @@
           "price": 0.0001
         },
         "cache_read_input_token": {
-          "price": 8e-06
+          "price": 0.000008
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 4e-05
+          "price": 0.00004
         },
         "response_token": {
           "price": 0.0002
@@ -361,7 +361,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 6.25e-05
+          "price": 0.0000625
         },
         "response_token": {
           "price": 0.00025
@@ -389,7 +389,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 6.25e-05
+          "price": 0.0000625
         },
         "response_token": {
           "price": 0.00025
@@ -417,7 +417,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 6.25e-05
+          "price": 0.0000625
         },
         "response_token": {
           "price": 0.00025
@@ -429,10 +429,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-06
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -450,10 +450,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 3.75e-06
+          "price": 0.00000375
         },
         "response_token": {
-          "price": 1.5e-06
+          "price": 0.0000015
         }
       }
     }
@@ -462,10 +462,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-06
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -478,10 +478,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 3.75e-06
+          "price": 0.00000375
         },
         "response_token": {
-          "price": 1.5e-06
+          "price": 0.0000015
         }
       }
     }
@@ -490,7 +490,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5e-06
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -498,7 +498,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2e-06
+          "price": 0.000002
         },
         "response_token": {
           "price": 0
@@ -510,7 +510,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1e-05
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -518,7 +518,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 8e-06
+          "price": 0.000008
         },
         "response_token": {
           "price": 0
@@ -530,7 +530,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5e-06
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -538,7 +538,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2e-06
+          "price": 0.000002
         },
         "response_token": {
           "price": 0
@@ -550,7 +550,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1e-05
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -558,7 +558,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 8e-06
+          "price": 0.000008
         },
         "response_token": {
           "price": 0
@@ -570,7 +570,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5e-06
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -578,7 +578,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2e-06
+          "price": 0.000002
         },
         "response_token": {
           "price": 0
@@ -590,7 +590,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5e-06
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -598,7 +598,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2e-06
+          "price": 0.000002
         },
         "response_token": {
           "price": 0
@@ -610,7 +610,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1e-05
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -618,7 +618,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 8e-06
+          "price": 0.000008
         },
         "response_token": {
           "price": 0
@@ -630,7 +630,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1e-05
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -638,7 +638,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 8e-06
+          "price": 0.000008
         },
         "response_token": {
           "price": 0
@@ -650,7 +650,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5e-06
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -658,7 +658,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2e-06
+          "price": 0.000002
         },
         "response_token": {
           "price": 0
@@ -876,7 +876,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 6.25e-05
+          "price": 0.0000625
         },
         "response_token": {
           "price": 0.00025
@@ -896,7 +896,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 6.25e-05
+          "price": 0.0000625
         },
         "response_token": {
           "price": 0.00025
@@ -908,10 +908,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-06
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -929,10 +929,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 3.75e-06
+          "price": 0.00000375
         },
         "response_token": {
-          "price": 1.5e-06
+          "price": 0.0000015
         }
       }
     }
@@ -941,10 +941,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -957,10 +957,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 3.75e-06
+          "price": 0.00000375
         },
         "response_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         }
       }
     }
@@ -969,10 +969,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
-          "price": 6e-05
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -988,10 +988,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       }
     }
@@ -1000,10 +1000,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
-          "price": 6e-05
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -1019,10 +1019,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       }
     }
@@ -1071,10 +1071,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -1087,10 +1087,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 3.75e-06
+          "price": 0.00000375
         },
         "response_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         }
       }
     }
@@ -1099,10 +1099,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -1118,10 +1118,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 3.75e-06
+          "price": 0.00000375
         },
         "response_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         }
       }
     }
@@ -1149,7 +1149,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 6.25e-05
+          "price": 0.0000625
         },
         "response_token": {
           "price": 0.0005
@@ -1170,7 +1170,7 @@
                     "price": 0.001
                   },
                   "cache_read_input_token": {
-                    "price": 1.3e-05
+                    "price": 0.000013
                   },
                   "additional_units": {
                     "web_search": {
@@ -1202,7 +1202,7 @@
                         "price": 0.001
                       },
                       "cache_read_input_token": {
-                        "price": 1.3e-05
+                        "price": 0.000013
                       },
                       "additional_units": {
                         "web_search": {
@@ -1231,7 +1231,7 @@
                         "price": 0.0015
                       },
                       "cache_read_input_token": {
-                        "price": 2.5e-05
+                        "price": 0.000025
                       },
                       "additional_units": {
                         "web_search": {
@@ -1262,7 +1262,7 @@
                     "price": 0.0018
                   },
                   "cache_read_input_token": {
-                    "price": 2.3e-05
+                    "price": 0.000023
                   },
                   "additional_units": {
                     "web_search": {
@@ -1294,7 +1294,7 @@
                         "price": 0.0018
                       },
                       "cache_read_input_token": {
-                        "price": 2.3e-05
+                        "price": 0.000023
                       },
                       "additional_units": {
                         "web_search": {
@@ -1323,7 +1323,7 @@
                         "price": 0.0027
                       },
                       "cache_read_input_token": {
-                        "price": 4.5e-05
+                        "price": 0.000045
                       },
                       "additional_units": {
                         "web_search": {
@@ -1348,7 +1348,7 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 6.25e-05
+                    "price": 0.0000625
                   },
                   "response_token": {
                     "price": 0.0005
@@ -1377,7 +1377,7 @@
                   "pricing_config": {
                     "batch_config": {
                       "request_token": {
-                        "price": 6.25e-05
+                        "price": 0.0000625
                       },
                       "response_token": {
                         "price": 0.0005
@@ -1455,7 +1455,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 6.25e-05
+          "price": 0.0000625
         },
         "response_token": {
           "price": 0.0005
@@ -1476,7 +1476,7 @@
                     "price": 0.001
                   },
                   "cache_read_input_token": {
-                    "price": 1.3e-05
+                    "price": 0.000013
                   },
                   "additional_units": {
                     "web_search": {
@@ -1508,7 +1508,7 @@
                         "price": 0.001
                       },
                       "cache_read_input_token": {
-                        "price": 1.3e-05
+                        "price": 0.000013
                       },
                       "additional_units": {
                         "web_search": {
@@ -1537,7 +1537,7 @@
                         "price": 0.0015
                       },
                       "cache_read_input_token": {
-                        "price": 2.5e-05
+                        "price": 0.000025
                       },
                       "additional_units": {
                         "web_search": {
@@ -1568,7 +1568,7 @@
                     "price": 0.0018
                   },
                   "cache_read_input_token": {
-                    "price": 2.3e-05
+                    "price": 0.000023
                   },
                   "additional_units": {
                     "web_search": {
@@ -1600,7 +1600,7 @@
                         "price": 0.0018
                       },
                       "cache_read_input_token": {
-                        "price": 2.3e-05
+                        "price": 0.000023
                       },
                       "additional_units": {
                         "web_search": {
@@ -1629,7 +1629,7 @@
                         "price": 0.0027
                       },
                       "cache_read_input_token": {
-                        "price": 4.5e-05
+                        "price": 0.000045
                       },
                       "additional_units": {
                         "web_search": {
@@ -1654,7 +1654,7 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 6.25e-05
+                    "price": 0.0000625
                   },
                   "response_token": {
                     "price": 0.0005
@@ -1683,7 +1683,7 @@
                   "pricing_config": {
                     "batch_config": {
                       "request_token": {
-                        "price": 6.25e-05
+                        "price": 0.0000625
                       },
                       "response_token": {
                         "price": 0.0005
@@ -1748,10 +1748,10 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 2e-05
+          "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 2e-05
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -1791,7 +1791,7 @@
                     "price": 0.0012
                   },
                   "cache_read_input_token": {
-                    "price": 2e-05
+                    "price": 0.00002
                   },
                   "additional_units": {
                     "web_search": {
@@ -1823,7 +1823,7 @@
                         "price": 0.0012
                       },
                       "cache_read_input_token": {
-                        "price": 2e-05
+                        "price": 0.00002
                       },
                       "additional_units": {
                         "web_search": {
@@ -1852,7 +1852,7 @@
                         "price": 0.0018
                       },
                       "cache_read_input_token": {
-                        "price": 4e-05
+                        "price": 0.00004
                       },
                       "additional_units": {
                         "web_search": {
@@ -1883,7 +1883,7 @@
                     "price": 0.00216
                   },
                   "cache_read_input_token": {
-                    "price": 3.6e-05
+                    "price": 0.000036
                   },
                   "additional_units": {
                     "web_search": {
@@ -1915,7 +1915,7 @@
                         "price": 0.00216
                       },
                       "cache_read_input_token": {
-                        "price": 3.6e-05
+                        "price": 0.000036
                       },
                       "additional_units": {
                         "web_search": {
@@ -1944,7 +1944,7 @@
                         "price": 0.00324
                       },
                       "cache_read_input_token": {
-                        "price": 7.2e-05
+                        "price": 0.000072
                       },
                       "additional_units": {
                         "web_search": {
@@ -2063,7 +2063,7 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 2e-05
+          "price": 0.00002
         },
         "cache_read_input_token": {
           "price": 0.00045
@@ -2100,7 +2100,7 @@
                     "price": 0.0012
                   },
                   "cache_read_input_token": {
-                    "price": 2e-05
+                    "price": 0.00002
                   },
                   "additional_units": {
                     "web_search": {
@@ -2132,7 +2132,7 @@
                         "price": 0.0012
                       },
                       "cache_read_input_token": {
-                        "price": 2e-05
+                        "price": 0.00002
                       },
                       "additional_units": {
                         "web_search": {
@@ -2161,7 +2161,7 @@
                         "price": 0.0018
                       },
                       "cache_read_input_token": {
-                        "price": 4e-05
+                        "price": 0.00004
                       },
                       "additional_units": {
                         "web_search": {
@@ -2192,7 +2192,7 @@
                     "price": 0.00216
                   },
                   "cache_read_input_token": {
-                    "price": 3.6e-05
+                    "price": 0.000036
                   },
                   "additional_units": {
                     "web_search": {
@@ -2224,7 +2224,7 @@
                         "price": 0.00216
                       },
                       "cache_read_input_token": {
-                        "price": 3.6e-05
+                        "price": 0.000036
                       },
                       "additional_units": {
                         "web_search": {
@@ -2253,7 +2253,7 @@
                         "price": 0.00324
                       },
                       "cache_read_input_token": {
-                        "price": 7.2e-05
+                        "price": 0.000072
                       },
                       "additional_units": {
                         "web_search": {
@@ -2366,10 +2366,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
-          "price": 6e-05
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -2382,10 +2382,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       }
     },
@@ -2397,13 +2397,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "response_token": {
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 3e-06
+                    "price": 0.000003
                   },
                   "request_audio_token": {
                     "price": 0.0001
@@ -2429,13 +2429,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 5.4e-05
+                    "price": 0.000054
                   },
                   "response_token": {
                     "price": 0.00045
                   },
                   "cache_read_input_token": {
-                    "price": 5e-06
+                    "price": 0.000005
                   },
                   "request_audio_token": {
                     "price": 0.00018
@@ -2461,13 +2461,13 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "response_token": {
                     "price": 0.000125
                   },
                   "request_audio_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "additional_units": {
                     "web_search": {
@@ -2495,10 +2495,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
-          "price": 6e-05
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -2511,10 +2511,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       }
     },
@@ -2526,13 +2526,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "response_token": {
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 3e-06
+                    "price": 0.000003
                   },
                   "request_audio_token": {
                     "price": 0.0001
@@ -2558,13 +2558,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 5.4e-05
+                    "price": 0.000054
                   },
                   "response_token": {
                     "price": 0.00045
                   },
                   "cache_read_input_token": {
-                    "price": 5e-06
+                    "price": 0.000005
                   },
                   "request_audio_token": {
                     "price": 0.00018
@@ -2590,13 +2590,13 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "response_token": {
                     "price": 0.000125
                   },
                   "request_audio_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "additional_units": {
                     "web_search": {
@@ -2627,7 +2627,7 @@
           "price": 0
         },
         "response_token": {
-          "price": 2e-05
+          "price": 0.00002
         },
         "additional_units": {
           "input_image": {
@@ -2649,7 +2649,7 @@
           "price": 0
         },
         "response_token": {
-          "price": 1.6e-05
+          "price": 0.000016
         }
       }
     }
@@ -2667,7 +2667,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -2693,7 +2693,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -2736,10 +2736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1e-05
+          "price": 0.00001
         },
         "response_token": {
-          "price": 4e-05
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2752,10 +2752,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 5e-06
+          "price": 0.000005
         },
         "response_token": {
-          "price": 2e-05
+          "price": 0.00002
         }
       }
     },
@@ -2767,16 +2767,16 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 1e-05
+                    "price": 0.00001
                   },
                   "response_token": {
-                    "price": 4e-05
+                    "price": 0.00004
                   },
                   "cache_read_input_token": {
-                    "price": 1e-06
+                    "price": 0.000001
                   },
                   "request_audio_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "additional_units": {
                     "web_search": {
@@ -2799,16 +2799,16 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 1.8e-05
+                    "price": 0.000018
                   },
                   "response_token": {
-                    "price": 7.2e-05
+                    "price": 0.000072
                   },
                   "cache_read_input_token": {
-                    "price": 2e-06
+                    "price": 0.000002
                   },
                   "request_audio_token": {
-                    "price": 5.4e-05
+                    "price": 0.000054
                   },
                   "additional_units": {
                     "web_search": {
@@ -2831,13 +2831,13 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5e-06
+                    "price": 0.000005
                   },
                   "response_token": {
-                    "price": 2e-05
+                    "price": 0.00002
                   },
                   "request_audio_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "additional_units": {
                     "web_search": {
@@ -2865,7 +2865,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "response_token": {
           "price": 0.00025
@@ -2885,7 +2885,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 3e-06
+          "price": 0.000003
         }
       },
       "finetune_config": {
@@ -2895,7 +2895,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.000125
@@ -2910,13 +2910,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "response_token": {
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 3e-06
+                    "price": 0.000003
                   },
                   "request_audio_token": {
                     "price": 0.0001
@@ -2942,13 +2942,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 5.4e-05
+                    "price": 0.000054
                   },
                   "response_token": {
                     "price": 0.00045
                   },
                   "cache_read_input_token": {
-                    "price": 5e-06
+                    "price": 0.000005
                   },
                   "request_audio_token": {
                     "price": 0.00018
@@ -2974,13 +2974,13 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "response_token": {
                     "price": 0.000125
                   },
                   "request_audio_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "additional_units": {
                     "web_search": {
@@ -3008,7 +3008,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "response_token": {
           "price": 0.00025
@@ -3028,7 +3028,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 3e-06
+          "price": 0.000003
         }
       },
       "finetune_config": {
@@ -3038,7 +3038,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.000125
@@ -3053,7 +3053,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "response_token": {
                     "price": 0.00025
@@ -3082,7 +3082,7 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "response_token": {
                     "price": 0.000125
@@ -3133,7 +3133,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 2e-05
+          "price": 0.00002
         }
       },
       "finetune_config": {
@@ -3238,7 +3238,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 1.25e-05
+          "price": 0.0000125
         }
       },
       "finetune_config": {
@@ -3248,7 +3248,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 6.25e-05
+          "price": 0.0000625
         },
         "response_token": {
           "price": 0.0005
@@ -3269,7 +3269,7 @@
                     "price": 0.001
                   },
                   "cache_read_input_token": {
-                    "price": 1.3e-05
+                    "price": 0.000013
                   },
                   "additional_units": {
                     "web_search": {
@@ -3301,7 +3301,7 @@
                         "price": 0.001
                       },
                       "cache_read_input_token": {
-                        "price": 1.3e-05
+                        "price": 0.000013
                       },
                       "additional_units": {
                         "web_search": {
@@ -3330,7 +3330,7 @@
                         "price": 0.0015
                       },
                       "cache_read_input_token": {
-                        "price": 2.5e-05
+                        "price": 0.000025
                       },
                       "additional_units": {
                         "web_search": {
@@ -3361,7 +3361,7 @@
                     "price": 0.0018
                   },
                   "cache_read_input_token": {
-                    "price": 2.3e-05
+                    "price": 0.000023
                   },
                   "additional_units": {
                     "web_search": {
@@ -3393,7 +3393,7 @@
                         "price": 0.0018
                       },
                       "cache_read_input_token": {
-                        "price": 2.3e-05
+                        "price": 0.000023
                       },
                       "additional_units": {
                         "web_search": {
@@ -3422,7 +3422,7 @@
                         "price": 0.0027
                       },
                       "cache_read_input_token": {
-                        "price": 4.5e-05
+                        "price": 0.000045
                       },
                       "additional_units": {
                         "web_search": {
@@ -3447,7 +3447,7 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 6.25e-05
+                    "price": 0.0000625
                   },
                   "response_token": {
                     "price": 0.0005
@@ -3476,7 +3476,7 @@
                   "pricing_config": {
                     "batch_config": {
                       "request_token": {
-                        "price": 6.25e-05
+                        "price": 0.0000625
                       },
                       "response_token": {
                         "price": 0.0005
@@ -3535,10 +3535,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1e-05
+          "price": 0.00001
         },
         "response_token": {
-          "price": 4e-05
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -3552,7 +3552,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 1e-06
+          "price": 0.000001
         }
       },
       "finetune_config": {
@@ -3562,10 +3562,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 5e-06
+          "price": 0.000005
         },
         "response_token": {
-          "price": 2e-05
+          "price": 0.00002
         }
       }
     },
@@ -3577,16 +3577,16 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 1e-05
+                    "price": 0.00001
                   },
                   "response_token": {
-                    "price": 4e-05
+                    "price": 0.00004
                   },
                   "cache_read_input_token": {
-                    "price": 1e-06
+                    "price": 0.000001
                   },
                   "request_audio_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "additional_units": {
                     "web_search": {
@@ -3609,16 +3609,16 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 1.8e-05
+                    "price": 0.000018
                   },
                   "response_token": {
-                    "price": 7.2e-05
+                    "price": 0.000072
                   },
                   "cache_read_input_token": {
-                    "price": 2e-06
+                    "price": 0.000002
                   },
                   "request_audio_token": {
-                    "price": 5.4e-05
+                    "price": 0.000054
                   },
                   "additional_units": {
                     "web_search": {
@@ -3641,13 +3641,13 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5e-06
+                    "price": 0.000005
                   },
                   "response_token": {
-                    "price": 2e-05
+                    "price": 0.00002
                   },
                   "request_audio_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "additional_units": {
                     "web_search": {
@@ -3716,7 +3716,7 @@
       "pay_as_you_go": {},
       "finetune_config": {
         "pay_per_token": {
-          "price": 6.7e-05
+          "price": 0.000067
         }
       }
     }
@@ -3726,7 +3726,7 @@
       "pay_as_you_go": {},
       "finetune_config": {
         "pay_per_token": {
-          "price": 2.8e-05
+          "price": 0.000028
         }
       }
     }
@@ -3736,7 +3736,7 @@
       "pay_as_you_go": {},
       "finetune_config": {
         "pay_per_token": {
-          "price": 6.1e-05
+          "price": 0.000061
         }
       }
     }
@@ -3771,18 +3771,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
-          "price": 6e-05
+          "price": 0.00006
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       }
     }
@@ -4096,7 +4096,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -4122,7 +4122,7 @@
                     "price": 0.0015
                   },
                   "cache_read_input_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "cache_write_input_token": {
                     "price": 0.000375
@@ -4140,10 +4140,10 @@
                     "price": 0.00075
                   },
                   "cache_read_input_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "cache_write_input_token": {
-                    "price": 0.000188
+                    "price": 0.0001875
                   }
                 }
               }
@@ -4162,7 +4162,7 @@
                     "price": 0.00165
                   },
                   "cache_read_input_token": {
-                    "price": 3.3e-05
+                    "price": 0.000033
                   },
                   "cache_write_input_token": {
                     "price": 0.000413
@@ -4180,7 +4180,7 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 1.7e-05
+                    "price": 0.000017
                   },
                   "cache_write_input_token": {
                     "price": 0.000206
@@ -4202,7 +4202,7 @@
                     "price": 0.00165
                   },
                   "cache_read_input_token": {
-                    "price": 3.3e-05
+                    "price": 0.000033
                   },
                   "cache_write_input_token": {
                     "price": 0.000413
@@ -4220,7 +4220,7 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 1.7e-05
+                    "price": 0.000017
                   },
                   "cache_write_input_token": {
                     "price": 0.000206
@@ -4242,7 +4242,7 @@
                     "price": 0.00165
                   },
                   "cache_read_input_token": {
-                    "price": 3.3e-05
+                    "price": 0.000033
                   },
                   "cache_write_input_token": {
                     "price": 0.000413
@@ -4260,7 +4260,7 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 1.7e-05
+                    "price": 0.000017
                   },
                   "cache_write_input_token": {
                     "price": 0.000206
@@ -4286,7 +4286,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -4312,7 +4312,7 @@
                     "price": 0.0015
                   },
                   "cache_read_input_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "cache_write_input_token": {
                     "price": 0.000375
@@ -4330,10 +4330,10 @@
                     "price": 0.00075
                   },
                   "cache_read_input_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "cache_write_input_token": {
-                    "price": 0.000188
+                    "price": 0.0001875
                   }
                 }
               }
@@ -4352,7 +4352,7 @@
                     "price": 0.00165
                   },
                   "cache_read_input_token": {
-                    "price": 3.3e-05
+                    "price": 0.000033
                   },
                   "cache_write_input_token": {
                     "price": 0.000413
@@ -4370,7 +4370,7 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 1.7e-05
+                    "price": 0.000017
                   },
                   "cache_write_input_token": {
                     "price": 0.000206
@@ -4392,7 +4392,7 @@
                     "price": 0.00165
                   },
                   "cache_read_input_token": {
-                    "price": 3.3e-05
+                    "price": 0.000033
                   },
                   "cache_write_input_token": {
                     "price": 0.000413
@@ -4410,7 +4410,7 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 1.7e-05
+                    "price": 0.000017
                   },
                   "cache_write_input_token": {
                     "price": 0.000206
@@ -4432,7 +4432,7 @@
                     "price": 0.00165
                   },
                   "cache_read_input_token": {
-                    "price": 3.3e-05
+                    "price": 0.000033
                   },
                   "cache_write_input_token": {
                     "price": 0.000413
@@ -4450,7 +4450,7 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 1.7e-05
+                    "price": 0.000017
                   },
                   "cache_write_input_token": {
                     "price": 0.000206
@@ -4476,12 +4476,12 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 1e-05
+          "price": 0.00001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00025
@@ -4502,7 +4502,7 @@
                     "price": 0.0005
                   },
                   "cache_read_input_token": {
-                    "price": 1e-05
+                    "price": 0.00001
                   },
                   "cache_write_input_token": {
                     "price": 0.000125
@@ -4514,16 +4514,16 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "response_token": {
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 5e-06
+                    "price": 0.000005
                   },
                   "cache_write_input_token": {
-                    "price": 6.25e-05
+                    "price": 0.0000625
                   }
                 }
               }
@@ -4542,7 +4542,7 @@
                     "price": 0.00055
                   },
                   "cache_read_input_token": {
-                    "price": 1.1e-05
+                    "price": 0.000011
                   },
                   "cache_write_input_token": {
                     "price": 0.0001375
@@ -4554,16 +4554,16 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "response_token": {
                     "price": 0.000275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-06
+                    "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 6.88e-05
+                    "price": 0.00006880000000000001
                   }
                 }
               }
@@ -4582,7 +4582,7 @@
                     "price": 0.00055
                   },
                   "cache_read_input_token": {
-                    "price": 1.1e-05
+                    "price": 0.000011
                   },
                   "cache_write_input_token": {
                     "price": 0.0001375
@@ -4594,16 +4594,16 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "response_token": {
                     "price": 0.000275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-06
+                    "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 6.88e-05
+                    "price": 0.00006880000000000001
                   }
                 }
               }
@@ -4622,7 +4622,7 @@
                     "price": 0.00055
                   },
                   "cache_read_input_token": {
-                    "price": 1.1e-05
+                    "price": 0.000011
                   },
                   "cache_write_input_token": {
                     "price": 0.0001375
@@ -4634,16 +4634,16 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "response_token": {
                     "price": 0.000275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-06
+                    "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 6.88e-05
+                    "price": 0.00006880000000000001
                   }
                 }
               }
@@ -4662,7 +4662,7 @@
                     "price": 0.00055
                   },
                   "cache_read_input_token": {
-                    "price": 1.1e-05
+                    "price": 0.000011
                   },
                   "cache_write_input_token": {
                     "price": 0.0001375
@@ -4674,16 +4674,16 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "response_token": {
                     "price": 0.000275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-06
+                    "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 6.88e-05
+                    "price": 0.00006880000000000001
                   }
                 }
               }
@@ -4706,12 +4706,12 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 1e-05
+          "price": 0.00001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00025
@@ -4732,7 +4732,7 @@
                     "price": 0.0005
                   },
                   "cache_read_input_token": {
-                    "price": 1e-05
+                    "price": 0.00001
                   },
                   "cache_write_input_token": {
                     "price": 0.000125
@@ -4744,16 +4744,16 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "response_token": {
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 5e-06
+                    "price": 0.000005
                   },
                   "cache_write_input_token": {
-                    "price": 6.25e-05
+                    "price": 0.0000625
                   }
                 }
               }
@@ -4772,7 +4772,7 @@
                     "price": 0.00055
                   },
                   "cache_read_input_token": {
-                    "price": 1.1e-05
+                    "price": 0.000011
                   },
                   "cache_write_input_token": {
                     "price": 0.0001375
@@ -4784,16 +4784,16 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "response_token": {
                     "price": 0.000275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-06
+                    "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 6.88e-05
+                    "price": 0.00006880000000000001
                   }
                 }
               }
@@ -4812,7 +4812,7 @@
                     "price": 0.00055
                   },
                   "cache_read_input_token": {
-                    "price": 1.1e-05
+                    "price": 0.000011
                   },
                   "cache_write_input_token": {
                     "price": 0.0001375
@@ -4824,16 +4824,16 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "response_token": {
                     "price": 0.000275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-06
+                    "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 6.88e-05
+                    "price": 0.00006880000000000001
                   }
                 }
               }
@@ -4852,7 +4852,7 @@
                     "price": 0.00055
                   },
                   "cache_read_input_token": {
-                    "price": 1.1e-05
+                    "price": 0.000011
                   },
                   "cache_write_input_token": {
                     "price": 0.0001375
@@ -4864,16 +4864,16 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "response_token": {
                     "price": 0.000275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-06
+                    "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 6.88e-05
+                    "price": 0.00006880000000000001
                   }
                 }
               }
@@ -4892,7 +4892,7 @@
                     "price": 0.00055
                   },
                   "cache_read_input_token": {
-                    "price": 1.1e-05
+                    "price": 0.000011
                   },
                   "cache_write_input_token": {
                     "price": 0.0001375
@@ -4904,16 +4904,16 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "response_token": {
                     "price": 0.000275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-06
+                    "price": 0.0000055
                   },
                   "cache_write_input_token": {
-                    "price": 6.88e-05
+                    "price": 0.00006880000000000001
                   }
                 }
               }
@@ -4947,7 +4947,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -4955,7 +4955,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 1.2e-05
+          "price": 0.000012
         },
         "response_token": {
           "price": 0
@@ -5183,7 +5183,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 5e-05
+          "price": 0.00005
         }
       },
       "batch_config": {
@@ -5209,7 +5209,7 @@
                     "price": 0.0025
                   },
                   "cache_read_input_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "cache_write_input_token": {
                     "price": 0.000625
@@ -5227,7 +5227,7 @@
                     "price": 0.00125
                   },
                   "cache_read_input_token": {
-                    "price": 2.5e-05
+                    "price": 0.000025
                   },
                   "cache_write_input_token": {
                     "price": 0.0003125
@@ -5249,7 +5249,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -5267,7 +5267,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -5289,7 +5289,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -5307,7 +5307,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -5329,7 +5329,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -5347,7 +5347,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -5373,7 +5373,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 5e-05
+          "price": 0.00005
         }
       },
       "batch_config": {
@@ -5399,7 +5399,7 @@
                     "price": 0.0025
                   },
                   "cache_read_input_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "cache_write_input_token": {
                     "price": 0.000625
@@ -5417,7 +5417,7 @@
                     "price": 0.00125
                   },
                   "cache_read_input_token": {
-                    "price": 2.5e-05
+                    "price": 0.000025
                   },
                   "cache_write_input_token": {
                     "price": 0.0003125
@@ -5439,7 +5439,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -5457,7 +5457,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -5479,7 +5479,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -5497,7 +5497,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -5519,7 +5519,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -5537,7 +5537,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -5554,7 +5554,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "response_token": {
           "price": 0.00025
@@ -5574,12 +5574,12 @@
           }
         },
         "cache_read_input_token": {
-          "price": 3e-06
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.000125
@@ -5594,7 +5594,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "response_token": {
                     "price": 0.00025
@@ -5623,7 +5623,7 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "response_token": {
                     "price": 0.000125
@@ -5703,16 +5703,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.0003
         },
         "cache_write_input_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 5e-06
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -5725,7 +5725,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "response_token": {
           "price": 0.00015
@@ -5740,13 +5740,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "response_token": {
                     "price": 0.0003
                   },
                   "cache_read_input_token": {
-                    "price": 5e-06
+                    "price": 0.000005
                   },
                   "request_audio_token": {
                     "price": 0.0001
@@ -5772,13 +5772,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 9e-05
+                    "price": 0.00009000000000000001
                   },
                   "response_token": {
                     "price": 0.00054
                   },
                   "cache_read_input_token": {
-                    "price": 9e-06
+                    "price": 0.000009
                   },
                   "request_audio_token": {
                     "price": 0.00018
@@ -5804,13 +5804,13 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 2.5e-05
+                    "price": 0.000025
                   },
                   "response_token": {
                     "price": 0.00015
                   },
                   "request_audio_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "additional_units": {
                     "web_search": {
@@ -5847,7 +5847,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 5e-05
+          "price": 0.00005
         }
       },
       "batch_config": {
@@ -5873,7 +5873,7 @@
                     "price": 0.0025
                   },
                   "cache_read_input_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "cache_write_input_token": {
                     "price": 0.000625
@@ -5891,7 +5891,7 @@
                     "price": 0.00125
                   },
                   "cache_read_input_token": {
-                    "price": 2.5e-05
+                    "price": 0.000025
                   },
                   "cache_write_input_token": {
                     "price": 0.0003125
@@ -5913,7 +5913,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -5931,7 +5931,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -5953,7 +5953,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -5971,7 +5971,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -5993,7 +5993,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -6011,7 +6011,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -6037,7 +6037,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 5e-05
+          "price": 0.00005
         }
       },
       "batch_config": {
@@ -6063,7 +6063,7 @@
                     "price": 0.0025
                   },
                   "cache_read_input_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "cache_write_input_token": {
                     "price": 0.000625
@@ -6081,7 +6081,7 @@
                     "price": 0.00125
                   },
                   "cache_read_input_token": {
-                    "price": 2.5e-05
+                    "price": 0.000025
                   },
                   "cache_write_input_token": {
                     "price": 0.0003125
@@ -6103,7 +6103,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -6121,7 +6121,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -6143,7 +6143,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -6161,7 +6161,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -6183,7 +6183,7 @@
                     "price": 0.00275
                   },
                   "cache_read_input_token": {
-                    "price": 5.5e-05
+                    "price": 0.000055
                   },
                   "cache_write_input_token": {
                     "price": 0.0006875
@@ -6201,7 +6201,7 @@
                     "price": 0.001375
                   },
                   "cache_read_input_token": {
-                    "price": 2.75e-05
+                    "price": 0.0000275
                   },
                   "cache_write_input_token": {
                     "price": 0.0003438
@@ -6227,7 +6227,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -6253,7 +6253,7 @@
                     "price": 0.0015
                   },
                   "cache_read_input_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "cache_write_input_token": {
                     "price": 0.000375
@@ -6271,10 +6271,10 @@
                     "price": 0.00075
                   },
                   "cache_read_input_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "cache_write_input_token": {
-                    "price": 0.000188
+                    "price": 0.0001875
                   }
                 }
               }
@@ -6293,7 +6293,7 @@
                     "price": 0.00165
                   },
                   "cache_read_input_token": {
-                    "price": 3.3e-05
+                    "price": 0.000033
                   },
                   "cache_write_input_token": {
                     "price": 0.000413
@@ -6311,7 +6311,7 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 1.7e-05
+                    "price": 0.000017
                   },
                   "cache_write_input_token": {
                     "price": 0.000206
@@ -6333,7 +6333,7 @@
                     "price": 0.00165
                   },
                   "cache_read_input_token": {
-                    "price": 3.3e-05
+                    "price": 0.000033
                   },
                   "cache_write_input_token": {
                     "price": 0.000413
@@ -6351,7 +6351,7 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 1.7e-05
+                    "price": 0.000017
                   },
                   "cache_write_input_token": {
                     "price": 0.000206
@@ -6373,7 +6373,7 @@
                     "price": 0.00165
                   },
                   "cache_read_input_token": {
-                    "price": 3.3e-05
+                    "price": 0.000033
                   },
                   "cache_write_input_token": {
                     "price": 0.000413
@@ -6391,7 +6391,7 @@
                     "price": 0.000825
                   },
                   "cache_read_input_token": {
-                    "price": 1.7e-05
+                    "price": 0.000017
                   },
                   "cache_write_input_token": {
                     "price": 0.000206
@@ -6414,10 +6414,10 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 2e-05
+          "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 2e-05
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -6454,7 +6454,7 @@
                     "price": 0.0012
                   },
                   "cache_read_input_token": {
-                    "price": 2e-05
+                    "price": 0.00002
                   },
                   "additional_units": {
                     "web_search": {
@@ -6486,7 +6486,7 @@
                         "price": 0.0012
                       },
                       "cache_read_input_token": {
-                        "price": 2e-05
+                        "price": 0.00002
                       },
                       "additional_units": {
                         "web_search": {
@@ -6515,7 +6515,7 @@
                         "price": 0.0018
                       },
                       "cache_read_input_token": {
-                        "price": 4e-05
+                        "price": 0.00004
                       },
                       "additional_units": {
                         "web_search": {
@@ -6546,7 +6546,7 @@
                     "price": 0.00216
                   },
                   "cache_read_input_token": {
-                    "price": 3.6e-05
+                    "price": 0.000036
                   },
                   "additional_units": {
                     "web_search": {
@@ -6578,7 +6578,7 @@
                         "price": 0.00216
                       },
                       "cache_read_input_token": {
-                        "price": 3.6e-05
+                        "price": 0.000036
                       },
                       "additional_units": {
                         "web_search": {
@@ -6607,7 +6607,7 @@
                         "price": 0.00324
                       },
                       "cache_read_input_token": {
-                        "price": 7.2e-05
+                        "price": 0.000072
                       },
                       "additional_units": {
                         "web_search": {
@@ -6726,7 +6726,7 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 2e-05
+          "price": 0.00002
         },
         "cache_read_input_token": {
           "price": 0.00045
@@ -6763,7 +6763,7 @@
                     "price": 0.0012
                   },
                   "cache_read_input_token": {
-                    "price": 2e-05
+                    "price": 0.00002
                   },
                   "additional_units": {
                     "web_search": {
@@ -6795,7 +6795,7 @@
                         "price": 0.0012
                       },
                       "cache_read_input_token": {
-                        "price": 2e-05
+                        "price": 0.00002
                       },
                       "additional_units": {
                         "web_search": {
@@ -6824,7 +6824,7 @@
                         "price": 0.0018
                       },
                       "cache_read_input_token": {
-                        "price": 4e-05
+                        "price": 0.00004
                       },
                       "additional_units": {
                         "web_search": {
@@ -6855,7 +6855,7 @@
                     "price": 0.00216
                   },
                   "cache_read_input_token": {
-                    "price": 3.6e-05
+                    "price": 0.000036
                   },
                   "additional_units": {
                     "web_search": {
@@ -6887,7 +6887,7 @@
                         "price": 0.00216
                       },
                       "cache_read_input_token": {
-                        "price": 3.6e-05
+                        "price": 0.000036
                       },
                       "additional_units": {
                         "web_search": {
@@ -6916,7 +6916,7 @@
                         "price": 0.00324
                       },
                       "cache_read_input_token": {
-                        "price": 7.2e-05
+                        "price": 0.000072
                       },
                       "additional_units": {
                         "web_search": {
@@ -7029,16 +7029,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "response_token": {
           "price": 0.00015
         },
         "cache_write_input_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "cache_read_input_token": {
-          "price": 2.5e-06
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -7051,10 +7051,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 1.25e-05
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 7.5e-05
+          "price": 0.00007499999999999999
         }
       }
     },
@@ -7066,16 +7066,16 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 2.5e-05
+                    "price": 0.000025
                   },
                   "response_token": {
                     "price": 0.00015
                   },
                   "cache_read_input_token": {
-                    "price": 3e-06
+                    "price": 0.000003
                   },
                   "request_audio_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "additional_units": {
                     "web_search": {
@@ -7098,16 +7098,16 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 4.5e-05
+                    "price": 0.000045
                   },
                   "response_token": {
                     "price": 0.00027
                   },
                   "cache_read_input_token": {
-                    "price": 5e-06
+                    "price": 0.000005
                   },
                   "request_audio_token": {
-                    "price": 9e-05
+                    "price": 0.00009000000000000001
                   },
                   "additional_units": {
                     "web_search": {
@@ -7130,13 +7130,13 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 1.3e-05
+                    "price": 0.000013
                   },
                   "response_token": {
-                    "price": 7.5e-05
+                    "price": 0.00007499999999999999
                   },
                   "request_audio_token": {
-                    "price": 2.5e-05
+                    "price": 0.000025
                   },
                   "additional_units": {
                     "web_search": {
@@ -7164,7 +7164,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.0003
@@ -7183,7 +7183,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "response_token": {
           "price": 0.00015
@@ -7198,7 +7198,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "response_token": {
                     "price": 0.0003
@@ -7227,7 +7227,7 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 2.5e-05
+                    "price": 0.000025
                   },
                   "response_token": {
                     "price": 0.00015
@@ -7298,13 +7298,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "response_token": {
           "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 3e-06
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -7323,7 +7323,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.000125
@@ -7338,13 +7338,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "response_token": {
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 3e-06
+                    "price": 0.000003
                   },
                   "request_audio_token": {
                     "price": 0.0001
@@ -7370,13 +7370,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 5.4e-05
+                    "price": 0.000054
                   },
                   "response_token": {
                     "price": 0.00045
                   },
                   "cache_read_input_token": {
-                    "price": 5e-06
+                    "price": 0.000005
                   },
                   "request_audio_token": {
                     "price": 0.00018
@@ -7402,13 +7402,13 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "response_token": {
                     "price": 0.000125
                   },
                   "request_audio_token": {
-                    "price": 5e-05
+                    "price": 0.00005
                   },
                   "additional_units": {
                     "web_search": {
@@ -7436,13 +7436,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1e-05
+          "price": 0.00001
         },
         "response_token": {
-          "price": 4e-05
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 1e-06
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -7458,10 +7458,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 5e-06
+          "price": 0.000005
         },
         "response_token": {
-          "price": 2e-05
+          "price": 0.00002
         }
       }
     },
@@ -7473,16 +7473,16 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 1e-05
+                    "price": 0.00001
                   },
                   "response_token": {
-                    "price": 4e-05
+                    "price": 0.00004
                   },
                   "cache_read_input_token": {
-                    "price": 1e-06
+                    "price": 0.000001
                   },
                   "request_audio_token": {
-                    "price": 3e-05
+                    "price": 0.00003
                   },
                   "additional_units": {
                     "web_search": {
@@ -7505,16 +7505,16 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 1.8e-05
+                    "price": 0.000018
                   },
                   "response_token": {
-                    "price": 7.2e-05
+                    "price": 0.000072
                   },
                   "cache_read_input_token": {
-                    "price": 2e-06
+                    "price": 0.000002
                   },
                   "request_audio_token": {
-                    "price": 5.4e-05
+                    "price": 0.000054
                   },
                   "additional_units": {
                     "web_search": {
@@ -7537,13 +7537,13 @@
               "pricing_config": {
                 "batch_config": {
                   "request_token": {
-                    "price": 5e-06
+                    "price": 0.000005
                   },
                   "response_token": {
-                    "price": 2e-05
+                    "price": 0.00002
                   },
                   "request_audio_token": {
-                    "price": 1.5e-05
+                    "price": 0.000015
                   },
                   "additional_units": {
                     "web_search": {
@@ -7685,7 +7685,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2e-05
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
@@ -7736,7 +7736,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5e-06
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -7748,7 +7748,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5e-06
+          "price": 0.0000025
         },
         "response_token": {
           "price": 0
@@ -7774,18 +7774,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 9e-06
+          "price": 0.000009
         },
         "response_token": {
-          "price": 3.6e-05
+          "price": 0.000036
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 4.5e-06
+          "price": 0.0000045
         },
         "response_token": {
-          "price": 1.8e-05
+          "price": 0.000018
         }
       }
     }
@@ -7794,18 +7794,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.2e-05
+          "price": 0.000072
         },
         "response_token": {
-          "price": 7.2e-05
+          "price": 0.000072
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 3.6e-05
+          "price": 0.000036
         },
         "response_token": {
-          "price": 3.6e-05
+          "price": 0.000036
         }
       }
     }
@@ -7814,7 +7814,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3.5e-05
+          "price": 0.000035
         },
         "response_token": {
           "price": 0.000115
@@ -7822,10 +7822,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 1.75e-05
+          "price": 0.0000175
         },
         "response_token": {
-          "price": 5.75e-05
+          "price": 0.0000575
         }
       }
     }
@@ -7834,10 +7834,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1e-05
+          "price": 0.00001
         },
         "response_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       }
     }
@@ -7846,7 +7846,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 4e-05
+          "price": 0.00004
         },
         "response_token": {
           "price": 0.0002
@@ -7858,10 +7858,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "response_token": {
-          "price": 9e-05
+          "price": 0.00009000000000000001
         }
       }
     }
@@ -7878,7 +7878,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 6.75e-05
+          "price": 0.0000675
         },
         "response_token": {
           "price": 0.00027
@@ -7890,21 +7890,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 6e-05
+          "price": 0.00006
         },
         "response_token": {
           "price": 0.00017
         },
         "cache_read_input_token": {
-          "price": 6e-06
+          "price": 0.000006
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "response_token": {
-          "price": 8.5e-05
+          "price": 0.00008500000000000001
         }
       }
     }
@@ -7913,21 +7913,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5.6e-05
+          "price": 0.000056
         },
         "response_token": {
           "price": 0.000168
         },
         "cache_read_input_token": {
-          "price": 5.6e-06
+          "price": 0.0000056
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 2.8e-05
+          "price": 0.000028
         },
         "response_token": {
-          "price": 8.4e-05
+          "price": 0.000084
         }
       }
     }
@@ -7948,18 +7948,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.2e-05
+          "price": 0.000022
         },
         "response_token": {
-          "price": 8.8e-05
+          "price": 0.000088
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 1.1e-05
+          "price": 0.000011
         },
         "response_token": {
-          "price": 4.4e-05
+          "price": 0.000044
         }
       }
     }
@@ -7968,21 +7968,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.2e-05
+          "price": 0.000022
         },
         "response_token": {
           "price": 0.00018
         },
         "cache_read_input_token": {
-          "price": 2.2e-06
+          "price": 0.0000022
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 1.1e-05
+          "price": 0.000011
         },
         "response_token": {
-          "price": 9e-05
+          "price": 0.00009000000000000001
         }
       }
     }
@@ -7991,7 +7991,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00012
@@ -8003,7 +8003,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00012
@@ -8015,13 +8015,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "response_token": {
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 3e-06
+          "price": 0.000003
         }
       }
     }
@@ -8030,13 +8030,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 6e-05
+          "price": 0.00006
         },
         "response_token": {
           "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 6e-06
+          "price": 0.000006
         }
       }
     }
@@ -8045,7 +8045,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 6e-05
+          "price": 0.00006
         },
         "response_token": {
           "price": 0.00022
@@ -8063,7 +8063,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 1e-05
+          "price": 0.00001
         }
       }
     }
@@ -8072,18 +8072,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
-          "price": 6e-05
+          "price": 0.00006
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       }
     }
@@ -8153,7 +8153,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -8179,12 +8179,12 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 1e-05
+          "price": 0.00001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00025
@@ -8205,7 +8205,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 5e-05
+          "price": 0.00005
         }
       },
       "batch_config": {
@@ -8231,7 +8231,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -8248,18 +8248,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
-          "price": 6e-05
+          "price": 0.00006
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 7.5e-06
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 3e-05
+          "price": 0.00003
         }
       }
     }
@@ -8268,10 +8268,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5e-05
+          "price": 0.000015
         },
         "response_token": {
-          "price": 6e-05
+          "price": 0.00006
         }
       }
     }
@@ -8280,18 +8280,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "response_token": {
-          "price": 7e-05
+          "price": 0.00006999999999999999
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 1.25e-05
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 3.5e-05
+          "price": 0.000035
         }
       }
     }
@@ -8300,21 +8300,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7e-06
+          "price": 0.000007
         },
         "response_token": {
-          "price": 2.5e-05
+          "price": 0.000025
         },
         "cache_read_input_token": {
-          "price": 7e-07
+          "price": 0.0000007
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 3.5e-06
+          "price": 0.0000035
         },
         "response_token": {
-          "price": 1.25e-05
+          "price": 0.0000125
         }
       }
     }
@@ -8329,7 +8329,7 @@
           "price": 0.0006
         },
         "cache_read_input_token": {
-          "price": 2e-05
+          "price": 0.00002
         }
       }
     }
@@ -8338,13 +8338,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2e-05
+          "price": 0.00002
         },
         "response_token": {
-          "price": 5e-05
+          "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 5e-06
+          "price": 0.000005
         }
       }
     }
@@ -8353,7 +8353,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3e-05
+          "price": 0.00003
         },
         "response_token": {
           "price": 0.00012
@@ -8365,10 +8365,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5e-08
+          "price": 0.00000005
         },
         "response_token": {
-          "price": 5e-08
+          "price": 0.00000005
         }
       }
     }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -40,7 +40,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-05
         },
         "response_token": {
           "price": 0.00015
@@ -56,10 +56,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-05
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-05
         }
       }
     }
@@ -68,7 +68,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-05
         },
         "response_token": {
           "price": 0.00015
@@ -84,10 +84,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-05
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-05
         }
       }
     }
@@ -124,7 +124,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-05
         },
         "response_token": {
           "price": 0.00015
@@ -140,10 +140,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-05
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-05
         }
       }
     }
@@ -152,7 +152,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-05
         },
         "response_token": {
           "price": 0.00015
@@ -168,10 +168,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-05
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-05
         }
       }
     }
@@ -180,7 +180,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-05
         },
         "response_token": {
           "price": 0.00015
@@ -196,10 +196,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-05
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-05
         }
       }
     }
@@ -208,24 +208,24 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-05
         },
         "response_token": {
           "price": 0.000125
         },
         "cache_write_input_token": {
-          "price": 0.00003
+          "price": 3e-05
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-06
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 1.25e-05
         },
         "response_token": {
-          "price": 0.0000625
+          "price": 6.25e-05
         }
       }
     }
@@ -314,7 +314,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 8e-05
         },
         "response_token": {
           "price": 0.0004
@@ -323,12 +323,12 @@
           "price": 0.0001
         },
         "cache_read_input_token": {
-          "price": 0.000008
+          "price": 8e-06
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00004
+          "price": 4e-05
         },
         "response_token": {
           "price": 0.0002
@@ -361,7 +361,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-05
         },
         "response_token": {
           "price": 0.00025
@@ -389,7 +389,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-05
         },
         "response_token": {
           "price": 0.00025
@@ -417,7 +417,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-05
         },
         "response_token": {
           "price": 0.00025
@@ -429,10 +429,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.000003
+          "price": 3e-06
         },
         "additional_units": {
           "web_search": {
@@ -450,10 +450,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-06
         },
         "response_token": {
-          "price": 0.0000015
+          "price": 1.5e-06
         }
       }
     }
@@ -462,10 +462,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.000003
+          "price": 3e-06
         },
         "additional_units": {
           "web_search": {
@@ -478,10 +478,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-06
         },
         "response_token": {
-          "price": 0.0000015
+          "price": 1.5e-06
         }
       }
     }
@@ -490,7 +490,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-06
         },
         "response_token": {
           "price": 0
@@ -498,7 +498,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000002
+          "price": 2e-06
         },
         "response_token": {
           "price": 0
@@ -510,7 +510,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-05
         },
         "response_token": {
           "price": 0
@@ -518,7 +518,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000008
+          "price": 8e-06
         },
         "response_token": {
           "price": 0
@@ -530,7 +530,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-06
         },
         "response_token": {
           "price": 0
@@ -538,7 +538,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000002
+          "price": 2e-06
         },
         "response_token": {
           "price": 0
@@ -550,7 +550,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-05
         },
         "response_token": {
           "price": 0
@@ -558,7 +558,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000008
+          "price": 8e-06
         },
         "response_token": {
           "price": 0
@@ -570,7 +570,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-06
         },
         "response_token": {
           "price": 0
@@ -578,7 +578,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000002
+          "price": 2e-06
         },
         "response_token": {
           "price": 0
@@ -590,7 +590,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-06
         },
         "response_token": {
           "price": 0
@@ -598,7 +598,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000002
+          "price": 2e-06
         },
         "response_token": {
           "price": 0
@@ -610,7 +610,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-05
         },
         "response_token": {
           "price": 0
@@ -618,7 +618,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000008
+          "price": 8e-06
         },
         "response_token": {
           "price": 0
@@ -630,7 +630,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-05
         },
         "response_token": {
           "price": 0
@@ -638,7 +638,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000008
+          "price": 8e-06
         },
         "response_token": {
           "price": 0
@@ -650,7 +650,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-06
         },
         "response_token": {
           "price": 0
@@ -658,7 +658,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000002
+          "price": 2e-06
         },
         "response_token": {
           "price": 0
@@ -876,7 +876,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-05
         },
         "response_token": {
           "price": 0.00025
@@ -896,7 +896,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-05
         },
         "response_token": {
           "price": 0.00025
@@ -908,10 +908,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.000003
+          "price": 3e-06
         },
         "additional_units": {
           "web_search": {
@@ -929,10 +929,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-06
         },
         "response_token": {
-          "price": 0.0000015
+          "price": 1.5e-06
         }
       }
     }
@@ -941,10 +941,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-05
         },
         "additional_units": {
           "web_search": {
@@ -957,10 +957,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-06
         },
         "response_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         }
       }
     }
@@ -969,10 +969,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-05
         },
         "additional_units": {
           "web_search": {
@@ -988,10 +988,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       }
     }
@@ -1000,10 +1000,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-05
         },
         "additional_units": {
           "web_search": {
@@ -1019,10 +1019,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       }
     }
@@ -1071,10 +1071,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-05
         },
         "additional_units": {
           "web_search": {
@@ -1087,10 +1087,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-06
         },
         "response_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         }
       }
     }
@@ -1099,10 +1099,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-05
         },
         "additional_units": {
           "web_search": {
@@ -1118,10 +1118,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-06
         },
         "response_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         }
       }
     }
@@ -1149,10 +1149,285 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-05
         },
         "response_token": {
           "price": 0.0005
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000125
+                  },
+                  "response_token": {
+                    "price": 0.001
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.3e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000125
+                      },
+                      "response_token": {
+                        "price": 0.001
+                      },
+                      "cache_read_input_token": {
+                        "price": 1.3e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "response_token": {
+                        "price": 0.0015
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000225
+                  },
+                  "response_token": {
+                    "price": 0.0018
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.3e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000225
+                      },
+                      "response_token": {
+                        "price": 0.0018
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.3e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00045
+                      },
+                      "response_token": {
+                        "price": 0.0027
+                      },
+                      "cache_read_input_token": {
+                        "price": 4.5e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 6.25e-05
+                  },
+                  "response_token": {
+                    "price": 0.0005
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 6.25e-05
+                      },
+                      "response_token": {
+                        "price": 0.0005
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 0.000125
+                      },
+                      "response_token": {
+                        "price": 0.00075
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1180,10 +1455,285 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-05
         },
         "response_token": {
           "price": 0.0005
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000125
+                  },
+                  "response_token": {
+                    "price": 0.001
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.3e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000125
+                      },
+                      "response_token": {
+                        "price": 0.001
+                      },
+                      "cache_read_input_token": {
+                        "price": 1.3e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "response_token": {
+                        "price": 0.0015
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000225
+                  },
+                  "response_token": {
+                    "price": 0.0018
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.3e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000225
+                      },
+                      "response_token": {
+                        "price": 0.0018
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.3e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00045
+                      },
+                      "response_token": {
+                        "price": 0.0027
+                      },
+                      "cache_read_input_token": {
+                        "price": 4.5e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 6.25e-05
+                  },
+                  "response_token": {
+                    "price": 0.0005
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 6.25e-05
+                      },
+                      "response_token": {
+                        "price": 0.0005
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 0.000125
+                      },
+                      "response_token": {
+                        "price": 0.00075
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1198,10 +1748,10 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 0.00002
+          "price": 2e-05
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-05
         },
         "additional_units": {
           "web_search": {
@@ -1226,6 +1776,281 @@
           "price": 0.0006
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0012
+                  },
+                  "cache_read_input_token": {
+                    "price": 2e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "response_token": {
+                        "price": 0.0012
+                      },
+                      "cache_read_input_token": {
+                        "price": 2e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0004
+                      },
+                      "response_token": {
+                        "price": 0.0018
+                      },
+                      "cache_read_input_token": {
+                        "price": 4e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00036
+                  },
+                  "response_token": {
+                    "price": 0.00216
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.6e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00036
+                      },
+                      "response_token": {
+                        "price": 0.00216
+                      },
+                      "cache_read_input_token": {
+                        "price": 3.6e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00072
+                      },
+                      "response_token": {
+                        "price": 0.00324
+                      },
+                      "cache_read_input_token": {
+                        "price": 7.2e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 0.0001
+                      },
+                      "response_token": {
+                        "price": 0.0006
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "response_token": {
+                        "price": 0.0009
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "gemini-3-pro-preview-02-05": {
@@ -1238,7 +2063,7 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 0.00002
+          "price": 2e-05
         },
         "cache_read_input_token": {
           "price": 0.00045
@@ -1260,16 +2085,291 @@
           "price": 0.0006
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0012
+                  },
+                  "cache_read_input_token": {
+                    "price": 2e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "response_token": {
+                        "price": 0.0012
+                      },
+                      "cache_read_input_token": {
+                        "price": 2e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0004
+                      },
+                      "response_token": {
+                        "price": 0.0018
+                      },
+                      "cache_read_input_token": {
+                        "price": 4e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00036
+                  },
+                  "response_token": {
+                    "price": 0.00216
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.6e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00036
+                      },
+                      "response_token": {
+                        "price": 0.00216
+                      },
+                      "cache_read_input_token": {
+                        "price": 3.6e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00072
+                      },
+                      "response_token": {
+                        "price": 0.00324
+                      },
+                      "cache_read_input_token": {
+                        "price": 7.2e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 0.0001
+                      },
+                      "response_token": {
+                        "price": 0.0006
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "response_token": {
+                        "price": 0.0009
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "gemini-2.5-flash-preview-04-17": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-05
         },
         "additional_units": {
           "web_search": {
@@ -1282,10 +2382,111 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-05
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 3e-05
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  },
+                  "cache_read_input_token": {
+                    "price": 3e-06
+                  },
+                  "request_audio_token": {
+                    "price": 0.0001
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 5.4e-05
+                  },
+                  "response_token": {
+                    "price": 0.00045
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-06
+                  },
+                  "request_audio_token": {
+                    "price": 0.00018
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 1.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "request_audio_token": {
+                    "price": 5e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1294,10 +2495,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-05
         },
         "additional_units": {
           "web_search": {
@@ -1310,10 +2511,111 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-05
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 3e-05
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  },
+                  "cache_read_input_token": {
+                    "price": 3e-06
+                  },
+                  "request_audio_token": {
+                    "price": 0.0001
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 5.4e-05
+                  },
+                  "response_token": {
+                    "price": 0.00045
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-06
+                  },
+                  "request_audio_token": {
+                    "price": 0.00018
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 1.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "request_audio_token": {
+                    "price": 5e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1325,7 +2627,7 @@
           "price": 0
         },
         "response_token": {
-          "price": 0.00002
+          "price": 2e-05
         },
         "additional_units": {
           "input_image": {
@@ -1347,7 +2649,7 @@
           "price": 0
         },
         "response_token": {
-          "price": 0.000016
+          "price": 1.6e-05
         }
       }
     }
@@ -1365,7 +2667,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       },
       "batch_config": {
@@ -1391,7 +2693,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       },
       "batch_config": {
@@ -1434,10 +2736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-05
         },
         "response_token": {
-          "price": 0.00004
+          "price": 4e-05
         },
         "additional_units": {
           "web_search": {
@@ -1450,10 +2752,111 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 5e-06
         },
         "response_token": {
-          "price": 0.00002
+          "price": 2e-05
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 1e-05
+                  },
+                  "response_token": {
+                    "price": 4e-05
+                  },
+                  "cache_read_input_token": {
+                    "price": 1e-06
+                  },
+                  "request_audio_token": {
+                    "price": 3e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 1.8e-05
+                  },
+                  "response_token": {
+                    "price": 7.2e-05
+                  },
+                  "cache_read_input_token": {
+                    "price": 2e-06
+                  },
+                  "request_audio_token": {
+                    "price": 5.4e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5e-06
+                  },
+                  "response_token": {
+                    "price": 2e-05
+                  },
+                  "request_audio_token": {
+                    "price": 1.5e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1462,7 +2865,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-05
         },
         "response_token": {
           "price": 0.00025
@@ -1482,7 +2885,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-06
         }
       },
       "finetune_config": {
@@ -1492,10 +2895,111 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
           "price": 0.000125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 3e-05
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  },
+                  "cache_read_input_token": {
+                    "price": 3e-06
+                  },
+                  "request_audio_token": {
+                    "price": 0.0001
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 5.4e-05
+                  },
+                  "response_token": {
+                    "price": 0.00045
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-06
+                  },
+                  "request_audio_token": {
+                    "price": 0.00018
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 1.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "request_audio_token": {
+                    "price": 5e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1504,7 +3008,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-05
         },
         "response_token": {
           "price": 0.00025
@@ -1524,7 +3028,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-06
         }
       },
       "finetune_config": {
@@ -1534,10 +3038,76 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
           "price": 0.000125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 3e-05
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  },
+                  "response_image_token": {
+                    "price": 0.003
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 1.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "response_image_token": {
+                    "price": 0.0015
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1563,7 +3133,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-05
         }
       },
       "finetune_config": {
@@ -1577,6 +3147,72 @@
         },
         "response_token": {
           "price": 0.0006
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0012
+                  },
+                  "response_image_token": {
+                    "price": 0.012
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "response_image_token": {
+                    "price": 0.006
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1602,7 +3238,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-05
         }
       },
       "finetune_config": {
@@ -1612,10 +3248,285 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-05
         },
         "response_token": {
           "price": 0.0005
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000125
+                  },
+                  "response_token": {
+                    "price": 0.001
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.3e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000125
+                      },
+                      "response_token": {
+                        "price": 0.001
+                      },
+                      "cache_read_input_token": {
+                        "price": 1.3e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "response_token": {
+                        "price": 0.0015
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000225
+                  },
+                  "response_token": {
+                    "price": 0.0018
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.3e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000225
+                      },
+                      "response_token": {
+                        "price": 0.0018
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.3e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00045
+                      },
+                      "response_token": {
+                        "price": 0.0027
+                      },
+                      "cache_read_input_token": {
+                        "price": 4.5e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 6.25e-05
+                  },
+                  "response_token": {
+                    "price": 0.0005
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 6.25e-05
+                      },
+                      "response_token": {
+                        "price": 0.0005
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 0.000125
+                      },
+                      "response_token": {
+                        "price": 0.00075
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1624,10 +3535,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-05
         },
         "response_token": {
-          "price": 0.00004
+          "price": 4e-05
         },
         "additional_units": {
           "web_search": {
@@ -1641,7 +3552,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 1e-06
         }
       },
       "finetune_config": {
@@ -1651,10 +3562,111 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 5e-06
         },
         "response_token": {
-          "price": 0.00002
+          "price": 2e-05
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 1e-05
+                  },
+                  "response_token": {
+                    "price": 4e-05
+                  },
+                  "cache_read_input_token": {
+                    "price": 1e-06
+                  },
+                  "request_audio_token": {
+                    "price": 3e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 1.8e-05
+                  },
+                  "response_token": {
+                    "price": 7.2e-05
+                  },
+                  "cache_read_input_token": {
+                    "price": 2e-06
+                  },
+                  "request_audio_token": {
+                    "price": 5.4e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5e-06
+                  },
+                  "response_token": {
+                    "price": 2e-05
+                  },
+                  "request_audio_token": {
+                    "price": 1.5e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1704,7 +3716,7 @@
       "pay_as_you_go": {},
       "finetune_config": {
         "pay_per_token": {
-          "price": 0.000067
+          "price": 6.7e-05
         }
       }
     }
@@ -1714,7 +3726,7 @@
       "pay_as_you_go": {},
       "finetune_config": {
         "pay_per_token": {
-          "price": 0.000028
+          "price": 2.8e-05
         }
       }
     }
@@ -1724,7 +3736,7 @@
       "pay_as_you_go": {},
       "finetune_config": {
         "pay_per_token": {
-          "price": 0.000061
+          "price": 6.1e-05
         }
       }
     }
@@ -1759,18 +3771,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-05
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       }
     }
@@ -2084,7 +4096,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       },
       "batch_config": {
@@ -2093,6 +4105,170 @@
         },
         "response_token": {
           "price": 0.00075
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0003
+                  },
+                  "response_token": {
+                    "price": 0.0015
+                  },
+                  "cache_read_input_token": {
+                    "price": 3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000375
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.00075
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000188
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east5": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000413
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.7e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000206
+                  }
+                }
+              }
+            }
+          }
+        },
+        "europe-west1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000413
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.7e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000206
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-southeast1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000413
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.7e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000206
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2110,7 +4286,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       },
       "batch_config": {
@@ -2119,6 +4295,170 @@
         },
         "response_token": {
           "price": 0.00075
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0003
+                  },
+                  "response_token": {
+                    "price": 0.0015
+                  },
+                  "cache_read_input_token": {
+                    "price": 3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000375
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.00075
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000188
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east5": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000413
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.7e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000206
+                  }
+                }
+              }
+            }
+          }
+        },
+        "europe-west1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000413
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.7e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000206
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-southeast1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000413
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.7e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000206
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2136,15 +4476,219 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 1e-05
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-05
         },
         "response_token": {
           "price": 0.00025
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0005
+                  },
+                  "cache_read_input_token": {
+                    "price": 1e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000125
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5e-05
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-06
+                  },
+                  "cache_write_input_token": {
+                    "price": 6.25e-05
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east5": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00011
+                  },
+                  "response_token": {
+                    "price": 0.00055
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.1e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001375
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-06
+                  },
+                  "cache_write_input_token": {
+                    "price": 6.88e-05
+                  }
+                }
+              }
+            }
+          }
+        },
+        "europe-west1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00011
+                  },
+                  "response_token": {
+                    "price": 0.00055
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.1e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001375
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-06
+                  },
+                  "cache_write_input_token": {
+                    "price": 6.88e-05
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-southeast1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00011
+                  },
+                  "response_token": {
+                    "price": 0.00055
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.1e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001375
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-06
+                  },
+                  "cache_write_input_token": {
+                    "price": 6.88e-05
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-east1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00011
+                  },
+                  "response_token": {
+                    "price": 0.00055
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.1e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001375
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-06
+                  },
+                  "cache_write_input_token": {
+                    "price": 6.88e-05
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2162,15 +4706,219 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 1e-05
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-05
         },
         "response_token": {
           "price": 0.00025
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0005
+                  },
+                  "cache_read_input_token": {
+                    "price": 1e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000125
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5e-05
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-06
+                  },
+                  "cache_write_input_token": {
+                    "price": 6.25e-05
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east5": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00011
+                  },
+                  "response_token": {
+                    "price": 0.00055
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.1e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001375
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-06
+                  },
+                  "cache_write_input_token": {
+                    "price": 6.88e-05
+                  }
+                }
+              }
+            }
+          }
+        },
+        "europe-west1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00011
+                  },
+                  "response_token": {
+                    "price": 0.00055
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.1e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001375
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-06
+                  },
+                  "cache_write_input_token": {
+                    "price": 6.88e-05
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-southeast1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00011
+                  },
+                  "response_token": {
+                    "price": 0.00055
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.1e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001375
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-06
+                  },
+                  "cache_write_input_token": {
+                    "price": 6.88e-05
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-east1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00011
+                  },
+                  "response_token": {
+                    "price": 0.00055
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.1e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001375
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-06
+                  },
+                  "cache_write_input_token": {
+                    "price": 6.88e-05
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2199,7 +4947,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
           "price": 0
@@ -2207,7 +4955,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
+          "price": 1.2e-05
         },
         "response_token": {
           "price": 0
@@ -2435,7 +5183,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-05
         }
       },
       "batch_config": {
@@ -2444,6 +5192,170 @@
         },
         "response_token": {
           "price": 0.00125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east5": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
+        },
+        "europe-west1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-southeast1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2461,7 +5373,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-05
         }
       },
       "batch_config": {
@@ -2472,13 +5384,177 @@
           "price": 0.00125
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east5": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
+        },
+        "europe-west1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-southeast1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "gemini-2.5-flash-image-preview": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-05
         },
         "response_token": {
           "price": 0.00025
@@ -2498,15 +5574,81 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-06
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
           "price": 0.000125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 3e-05
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  },
+                  "response_image_token": {
+                    "price": 0.003
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 1.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "response_image_token": {
+                    "price": 0.0015
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2561,16 +5703,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-05
         },
         "response_token": {
           "price": 0.0003
         },
         "cache_write_input_token": {
-          "price": 0.00005
+          "price": 5e-05
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 5e-06
         },
         "additional_units": {
           "web_search": {
@@ -2583,10 +5725,111 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-05
         },
         "response_token": {
           "price": 0.00015
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 5e-05
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-06
+                  },
+                  "request_audio_token": {
+                    "price": 0.0001
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 9e-05
+                  },
+                  "response_token": {
+                    "price": 0.00054
+                  },
+                  "cache_read_input_token": {
+                    "price": 9e-06
+                  },
+                  "request_audio_token": {
+                    "price": 0.00018
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 2.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  },
+                  "request_audio_token": {
+                    "price": 5e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2604,7 +5847,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-05
         }
       },
       "batch_config": {
@@ -2613,6 +5856,170 @@
         },
         "response_token": {
           "price": 0.00125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east5": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
+        },
+        "europe-west1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-southeast1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2630,7 +6037,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-05
         }
       },
       "batch_config": {
@@ -2639,6 +6046,170 @@
         },
         "response_token": {
           "price": 0.00125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east5": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
+        },
+        "europe-west1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-southeast1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_read_input_token": {
+                    "price": 5.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 2.75e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003438
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2656,7 +6227,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       },
       "batch_config": {
@@ -2665,6 +6236,170 @@
         },
         "response_token": {
           "price": 0.00075
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0003
+                  },
+                  "response_token": {
+                    "price": 0.0015
+                  },
+                  "cache_read_input_token": {
+                    "price": 3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000375
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.00075
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.5e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000188
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east5": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000413
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.7e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000206
+                  }
+                }
+              }
+            }
+          }
+        },
+        "europe-west1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000413
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.7e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000206
+                  }
+                }
+              }
+            }
+          }
+        },
+        "asia-southeast1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.3e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000413
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 1.7e-05
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000206
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2679,10 +6414,10 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 0.00002
+          "price": 2e-05
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-05
         },
         "additional_units": {
           "web_search": {
@@ -2704,6 +6439,281 @@
           "price": 0.0006
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0012
+                  },
+                  "cache_read_input_token": {
+                    "price": 2e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "response_token": {
+                        "price": 0.0012
+                      },
+                      "cache_read_input_token": {
+                        "price": 2e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0004
+                      },
+                      "response_token": {
+                        "price": 0.0018
+                      },
+                      "cache_read_input_token": {
+                        "price": 4e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00036
+                  },
+                  "response_token": {
+                    "price": 0.00216
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.6e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00036
+                      },
+                      "response_token": {
+                        "price": 0.00216
+                      },
+                      "cache_read_input_token": {
+                        "price": 3.6e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00072
+                      },
+                      "response_token": {
+                        "price": 0.00324
+                      },
+                      "cache_read_input_token": {
+                        "price": 7.2e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 0.0001
+                      },
+                      "response_token": {
+                        "price": 0.0006
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "response_token": {
+                        "price": 0.0009
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "gemini-3.1-pro-preview-customtools": {
@@ -2716,7 +6726,7 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 0.00002
+          "price": 2e-05
         },
         "cache_read_input_token": {
           "price": 0.00045
@@ -2738,22 +6748,297 @@
           "price": 0.0006
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0012
+                  },
+                  "cache_read_input_token": {
+                    "price": 2e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "response_token": {
+                        "price": 0.0012
+                      },
+                      "cache_read_input_token": {
+                        "price": 2e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0004
+                      },
+                      "response_token": {
+                        "price": 0.0018
+                      },
+                      "cache_read_input_token": {
+                        "price": 4e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00036
+                  },
+                  "response_token": {
+                    "price": 0.00216
+                  },
+                  "cache_read_input_token": {
+                    "price": 3.6e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00036
+                      },
+                      "response_token": {
+                        "price": 0.00216
+                      },
+                      "cache_read_input_token": {
+                        "price": 3.6e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00072
+                      },
+                      "response_token": {
+                        "price": 0.00324
+                      },
+                      "cache_read_input_token": {
+                        "price": 7.2e-05
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 0.0001
+                      },
+                      "response_token": {
+                        "price": 0.0006
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "batch_config": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "response_token": {
+                        "price": 0.0009
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1.4
+                        },
+                        "search": {
+                          "price": 1.4
+                        },
+                        "enterprise_web_search": {
+                          "price": 1.4
+                        },
+                        "maps": {
+                          "price": 1.4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "gemini-3.1-flash-lite-preview": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-05
         },
         "response_token": {
           "price": 0.00015
         },
         "cache_write_input_token": {
-          "price": 0.000025
+          "price": 2.5e-05
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 2.5e-06
         },
         "additional_units": {
           "web_search": {
@@ -2766,10 +7051,111 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 1.25e-05
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-05
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 2.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  },
+                  "cache_read_input_token": {
+                    "price": 3e-06
+                  },
+                  "request_audio_token": {
+                    "price": 5e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 4.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.00027
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-06
+                  },
+                  "request_audio_token": {
+                    "price": 9e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 1.3e-05
+                  },
+                  "response_token": {
+                    "price": 7.5e-05
+                  },
+                  "request_audio_token": {
+                    "price": 2.5e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2778,7 +7164,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-05
         },
         "response_token": {
           "price": 0.0003
@@ -2797,10 +7183,76 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-05
         },
         "response_token": {
           "price": 0.00015
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 5e-05
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  },
+                  "response_image_token": {
+                    "price": 0.006
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 2.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  },
+                  "response_image_token": {
+                    "price": 0.003
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2846,13 +7298,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-05
         },
         "response_token": {
           "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-06
         },
         "additional_units": {
           "web_search": {
@@ -2871,10 +7323,111 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
           "price": 0.000125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 3e-05
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  },
+                  "cache_read_input_token": {
+                    "price": 3e-06
+                  },
+                  "request_audio_token": {
+                    "price": 0.0001
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 5.4e-05
+                  },
+                  "response_token": {
+                    "price": 0.00045
+                  },
+                  "cache_read_input_token": {
+                    "price": 5e-06
+                  },
+                  "request_audio_token": {
+                    "price": 0.00018
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 1.5e-05
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "request_audio_token": {
+                    "price": 5e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2883,13 +7436,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-05
         },
         "response_token": {
-          "price": 0.00004
+          "price": 4e-05
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 1e-06
         },
         "additional_units": {
           "web_search": {
@@ -2905,10 +7458,111 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 5e-06
         },
         "response_token": {
-          "price": 0.00002
+          "price": 2e-05
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 1e-05
+                  },
+                  "response_token": {
+                    "price": 4e-05
+                  },
+                  "cache_read_input_token": {
+                    "price": 1e-06
+                  },
+                  "request_audio_token": {
+                    "price": 3e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 1.8e-05
+                  },
+                  "response_token": {
+                    "price": 7.2e-05
+                  },
+                  "cache_read_input_token": {
+                    "price": 2e-06
+                  },
+                  "request_audio_token": {
+                    "price": 5.4e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "batch_config": {
+                  "request_token": {
+                    "price": 5e-06
+                  },
+                  "response_token": {
+                    "price": 2e-05
+                  },
+                  "request_audio_token": {
+                    "price": 1.5e-05
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2934,13 +7588,104 @@
           }
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000125
+                  },
+                  "response_token": {
+                    "price": 0.001
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 3.5
+                    },
+                    "search": {
+                      "price": 3.5
+                    },
+                    "enterprise_web_search": {
+                      "price": 4.5
+                    },
+                    "maps": {
+                      "price": 2.5
+                    }
+                  }
+                }
+              },
+              "context_tier_boundaries": [
+                200000
+              ],
+              "context_tiers": {
+                "lte-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000125
+                      },
+                      "response_token": {
+                        "price": 0.001
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200000": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "response_token": {
+                        "price": 0.0015
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 3.5
+                        },
+                        "search": {
+                          "price": 3.5
+                        },
+                        "enterprise_web_search": {
+                          "price": 4.5
+                        },
+                        "maps": {
+                          "price": 2.5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "gemini-embedding-2-preview": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 2e-05
         },
         "response_token": {
           "price": 0
@@ -2991,7 +7736,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-06
         },
         "response_token": {
           "price": 0
@@ -3003,7 +7748,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-06
         },
         "response_token": {
           "price": 0
@@ -3029,18 +7774,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000009
+          "price": 9e-06
         },
         "response_token": {
-          "price": 0.000036
+          "price": 3.6e-05
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000045
+          "price": 4.5e-06
         },
         "response_token": {
-          "price": 0.000018
+          "price": 1.8e-05
         }
       }
     }
@@ -3049,18 +7794,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000072
+          "price": 7.2e-05
         },
         "response_token": {
-          "price": 0.000072
+          "price": 7.2e-05
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000036
+          "price": 3.6e-05
         },
         "response_token": {
-          "price": 0.000036
+          "price": 3.6e-05
         }
       }
     }
@@ -3069,7 +7814,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000035
+          "price": 3.5e-05
         },
         "response_token": {
           "price": 0.000115
@@ -3077,10 +7822,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000175
+          "price": 1.75e-05
         },
         "response_token": {
-          "price": 0.0000575
+          "price": 5.75e-05
         }
       }
     }
@@ -3089,10 +7834,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-05
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       }
     }
@@ -3101,7 +7846,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 4e-05
         },
         "response_token": {
           "price": 0.0002
@@ -3113,10 +7858,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-05
         },
         "response_token": {
-          "price": 0.00009
+          "price": 9e-05
         }
       }
     }
@@ -3133,7 +7878,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000675
+          "price": 6.75e-05
         },
         "response_token": {
           "price": 0.00027
@@ -3145,21 +7890,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-05
         },
         "response_token": {
           "price": 0.00017
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 6e-06
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-05
         },
         "response_token": {
-          "price": 0.000085
+          "price": 8.5e-05
         }
       }
     }
@@ -3168,21 +7913,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000056
+          "price": 5.6e-05
         },
         "response_token": {
           "price": 0.000168
         },
         "cache_read_input_token": {
-          "price": 0.0000056
+          "price": 5.6e-06
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000028
+          "price": 2.8e-05
         },
         "response_token": {
-          "price": 0.000084
+          "price": 8.4e-05
         }
       }
     }
@@ -3203,18 +7948,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 2.2e-05
         },
         "response_token": {
-          "price": 0.000088
+          "price": 8.8e-05
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000011
+          "price": 1.1e-05
         },
         "response_token": {
-          "price": 0.000044
+          "price": 4.4e-05
         }
       }
     }
@@ -3223,21 +7968,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 2.2e-05
         },
         "response_token": {
           "price": 0.00018
         },
         "cache_read_input_token": {
-          "price": 0.0000022
+          "price": 2.2e-06
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000011
+          "price": 1.1e-05
         },
         "response_token": {
-          "price": 0.00009
+          "price": 9e-05
         }
       }
     }
@@ -3246,7 +7991,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
           "price": 0.00012
@@ -3258,7 +8003,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
           "price": 0.00012
@@ -3270,13 +8015,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-05
         },
         "response_token": {
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-06
         }
       }
     }
@@ -3285,13 +8030,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-05
         },
         "response_token": {
           "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 6e-06
         }
       }
     }
@@ -3300,7 +8045,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-05
         },
         "response_token": {
           "price": 0.00022
@@ -3318,7 +8063,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 1e-05
         }
       }
     }
@@ -3327,18 +8072,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-05
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       }
     }
@@ -3408,7 +8153,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       },
       "batch_config": {
@@ -3434,12 +8179,12 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 1e-05
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-05
         },
         "response_token": {
           "price": 0.00025
@@ -3460,7 +8205,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-05
         }
       },
       "batch_config": {
@@ -3486,7 +8231,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-05
         }
       },
       "batch_config": {
@@ -3503,18 +8248,153 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-05
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-05
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-06
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-05
+        }
+      }
+    }
+  },
+  "gemma-4-26b-it": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5e-05
+        },
+        "response_token": {
+          "price": 6e-05
+        }
+      }
+    }
+  },
+  "llama-4-scout-17b-16e-instruct-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5e-05
+        },
+        "response_token": {
+          "price": 7e-05
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 1.25e-05
+        },
+        "response_token": {
+          "price": 3.5e-05
+        }
+      }
+    }
+  },
+  "gpt-oss-20b-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7e-06
+        },
+        "response_token": {
+          "price": 2.5e-05
+        },
+        "cache_read_input_token": {
+          "price": 7e-07
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 3.5e-06
+        },
+        "response_token": {
+          "price": 1.25e-05
+        }
+      }
+    }
+  },
+  "grok-4.20-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0006
+        },
+        "cache_read_input_token": {
+          "price": 2e-05
+        }
+      }
+    }
+  },
+  "grok-4.1-fast-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2e-05
+        },
+        "response_token": {
+          "price": 5e-05
+        },
+        "cache_read_input_token": {
+          "price": 5e-06
+        }
+      }
+    }
+  },
+  "deepseek-ocr-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3e-05
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "mistral-ocr-2505": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5e-08
+        },
+        "response_token": {
+          "price": 5e-08
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_seconds": {
+            "price": 0.03
+          },
+          "video_seconds_1080p": {
+            "price": 0.05
+          },
+          "video_audio_seconds": {
+            "price": 0.05
+          },
+          "video_audio_seconds_1080p": {
+            "price": 0.08
+          }
         }
       }
     }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -5158,6 +5158,15 @@
           "video_seconds": {
             "price": 20
           },
+          "video_seconds_1080p": {
+            "price": 20
+          },
+          "video_seconds_4k": {
+            "price": 40
+          },
+          "video_audio_seconds": {
+            "price": 20
+          },
           "default_duration_seconds": {
             "price": 8
           },
@@ -5179,7 +5188,16 @@
         },
         "additional_units": {
           "video_seconds": {
+            "price": 8
+          },
+          "video_seconds_1080p": {
             "price": 10
+          },
+          "video_seconds_4k": {
+            "price": 25
+          },
+          "video_audio_seconds": {
+            "price": 2
           },
           "default_duration_seconds": {
             "price": 8
@@ -5204,6 +5222,12 @@
           "video_seconds": {
             "price": 20
           },
+          "video_seconds_1080p": {
+            "price": 20
+          },
+          "video_audio_seconds": {
+            "price": 20
+          },
           "default_duration_seconds": {
             "price": 8
           },
@@ -5225,7 +5249,13 @@
         },
         "additional_units": {
           "video_seconds": {
+            "price": 8
+          },
+          "video_seconds_1080p": {
             "price": 10
+          },
+          "video_audio_seconds": {
+            "price": 2
           },
           "default_duration_seconds": {
             "price": 8
@@ -5250,6 +5280,12 @@
           "video_seconds": {
             "price": 20
           },
+          "video_seconds_1080p": {
+            "price": 20
+          },
+          "video_audio_seconds": {
+            "price": 20
+          },
           "default_duration_seconds": {
             "price": 8
           },
@@ -5271,7 +5307,13 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 8
+          },
+          "video_seconds_1080p": {
+            "price": 10
+          },
+          "video_audio_seconds": {
+            "price": 2
           },
           "default_duration_seconds": {
             "price": 8
@@ -5932,7 +5974,16 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
+          },
+          "video_seconds_1080p": {
+            "price": 10
+          },
+          "video_seconds_4k": {
+            "price": 25
+          },
+          "video_audio_seconds": {
+            "price": 2
           },
           "default_duration_seconds": {
             "price": 8
@@ -5955,6 +6006,15 @@
         },
         "additional_units": {
           "video_seconds": {
+            "price": 20
+          },
+          "video_seconds_1080p": {
+            "price": 20
+          },
+          "video_seconds_4k": {
+            "price": 40
+          },
+          "video_audio_seconds": {
             "price": 20
           },
           "default_duration_seconds": {
@@ -8886,16 +8946,13 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0.03
+            "price": 3
           },
           "video_seconds_1080p": {
-            "price": 0.05
+            "price": 5
           },
           "video_audio_seconds": {
-            "price": 0.05
-          },
-          "video_audio_seconds_1080p": {
-            "price": 0.08
+            "price": 2
           }
         }
       }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -1144,7 +1144,13 @@
           },
           "enterprise_web_search": {
             "price": 4.5
+          },
+          "maps": {
+            "price": 2.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1366,6 +1372,14 @@
                     "maps": {
                       "price": 2.5
                     }
+                  }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000625
+                  },
+                  "response_token": {
+                    "price": 0.0005
                   }
                 }
               },
@@ -1450,7 +1464,13 @@
           },
           "enterprise_web_search": {
             "price": 4.5
+          },
+          "maps": {
+            "price": 2.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1672,6 +1692,14 @@
                     "maps": {
                       "price": 2.5
                     }
+                  }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000625
+                  },
+                  "response_token": {
+                    "price": 0.0005
                   }
                 }
               },
@@ -1765,6 +1793,9 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "maps": {
+            "price": 1.4
           }
         }
       },
@@ -2030,6 +2061,17 @@
                   "cache_write_input_token": {
                     "price": 0.00001
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001
+                  }
                 }
               },
               "context_tier_boundaries": [
@@ -2120,14 +2162,20 @@
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          },
+          "maps": {
+            "price": 1.4
           }
         }
       },
@@ -2372,6 +2420,17 @@
                   "cache_write_input_token": {
                     "price": 0.00001
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001
+                  }
                 }
               },
               "context_tier_boundaries": [
@@ -2447,10 +2506,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -2458,7 +2517,19 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          },
+          "maps": {
+            "price": 2.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        },
+        "request_audio_token": {
+          "price": 0.0001
         }
       },
       "batch_config": {
@@ -2563,6 +2634,17 @@
                     "maps": {
                       "price": 2.5
                     }
+                  }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "request_audio_token": {
+                    "price": 0.00005
                   }
                 }
               }
@@ -2576,10 +2658,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -2587,7 +2669,19 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          },
+          "maps": {
+            "price": 2.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        },
+        "request_audio_token": {
+          "price": 0.0001
         }
       },
       "batch_config": {
@@ -2692,6 +2786,17 @@
                     "maps": {
                       "price": 2.5
                     }
+                  }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "request_audio_token": {
+                    "price": 0.00005
                   }
                 }
               }
@@ -2828,7 +2933,19 @@
           },
           "search": {
             "price": 3.5
+          },
+          "enterprise_web_search": {
+            "price": 4.5
+          },
+          "maps": {
+            "price": 2.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        },
+        "request_audio_token": {
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -2934,6 +3051,17 @@
                       "price": 2.5
                     }
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  },
+                  "request_audio_token": {
+                    "price": 0.000015
+                  }
                 }
               }
             }
@@ -2963,10 +3091,16 @@
           },
           "image_token": {
             "price": 0.003
+          },
+          "maps": {
+            "price": 2.5
           }
         },
         "cache_read_input_token": {
           "price": 0.000003
+        },
+        "request_audio_token": {
+          "price": 0.0001
         }
       },
       "finetune_config": {
@@ -3086,6 +3220,17 @@
                       "price": 0.0015
                     }
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "request_audio_token": {
+                    "price": 0.00005
+                  }
                 }
               }
             }
@@ -3115,6 +3260,9 @@
           },
           "enterprise_web_search": {
             "price": 4.5
+          },
+          "maps": {
+            "price": 2.5
           }
         },
         "cache_read_input_token": {
@@ -3200,6 +3348,17 @@
                       "price": 0.0015
                     }
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "response_image_token": {
+                    "price": 0.0015
+                  }
                 }
               }
             }
@@ -3225,6 +3384,12 @@
             "price": 0.012
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          },
+          "maps": {
             "price": 1.4
           }
         },
@@ -3311,6 +3476,17 @@
                       "price": 0.006
                     }
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "response_image_token": {
+                    "price": 0.006
+                  }
                 }
               }
             }
@@ -3337,10 +3513,13 @@
           },
           "enterprise_web_search": {
             "price": 4.5
+          },
+          "maps": {
+            "price": 2.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "finetune_config": {
@@ -3568,6 +3747,14 @@
                       "price": 2.5
                     }
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000625
+                  },
+                  "response_token": {
+                    "price": 0.0005
+                  }
                 }
               },
               "context_tier_boundaries": [
@@ -3651,10 +3838,16 @@
           },
           "enterprise_web_search": {
             "price": 4.5
+          },
+          "maps": {
+            "price": 2.5
           }
         },
         "cache_read_input_token": {
           "price": 0.000001
+        },
+        "request_audio_token": {
+          "price": 0.00003
         }
       },
       "finetune_config": {
@@ -3764,6 +3957,17 @@
                     "maps": {
                       "price": 2.5
                     }
+                  }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  },
+                  "request_audio_token": {
+                    "price": 0.000015
                   }
                 }
               }
@@ -4247,6 +4451,20 @@
                   "cache_write_input_token": {
                     "price": 0.0001875
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.00075
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000015
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001875
+                  }
                 }
               }
             }
@@ -4275,6 +4493,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000165
                   },
@@ -4327,6 +4559,20 @@
                   "cache_write_input_token": {
                     "price": 0.00020625
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
                 }
               }
             }
@@ -4367,6 +4613,20 @@
                   "cache_write_input_token": {
                     "price": 0.00020625
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
                 }
               }
             }
@@ -4395,6 +4655,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000165
                   },
@@ -4477,6 +4751,20 @@
                   "cache_write_input_token": {
                     "price": 0.0001875
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.00075
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000015
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001875
+                  }
                 }
               }
             }
@@ -4505,6 +4793,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000165
                   },
@@ -4557,6 +4859,20 @@
                   "cache_write_input_token": {
                     "price": 0.00020625
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
                 }
               }
             }
@@ -4597,6 +4913,20 @@
                   "cache_write_input_token": {
                     "price": 0.00020625
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
                 }
               }
             }
@@ -4625,6 +4955,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000165
                   },
@@ -4707,6 +5051,20 @@
                   "cache_write_input_token": {
                     "price": 0.0000625
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000005
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000625
+                  }
                 }
               }
             }
@@ -4735,6 +5093,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000055
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00006875
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000055
                   },
@@ -4787,6 +5159,20 @@
                   "cache_write_input_token": {
                     "price": 0.00006875
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000055
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00006875
+                  }
                 }
               }
             }
@@ -4827,6 +5213,20 @@
                   "cache_write_input_token": {
                     "price": 0.00006875
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000055
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00006875
+                  }
                 }
               }
             }
@@ -4855,6 +5255,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000055
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00006875
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000055
                   },
@@ -4937,6 +5351,20 @@
                   "cache_write_input_token": {
                     "price": 0.0000625
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000005
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000625
+                  }
                 }
               }
             }
@@ -4965,6 +5393,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000055
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00006875
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000055
                   },
@@ -5017,6 +5459,20 @@
                   "cache_write_input_token": {
                     "price": 0.00006875
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000055
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00006875
+                  }
                 }
               }
             }
@@ -5057,6 +5513,20 @@
                   "cache_write_input_token": {
                     "price": 0.00006875
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000055
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00006875
+                  }
                 }
               }
             }
@@ -5085,6 +5555,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000055
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000055
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00006875
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000055
                   },
@@ -5456,6 +5940,20 @@
                   "cache_write_input_token": {
                     "price": 0.0003125
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  }
                 }
               }
             }
@@ -5484,6 +5982,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000275
                   },
@@ -5536,6 +6048,20 @@
                   "cache_write_input_token": {
                     "price": 0.00034375
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
                 }
               }
             }
@@ -5576,6 +6102,20 @@
                   "cache_write_input_token": {
                     "price": 0.00034375
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
                 }
               }
             }
@@ -5604,6 +6144,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000275
                   },
@@ -5686,6 +6240,20 @@
                   "cache_write_input_token": {
                     "price": 0.0003125
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  }
                 }
               }
             }
@@ -5714,6 +6282,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000275
                   },
@@ -5766,6 +6348,20 @@
                   "cache_write_input_token": {
                     "price": 0.00034375
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
                 }
               }
             }
@@ -5794,6 +6390,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000275
                   },
@@ -5846,6 +6456,20 @@
                   "cache_write_input_token": {
                     "price": 0.00034375
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
                 }
               }
             }
@@ -5875,6 +6499,9 @@
           },
           "enterprise_web_search": {
             "price": 4.5
+          },
+          "maps": {
+            "price": 2.5
           }
         },
         "cache_read_input_token": {
@@ -5954,6 +6581,17 @@
                     "image_token": {
                       "price": 0.0015
                     }
+                  }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "response_image_token": {
+                    "price": 0.0015
                   }
                 }
               }
@@ -6048,7 +6686,16 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          },
+          "maps": {
+            "price": 1.4
           }
+        },
+        "request_audio_token": {
+          "price": 0.0001
         }
       },
       "batch_config": {
@@ -6163,6 +6810,20 @@
                   "cache_write_input_token": {
                     "price": 0.000025
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  },
+                  "request_audio_token": {
+                    "price": 0.00005
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000025
+                  }
                 }
               }
             }
@@ -6233,6 +6894,20 @@
                   "cache_write_input_token": {
                     "price": 0.0003125
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  }
                 }
               }
             }
@@ -6261,6 +6936,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000275
                   },
@@ -6313,6 +7002,20 @@
                   "cache_write_input_token": {
                     "price": 0.00034375
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
                 }
               }
             }
@@ -6353,6 +7056,20 @@
                   "cache_write_input_token": {
                     "price": 0.00034375
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
                 }
               }
             }
@@ -6381,6 +7098,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000275
                   },
@@ -6463,6 +7194,20 @@
                   "cache_write_input_token": {
                     "price": 0.0003125
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  }
                 }
               }
             }
@@ -6491,6 +7236,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000275
                   },
@@ -6543,6 +7302,20 @@
                   "cache_write_input_token": {
                     "price": 0.00034375
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
                 }
               }
             }
@@ -6583,6 +7356,20 @@
                   "cache_write_input_token": {
                     "price": 0.00034375
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
                 }
               }
             }
@@ -6611,6 +7398,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000275
                   },
@@ -6693,6 +7494,20 @@
                   "cache_write_input_token": {
                     "price": 0.0001875
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.00075
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000015
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001875
+                  }
                 }
               }
             }
@@ -6721,6 +7536,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000165
                   },
@@ -6773,6 +7602,20 @@
                   "cache_write_input_token": {
                     "price": 0.00020625
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
                 }
               }
             }
@@ -6801,6 +7644,20 @@
             "batch": {
               "pricing_config": {
                 "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
+                },
+                "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000165
                   },
@@ -6853,6 +7710,20 @@
                   "cache_write_input_token": {
                     "price": 0.00020625
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  }
                 }
               }
             }
@@ -6885,6 +7756,12 @@
           },
           "image_token": {
             "price": 0.012
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          },
+          "maps": {
+            "price": 1.4
           }
         }
       },
@@ -7150,6 +8027,17 @@
                   "cache_write_input_token": {
                     "price": 0.00001
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001
+                  }
                 }
               },
               "context_tier_boundaries": [
@@ -7240,14 +8128,20 @@
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          },
+          "maps": {
+            "price": 1.4
           }
         }
       },
@@ -7492,6 +8386,17 @@
                   "cache_write_input_token": {
                     "price": 0.00001
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001
+                  }
                 }
               },
               "context_tier_boundaries": [
@@ -7576,7 +8481,7 @@
           "price": 0.000025
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -7584,7 +8489,16 @@
           },
           "search": {
             "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          },
+          "maps": {
+            "price": 1.4
           }
+        },
+        "request_audio_token": {
+          "price": 0.00005
         }
       },
       "batch_config": {
@@ -7699,6 +8613,20 @@
                   "cache_write_input_token": {
                     "price": 0.0000125
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000013
+                  },
+                  "response_token": {
+                    "price": 0.000075
+                  },
+                  "request_audio_token": {
+                    "price": 0.000025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000125
+                  }
                 }
               }
             }
@@ -7724,6 +8652,12 @@
             "price": 1.4
           },
           "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          },
+          "maps": {
             "price": 1.4
           }
         }
@@ -7802,6 +8736,17 @@
                       "price": 0.003
                     }
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  },
+                  "response_image_token": {
+                    "price": 0.003
+                  }
                 }
               }
             }
@@ -7871,7 +8816,13 @@
           },
           "image_token": {
             "price": 0.003
+          },
+          "maps": {
+            "price": 2.5
           }
+        },
+        "request_audio_token": {
+          "price": 0.0001
         }
       },
       "batch_config": {
@@ -7986,6 +8937,17 @@
                       "price": 0.0015
                     }
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "request_audio_token": {
+                    "price": 0.00005
+                  }
                 }
               }
             }
@@ -8015,7 +8977,13 @@
           },
           "enterprise_web_search": {
             "price": 4.5
+          },
+          "maps": {
+            "price": 2.5
           }
+        },
+        "request_audio_token": {
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -8121,6 +9089,17 @@
                       "price": 2.5
                     }
                   }
+                },
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  },
+                  "request_audio_token": {
+                    "price": 0.000015
+                  }
                 }
               }
             }
@@ -8147,6 +9126,9 @@
           },
           "enterprise_web_search": {
             "price": 4.5
+          },
+          "maps": {
+            "price": 2.5
           }
         }
       }


### PR DESCRIPTION
- Gemini 2.5 Pro: standard/priority/batch execution modes with <=200K/>200K context tier boundaries and grounding search prices
- Gemini 2.5 Flash, Flash Lite, Flash Image: standard/priority/batch modes (flat, no context tiers)
- Gemini 3.x series (3 Pro, 3 Flash, 3.1 Pro, 3.1 Flash-Lite, 3.1 Flash Image): standard/priority/batch with context tiers where applicable
- Claude models (Opus 4.6, Sonnet 4.6, Haiku 4.5, plus versioned aliases): regional custom_pricing for global, us-east5, europe-west1, asia-southeast1, asia-east1
- New model entries: gemma-4-26b-it, gpt-oss-20b-maas, grok-4.20-maas, grok-4.1-fast-maas, deepseek-ocr-maas, mistral-ocr-2505, veo-3.1-lite-generate-preview
- Existing pricing_config + batch_config preserved as default fallback and synced with custom_pricing standard mode values
- general/vertex-ai.json updated with new model entries

# Description

Add multi-layer custom_pricing for Vertex AI models with execution mode support (standard/priority/batch), context tier boundaries, regional pricing, and grounding/search additional units.

- [x] New model pricing
- [x] Update existing pricing
- [x] New model configuration

## Source Verification

**Source Links:**
- [Google Cloud Vertex AI Generative AI Pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing)
- [Google Cloud Vertex AI Pricing (general)](https://cloud.google.com/vertex-ai/pricing)
- [Anthropic on Vertex AI Pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models)

> [!IMPORTANT]
> Please include a link to the official pricing page from the provider. Simple "I heard it from somewhere" or screenshot sources are not accepted.

## Checklist

- [x] I have validated the JSON using `jq` or an online validator
- [x] I have verified that prices are in **cents per token** (not dollars)
- [x] I have included the source link above
- [ ] I have signed the CLA (if first-time contributor)

## Related Issue

N/A