### PR TITLE
feat: add custom_pricing (standard/batch/fast) for Claude Opus 4.6/4.7/4.8

### DIFF
--- a/pricing/anthropic.json
+++ b/pricing/anthropic.json
@@ -648,6 +648,154 @@
     }
   },
   "claude-opus-4-6": {
+    "custom_pricing": {
+      "regions": {
+        "global": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00005
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000025
+                  }
+                },
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000025
+                  }
+                }
+              }
+            },
+            "fast": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.003
+                  },
+                  "response_token": {
+                    "price": 0.015
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00055
+                  },
+                  "response_token": {
+                    "price": 0.00275
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0006875
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000055
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  }
+                },
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000275
+                  },
+                  "response_token": {
+                    "price": 0.001375
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00034375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000275
+                  }
+                }
+              }
+            },
+            "fast": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0033
+                  },
+                  "response_token": {
+                    "price": 0.0165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.004125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00033
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -669,11 +817,129 @@
         },
         "response_token": {
           "price": 0.00125
+        },
+        "cache_write_input_token": {
+          "price": 0.0003125
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
         }
       }
     }
   },
   "claude-sonnet-4-6": {
+    "custom_pricing": {
+      "regions": {
+        "global": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0003
+                  },
+                  "response_token": {
+                    "price": 0.0015
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.00075
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001875
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000015
+                  }
+                },
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.00075
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0001875
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00033
+                  },
+                  "response_token": {
+                    "price": 0.00165
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0004125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000033
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  }
+                },
+                "batch_config": {
+                  "request_token": {
+                    "price": 0.000165
+                  },
+                  "response_token": {
+                    "price": 0.000825
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00020625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000165
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -695,6 +961,12 @@
         },
         "response_token": {
           "price": 0.00075
+        },
+        "cache_write_input_token": {
+          "price": 0.0001875
+        },
+        "cache_read_input_token": {
+          "price": 0.000015
         }
       }
     }

--- a/pricing/anthropic.json
+++ b/pricing/anthropic.json
@@ -791,6 +791,72 @@
           "price": 0.00125
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00005
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.001
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  }
+                }
+              }
+            },
+            "fast": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.003
+                  },
+                  "response_token": {
+                    "price": 0.015
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.006
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "claude-sonnet-4-6": {
@@ -915,6 +981,72 @@
           "price": 0.00125
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00005
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.001
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  }
+                }
+              }
+            },
+            "fast": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.003
+                  },
+                  "response_token": {
+                    "price": 0.015
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.006
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "claude-opus-4-8": {
@@ -944,6 +1076,72 @@
         },
         "response_token": {
           "price": 0.00125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00005
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.001
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  }
+                }
+              }
+            },
+            "fast": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.001
+                  },
+                  "response_token": {
+                    "price": 0.005
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0001
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.002
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Adds multidimensional `custom_pricing` for the three Claude Opus models that support Anthropic **Fast mode** — `claude-opus-4-6`, `claude-opus-4-7`, and `claude-opus-4-8`.

Structure: `custom_pricing.regions.default.execution_modes.{standard,batch,fast}`.

- **`standard`**: mirrors base `pay_as_you_go` (input/output + 5m cache write, cache read, and `additional_units.cache_write_1h`).
- **`batch`**: 50% of standard input/output rates.
- **`fast`** (Opus only — Fast mode):
  - `claude-opus-4-6` / `claude-opus-4-7`: **$30 / MTok input, $150 / MTok output**
  - `claude-opus-4-8`: **$10 / MTok input, $50 / MTok output**
  - cache multipliers applied on top of fast rates (5m write 1.25x, 1h write 2x, read 0.1x).

`regions.default` is used (not `global`/`us`) because the current Anthropic pricing resolver emits only the `service_tier` dimension and falls back to `regions['default']` when no region is provided. The `us`/`inference_geo` 1.1x data-residency tier is intentionally omitted until the resolver emits a region dimension.

The existing top-level `pricing_config` (`pay_as_you_go` + `batch_config`) is preserved as a fallback for older gateway versions.

## Source Verification

**Source Links:**
- [Anthropic API Pricing](https://docs.claude.com/en/docs/about-claude/pricing) (Model pricing, Fast mode pricing, Batch processing, Prompt caching multipliers)

## Checklist

- [x] Validated the JSON
- [x] Prices verified in **cents per token** (not dollars)
- [x] Source link included above

## Related

- Gateway PR: Portkey-AI/gateway-enterprise-node#1713 (Anthropic multidimensional pricing resolver)