### PR TITLE
chore(pricing): Update google pricing

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1734,5 +1734,16 @@
       "supported": ["tools"]
     },
     "disablePlayground": true
+  },
+  "nano-banana-pro-preview": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/general/google.json
+++ b/general/google.json
@@ -1745,5 +1745,35 @@
       "primary": "video"
     },
     "disablePlayground": true
+  },
+  "gemini-embedding-2": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "text-embedding-005": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "text-embedding-004": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "textembedding-gecko@003": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "textembedding-gecko-multilingual@001": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3052,6 +3052,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3069,6 +3072,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -917,10 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1556,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -1681,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1715,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1749,10 +1749,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1783,10 +1783,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.014
           },
           "search": {
-            "price": 1.4
+            "price": 0.014
           }
         }
       },
@@ -2591,10 +2591,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -2622,10 +2622,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -3052,6 +3052,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3069,6 +3072,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3131,6 +3137,114 @@
         },
         "response_token": {
           "price": 0.0009
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 0.014
+          },
+          "search": {
+            "price": 0.014
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 0.014
+          },
+          "search": {
+            "price": 0.014
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.45
+          },
+          "input_audio": {
+            "price": 6.5
+          },
+          "input_video": {
+            "price": 12
+          }
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.45
+          },
+          "input_audio": {
+            "price": 6.5
+          },
+          "input_video": {
+            "price": 12
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,29 +736,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,29 +767,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -864,10 +864,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -923,17 +923,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.00003125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -957,17 +954,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000625
+          "price": 0.000025
         }
       },
       "batch_config": {
@@ -1165,10 +1159,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1199,10 +1193,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1407,13 +1401,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1441,17 +1432,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.00001
         }
       },
       "batch_config": {
@@ -1543,17 +1531,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1577,17 +1562,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1611,7 +1593,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1620,7 +1602,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1645,7 +1627,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1654,7 +1636,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1705,10 +1687,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1735,14 +1717,14 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1773,10 +1755,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1803,14 +1785,14 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1896,32 +1878,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00015
         }
       }
     }
@@ -1930,32 +1909,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00015
         }
       }
     }
@@ -1964,32 +1940,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -1998,32 +1974,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -2110,13 +2086,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0003
+            "price": 1.4
           }
         }
       },
@@ -2147,13 +2120,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0003
+            "price": 1.4
           }
         }
       },
@@ -2317,10 +2287,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2348,10 +2318,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2379,10 +2349,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2410,10 +2380,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2431,32 +2401,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.00003125
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2465,32 +2432,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.0000625
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.0009
         }
       }
     }
@@ -2505,20 +2469,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2536,20 +2500,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2561,29 +2525,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2592,29 +2556,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2623,29 +2587,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2654,29 +2618,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2692,10 +2656,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -2723,10 +2687,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -3052,7 +3016,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3075,7 +3039,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3099,7 +3063,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3116,7 +3083,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -921,10 +921,13 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -948,10 +951,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1156,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1187,10 +1190,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1395,10 +1398,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1429,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1587,7 +1590,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1599,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1624,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1633,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1684,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1715,10 +1718,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1749,10 +1752,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1783,10 +1786,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1872,17 +1875,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1903,17 +1906,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1943,20 +1946,20 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -1977,20 +1980,20 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2067,10 +2070,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2080,10 +2083,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2101,10 +2104,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2114,10 +2117,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
@@ -2271,20 +2274,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -2302,20 +2308,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -2333,20 +2342,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -2364,20 +2376,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -2401,7 +2416,7 @@
           "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
@@ -2409,15 +2424,18 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2429,10 +2447,10 @@
           "price": 0.00025
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
@@ -2440,15 +2458,18 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.0009
         }
       }
     }
@@ -2463,20 +2484,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2494,20 +2515,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2519,29 +2540,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2550,29 +2571,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.14
+            "price": 0.35
           },
           "search": {
-            "price": 0.14
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2581,29 +2602,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2612,29 +2633,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2650,10 +2671,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -2678,10 +2699,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -2820,7 +2841,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2864,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2887,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2910,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2933,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2956,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2979,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +3002,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -3043,7 +3064,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3060,7 +3081,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3139,7 +3160,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0
         },
         "response_token": {
           "price": 0
@@ -3151,7 +3172,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0
         },
         "response_token": {
           "price": 0

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -168,9 +168,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -199,9 +196,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -286,9 +280,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.0000625
         }
       },
       "batch_config": {
@@ -317,9 +308,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.00003125
         }
       },
       "batch_config": {
@@ -348,9 +336,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -379,9 +364,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -410,9 +392,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -441,9 +420,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -472,9 +448,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.0000625
         }
       },
       "batch_config": {
@@ -503,9 +476,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.00003125
         }
       },
       "batch_config": {
@@ -534,9 +504,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.0000625
         }
       },
       "batch_config": {
@@ -565,9 +532,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.00003125
         }
       },
       "batch_config": {
@@ -869,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -897,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -960,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -2013,7 +1977,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -2383,9 +2347,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0.00035
           }
         }
       },
@@ -2417,9 +2378,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0.00035
           }
         }
       },
@@ -2451,9 +2409,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0.00035
           }
         }
       },
@@ -2485,9 +2440,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0.00035
           }
         }
       },
@@ -2542,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -2698,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -2726,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -2868,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2891,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2914,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2937,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2960,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2983,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -3006,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3029,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3335,86 +3287,6 @@
       }
     }
   },
-  "gemini-1.0-pro-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.000075
-        }
-      }
-    }
-  },
-  "gemini-1.0-pro-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.000075
-        }
-      }
-    }
-  },
-  "gemini-1.0-pro-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.000075
-        }
-      }
-    }
-  },
-  "gemini-1.0-pro-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.000075
-        }
-      }
-    }
-  },
   "gemini-embedding-2-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3432,102 +3304,6 @@
       "pay_as_you_go": {
         "request_token": {
           "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "text-embedding-005-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "text-embedding-005-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "text-embedding-004-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "text-embedding-004-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "textembedding-gecko@003-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "textembedding-gecko@003-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "textembedding-gecko-multilingual@001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "textembedding-gecko-multilingual@001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
         },
         "response_token": {
           "price": 0

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -927,7 +927,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000031
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -947,7 +947,7 @@
           "price": 0.00025
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.002
         },
         "additional_units": {
           "web_search": {
@@ -961,7 +961,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000625
+          "price": 0.000025
         }
       },
       "batch_config": {
@@ -969,7 +969,7 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.001
         }
       }
     }
@@ -1155,7 +1155,7 @@
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -1163,9 +1163,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -1192,7 +1189,7 @@
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.0001
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -1200,9 +1197,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -1403,7 +1397,7 @@
           "price": 0.00003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.000125
         },
         "additional_units": {
           "web_search": {
@@ -1425,7 +1419,7 @@
           "price": 0.000015
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.0000625
         }
       }
     }
@@ -1434,7 +1428,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00006
         },
         "response_token": {
           "price": 0.00025
@@ -1451,12 +1445,12 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000015
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00003
         },
         "response_token": {
           "price": 0.000125
@@ -1890,10 +1884,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -1904,7 +1898,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1921,10 +1915,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -1935,7 +1929,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1952,10 +1946,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
@@ -1974,10 +1968,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -1986,10 +1980,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
@@ -2008,10 +2002,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -2085,16 +2079,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -2119,16 +2113,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -2289,13 +2283,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
@@ -2305,16 +2299,16 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2323,13 +2317,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.0001
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
@@ -2339,16 +2333,16 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -2357,29 +2351,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2388,29 +2385,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -2419,13 +2419,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
@@ -2435,16 +2435,16 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2453,13 +2453,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.0001
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
@@ -2469,16 +2469,16 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -2487,10 +2487,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2506,10 +2506,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -2518,10 +2518,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2537,10 +2537,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -2680,10 +2680,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2708,10 +2708,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2896,7 +2896,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 13
           },
           "default_duration_seconds": {
             "price": 8
@@ -2919,7 +2919,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 13
           },
           "default_duration_seconds": {
             "price": 8
@@ -2942,7 +2942,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -2965,7 +2965,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -2988,7 +2988,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -3011,7 +3011,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -3169,7 +3169,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0
         },
         "response_token": {
           "price": 0
@@ -3181,10 +3181,62 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "imagen-3.0-generate-002-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-3.0-generate-002-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-3.0-fast-generate-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 2
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-3.0-fast-generate-001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 2
+            }
+          }
         }
       }
     }
@@ -3194,7 +3246,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -3211,7 +3263,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -750,7 +750,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -781,7 +781,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -838,6 +838,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -866,6 +869,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -921,9 +927,6 @@
           },
           "search": {
             "price": 3.5
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -955,9 +958,6 @@
           },
           "search": {
             "price": 3.5
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1163,9 +1163,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -1200,9 +1197,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -1411,9 +1405,6 @@
           },
           "search": {
             "price": 3.5
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1445,9 +1436,6 @@
           },
           "search": {
             "price": 3.5
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1974,7 +1962,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2008,7 +1996,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2303,9 +2291,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2337,9 +2322,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2371,9 +2353,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2405,9 +2384,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2439,9 +2415,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2473,9 +2446,6 @@
           },
           "search": {
             "price": 1.4
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2512,7 +2482,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2543,7 +2513,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2623,7 +2593,7 @@
           "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         },
         "additional_units": {
           "web_search": {
@@ -2654,7 +2624,7 @@
           "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         },
         "additional_units": {
           "web_search": {
@@ -2691,6 +2661,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2719,6 +2692,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,14 +833,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -864,14 +861,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -923,17 +917,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -957,13 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1165,13 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -1202,13 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -1413,13 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00025
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1447,13 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00025
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1549,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1580,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1611,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1620,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1645,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1654,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1705,13 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00004
+            "price": 3.5
           }
         }
       },
@@ -1742,13 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00004
+            "price": 3.5
           }
         }
       },
@@ -1902,24 +1872,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00025
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1936,24 +1903,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00025
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1970,32 +1934,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00004
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2007,32 +1968,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00004
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2122,13 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0003
+            "price": 1.4
           }
         }
       },
@@ -2159,13 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0003
+            "price": 1.4
           }
         }
       },
@@ -2329,13 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -2363,13 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -2449,23 +2395,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -2483,23 +2426,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -2523,23 +2463,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00015
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2557,23 +2494,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00015
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2585,29 +2519,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2616,29 +2550,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2647,29 +2581,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2678,29 +2612,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2716,14 +2650,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2747,14 +2678,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2892,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2915,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2938,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2961,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2984,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -3007,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -3030,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3053,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3076,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3099,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3207,6 +3135,92 @@
       }
     }
   },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "veo-3.1-lite-generate-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3237,30 +3251,6 @@
           "default_sample_count": {
             "price": 1
           }
-        }
-      }
-    }
-  },
-  "gemini-embedding-2-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "gemini-embedding-2-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -917,10 +917,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -948,10 +951,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1159,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1187,10 +1196,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1395,10 +1407,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1441,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1543,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1556,13 +1574,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1587,7 +1605,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1614,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1621,7 +1639,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1648,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1681,10 +1699,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1715,10 +1733,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1879,10 +1897,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1928,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1947,16 +1965,16 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -1981,16 +1999,16 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2080,10 +2098,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2114,10 +2132,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2281,10 +2299,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2312,10 +2333,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2343,10 +2367,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2374,10 +2401,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2405,10 +2435,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2436,10 +2469,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2467,16 +2503,16 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2498,16 +2534,16 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2529,10 +2565,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2560,10 +2596,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2591,10 +2627,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2622,10 +2658,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2650,10 +2686,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2678,10 +2714,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,17 +743,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
           "price": 0.0000025
-        },
-        "request_audio_token": {
-          "price": 0.0001
         }
       },
       "batch_config": {
@@ -777,17 +774,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
           "price": 0.0000025
-        },
-        "request_audio_token": {
-          "price": 0.0001
         }
       },
       "batch_config": {
@@ -839,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -867,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -923,14 +917,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -954,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1159,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1193,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1401,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1432,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1531,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1562,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1593,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1602,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1627,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1636,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1687,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1721,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1885,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1909,29 +1903,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.0006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.00001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         }
       }
     }
@@ -1949,7 +1943,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1974,16 +1968,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -1996,10 +1990,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2086,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2107,32 +2101,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.0006
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.00001
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         }
       }
     }
@@ -2287,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2318,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2349,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2380,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2411,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2442,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2469,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2494,15 +2488,46 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.35
+          },
+          "search": {
+            "price": 0.35
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.000025
         },
         "response_token": {
           "price": 0.00015
         },
-        "cache_read_input_token": {
-          "price": 0.0000025
-        },
         "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
           "web_search": {
             "price": 0.35
           },
@@ -2521,45 +2546,14 @@
       }
     }
   },
-  "gemini-3.1-flash-image-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.006
-          },
-          "web_search": {
-            "price": 0.35
-          },
-          "search": {
-            "price": 0.35
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "gemini-3.1-flash-image-preview-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
@@ -2575,10 +2569,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2597,14 +2591,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "request_audio_token": {
-          "price": 0.0001
         }
       },
       "batch_config": {
@@ -2631,14 +2622,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "request_audio_token": {
-          "price": 0.0001
         }
       },
       "batch_config": {
@@ -2662,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -2690,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -3147,6 +3135,102 @@
       }
     }
   },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 3
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3167,40 +3251,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "veo-3.1-lite-generate-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 5
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
-        }
-      }
-    }
-  },
-  "veo-3.1-lite-generate-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 5
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3210,5 +3210,67 @@
         }
       }
     }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 0.35
+          },
+          "search": {
+            "price": 0.35
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 0.35
+          },
+          "search": {
+            "price": 0.35
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
   }
 }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -833,11 +833,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -861,11 +864,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -917,10 +923,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -948,10 +954,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1159,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1187,10 +1193,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1395,10 +1401,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1432,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1525,14 +1531,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1556,14 +1565,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1587,7 +1599,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1608,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1633,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1642,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1693,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1727,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1872,21 +1884,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1903,21 +1915,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1934,29 +1946,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -1968,29 +1980,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2080,10 +2092,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2114,10 +2126,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2281,10 +2293,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2312,10 +2324,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2343,10 +2355,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2374,10 +2386,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2395,20 +2407,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2426,20 +2438,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2463,20 +2475,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2494,20 +2506,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2519,29 +2531,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2550,29 +2562,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2581,29 +2593,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2612,29 +2624,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2650,11 +2662,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2678,11 +2693,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2866,7 +2884,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2907,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2976,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2999,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3022,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3045,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -3283,6 +3283,68 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -3301,10 +3301,10 @@
             "price": 0.012
           },
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -3332,10 +3332,10 @@
             "price": 0.012
           },
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -156,10 +156,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00000375
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -184,10 +184,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001875
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.0000075
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -268,10 +268,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.001
         },
         "additional_units": {
           "web_search": {
@@ -296,10 +296,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003125
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.0005
         },
         "additional_units": {
           "web_search": {
@@ -324,10 +324,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001875
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.0000075
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -352,10 +352,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00000375
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -380,10 +380,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001875
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.0000075
+          "price": 0.00003
         },
         "additional_units": {
           "web_search": {
@@ -408,10 +408,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00000375
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -436,10 +436,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.001
         },
         "additional_units": {
           "web_search": {
@@ -464,10 +464,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003125
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.0005
         },
         "additional_units": {
           "web_search": {
@@ -492,10 +492,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.001
         },
         "additional_units": {
           "web_search": {
@@ -520,10 +520,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003125
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.0005
         },
         "additional_units": {
           "web_search": {
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -921,13 +921,10 @@
           },
           "search": {
             "price": 3.5
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.00003125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -955,13 +952,10 @@
           },
           "search": {
             "price": 3.5
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000625
+          "price": 0.000025
         }
       },
       "batch_config": {
@@ -1155,7 +1149,7 @@
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -1189,7 +1183,7 @@
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.0001
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -1405,13 +1399,10 @@
           },
           "search": {
             "price": 3.5
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1439,13 +1430,10 @@
           },
           "search": {
             "price": 3.5
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1689,7 +1677,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -1723,7 +1711,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -1955,7 +1943,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1968,7 +1956,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1989,7 +1977,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2002,7 +1990,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2289,7 +2277,7 @@
           "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2320,7 +2308,7 @@
           "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.0001
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2413,7 +2401,7 @@
           "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2444,7 +2432,7 @@
           "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.0001
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2475,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2488,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2506,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2519,7 +2507,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2662,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -2690,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -2832,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2855,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2878,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2901,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2924,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2947,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2970,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2993,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3063,7 +3051,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3080,7 +3071,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3147,92 +3141,6 @@
       }
     }
   },
-  "gemini-2.0-flash-image-generation-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.003
-          },
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "gemini-2.0-flash-image-generation-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.003
-          },
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "gemini-1.0-pro-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000125
-        },
-        "response_token": {
-          "price": 0.0000375
-        }
-      }
-    }
-  },
-  "gemini-1.0-pro-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000125
-        },
-        "response_token": {
-          "price": 0.0000375
-        }
-      }
-    }
-  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3253,58 +3161,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "imagen-3.0-generate-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 4
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-3.0-generate-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 4
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-3.0-fast-generate-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 2
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-3.0-fast-generate-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 2
-            }
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -924,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1943,7 +1943,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1956,7 +1956,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1977,7 +1977,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1990,7 +1990,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2463,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2476,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2494,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2507,7 +2507,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2581,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3052,9 +3052,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3072,9 +3069,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,7 +736,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
           "price": 0.00004
@@ -767,7 +767,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
           "price": 0.00004
@@ -2581,7 +2581,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
           "price": 0.00004
@@ -2612,7 +2612,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
           "price": 0.00004
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3051,7 +3051,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3068,7 +3071,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3135,74 +3141,272 @@
       }
     }
   },
-  "nano-banana-pro-preview-lte-128k": {
+  "imagen-3.0-generate-001-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
           }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
         }
       }
     }
   },
-  "nano-banana-pro-preview-gt-128k": {
+  "imagen-3.0-generate-001-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
           }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
         }
       }
     }
   },
-  "veo-3.1-lite-generate-preview-lte-128k": {
+  "imagen-3.0-fast-generate-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 2
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-3.0-fast-generate-001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 2
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagegeneration@006-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 2
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagegeneration@006-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 2
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagegeneration@005-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 2
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagegeneration@005-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 2
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-upscaler-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 6
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-4.0-upscaler-001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 6
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-2.0-upscaler-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 0.3
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-2.0-upscaler-001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 0.3
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-visual-captioning-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 0.15
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-visual-captioning-001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 0.15
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-vqa-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 0.15
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-vqa-001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 0.15
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-product-recontext-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 12
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-product-recontext-001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 12
+            }
+          }
+        }
+      }
+    }
+  },
+  "vertex-virtual-try-on-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 6
+            }
+          }
+        }
+      }
+    }
+  },
+  "vertex-virtual-try-on-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 6
+            }
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-generate-001-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -3214,12 +3418,12 @@
       }
     }
   },
-  "veo-3.1-lite-generate-preview-gt-128k": {
+  "veo-3.1-generate-001-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -3231,7 +3435,281 @@
       }
     }
   },
-  "gemini-embedding-2-preview-lte-128k": {
+  "veo-3.1-fast-generate-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 10
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-fast-generate-001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 10
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "text-embedding-005-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-005-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-multilingual-embedding-002-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-multilingual-embedding-002-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "textembedding-gecko@003-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "textembedding-gecko@003-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-large-exp-03-07-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-large-exp-03-07-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "multilingual-e5-small-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000015
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00000075
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "multilingual-e5-small-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000015
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00000075
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "multilingual-e5-large-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00000125
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "multilingual-e5-large-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00000125
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-0-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -3243,7 +3721,31 @@
       }
     }
   },
-  "gemini-embedding-2-preview-gt-128k": {
+  "gemini-embedding-2-0-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "multimodalembedding@001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "multimodalembedding@001-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -1202,10 +1202,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }
@@ -2333,10 +2333,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }
@@ -2395,10 +2395,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -838,9 +838,6 @@
           "search": {
             "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -869,9 +866,6 @@
           "search": {
             "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -930,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -947,10 +941,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0015
         },
         "additional_units": {
           "web_search": {
@@ -961,7 +955,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000025
         }
       },
       "batch_config": {
@@ -1159,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1180,32 +1174,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.0018
         },
         "cache_write_input_token": {
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }
@@ -1401,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1432,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1531,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1562,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1593,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1602,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1627,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1636,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1687,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1721,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1878,21 +1872,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1909,21 +1903,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1940,23 +1934,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1974,23 +1968,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2086,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2120,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2287,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2308,29 +2302,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }
@@ -2401,20 +2395,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2432,20 +2426,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2469,14 +2463,14 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2500,14 +2494,14 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2525,29 +2519,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2556,29 +2550,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2587,29 +2581,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2618,29 +2612,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2661,9 +2655,6 @@
           "search": {
             "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2692,9 +2683,6 @@
           "search": {
             "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2832,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2855,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2878,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2901,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2924,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2947,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2970,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2993,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3016,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3039,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -917,10 +917,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -948,10 +951,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1159,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1187,10 +1196,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1395,10 +1407,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1441,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1543,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1574,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1605,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1614,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1639,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1648,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1699,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1733,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1872,29 +1890,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1903,29 +1924,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1934,23 +1958,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1968,23 +1992,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2080,10 +2104,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2114,10 +2138,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2281,10 +2305,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2312,10 +2339,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2343,10 +2373,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2374,10 +2407,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2395,29 +2431,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2426,29 +2465,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.00075
         }
       }
     }
@@ -2467,10 +2509,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2498,10 +2540,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2519,29 +2561,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2550,29 +2592,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2591,10 +2633,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2622,10 +2664,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2650,10 +2692,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2678,10 +2720,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -3135,46 +3177,6 @@
       }
     }
   },
-  "gemini-robotics-er-1.5-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      }
-    }
-  },
-  "gemini-robotics-er-1.5-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      }
-    }
-  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3204,7 +3206,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 5
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -3221,7 +3223,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 5
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3052,9 +3052,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3072,9 +3069,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3234,50 +3228,6 @@
           },
           "default_sample_count": {
             "price": 1
-          }
-        }
-      }
-    }
-  },
-  "lyria-3-clip-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "default": {
-            "price": 4
-          }
-        }
-      }
-    }
-  },
-  "lyria-3-clip-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "default": {
-            "price": 4
-          }
-        }
-      }
-    }
-  },
-  "lyria-3-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "default": {
-            "price": 8
-          }
-        }
-      }
-    }
-  },
-  "lyria-3-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "default": {
-            "price": 8
           }
         }
       }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -833,14 +833,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -864,14 +861,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -929,11 +923,11 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0.00035
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000031
         }
       },
       "batch_config": {
@@ -963,11 +957,11 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0.00035
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000625
         }
       },
       "batch_config": {
@@ -1161,7 +1155,7 @@
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -1169,6 +1163,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1195,7 +1192,7 @@
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0001
         },
         "additional_units": {
           "web_search": {
@@ -1203,6 +1200,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1411,10 +1411,13 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1442,10 +1445,13 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1545,9 +1551,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1579,9 +1582,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1890,10 +1890,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -1904,7 +1904,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -1921,10 +1921,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -1935,7 +1935,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -1961,7 +1961,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -1974,10 +1974,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -1995,7 +1995,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2008,10 +2008,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2094,7 +2094,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
@@ -2128,7 +2128,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
@@ -2295,7 +2295,7 @@
           "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2303,6 +2303,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2326,7 +2329,7 @@
           "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0001
         },
         "additional_units": {
           "web_search": {
@@ -2334,6 +2337,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2361,10 +2367,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2392,10 +2398,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2413,13 +2419,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2427,6 +2433,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2444,13 +2453,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0001
         },
         "additional_units": {
           "web_search": {
@@ -2458,6 +2467,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2475,10 +2487,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2494,10 +2506,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2506,10 +2518,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2525,10 +2537,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2668,14 +2680,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2699,14 +2708,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2844,7 +2850,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2867,7 +2873,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2936,7 +2942,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2959,7 +2965,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2982,7 +2988,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3005,7 +3011,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3028,7 +3034,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3051,7 +3057,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3067,7 +3073,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3084,7 +3090,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3163,7 +3169,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3175,7 +3181,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3188,7 +3194,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3205,7 +3211,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3149,6 +3149,17 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.000045
+          },
+          "input_audio": {
+            "price": 0.00065
+          },
+          "input_video": {
+            "price": 0.0012
+          }
         }
       }
     }
@@ -3161,6 +3172,17 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.000045
+          },
+          "input_audio": {
+            "price": 0.00065
+          },
+          "input_video": {
+            "price": 0.0012
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3141,6 +3141,68 @@
       }
     }
   },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3149,17 +3211,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.000045
-          },
-          "input_audio": {
-            "price": 0.00065
-          },
-          "input_video": {
-            "price": 0.0012
-          }
         }
       }
     }
@@ -3172,17 +3223,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.000045
-          },
-          "input_audio": {
-            "price": 0.00065
-          },
-          "input_video": {
-            "price": 0.0012
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3052,9 +3052,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3072,9 +3069,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -917,10 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1556,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1681,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1715,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1749,10 +1749,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1783,10 +1783,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2591,10 +2591,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2622,10 +2622,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -3149,17 +3149,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.45
-          },
-          "input_audio": {
-            "price": 6.5
-          },
-          "input_video": {
-            "price": 12
-          }
         }
       }
     }
@@ -3172,17 +3161,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.45
-          },
-          "input_audio": {
-            "price": 6.5
-          },
-          "input_video": {
-            "price": 12
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -917,10 +917,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -948,10 +951,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1140,10 +1146,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0.00002
@@ -1153,10 +1159,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -1174,10 +1183,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00004
@@ -1187,10 +1196,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -1395,14 +1407,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1419,29 +1434,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0007
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00035
         }
       }
     }
@@ -1525,13 +1543,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1574,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1605,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1614,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1639,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1648,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1699,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1733,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1872,17 +1890,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1903,17 +1921,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1934,10 +1952,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
@@ -1947,10 +1965,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1968,10 +1986,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
@@ -1981,10 +1999,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2067,10 +2085,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2080,10 +2098,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2101,10 +2119,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2114,10 +2132,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2271,20 +2289,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -2302,20 +2323,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -2333,20 +2357,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -2364,20 +2391,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -2395,20 +2425,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -2426,20 +2459,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
@@ -2457,20 +2493,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2488,20 +2524,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2519,29 +2555,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2550,29 +2586,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2591,10 +2627,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2622,10 +2658,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2650,10 +2686,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2678,10 +2714,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2820,7 +2856,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2879,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2948,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2971,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3040,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3063,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3043,7 +3079,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3060,7 +3096,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3219,7 +3255,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3231,7 +3267,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3287,68 +3323,6 @@
       }
     }
   },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
   "veo-3.1-lite-generate-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3379,30 +3353,6 @@
           "default_sample_count": {
             "price": 1
           }
-        }
-      }
-    }
-  },
-  "gemini-robotics-er-1.6-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "gemini-robotics-er-1.6-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -3149,17 +3149,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.45
-          },
-          "input_audio": {
-            "price": 6.5
-          },
-          "input_video": {
-            "price": 12
-          }
         }
       }
     }
@@ -3169,41 +3158,6 @@
       "pay_as_you_go": {
         "request_token": {
           "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.45
-          },
-          "input_audio": {
-            "price": 6.5
-          },
-          "input_video": {
-            "price": 12
-          }
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
         },
         "response_token": {
           "price": 0

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -917,14 +917,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -948,10 +951,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1159,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1187,10 +1196,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1395,10 +1407,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00025
           }
         },
         "cache_read_input_token": {
@@ -1422,14 +1437,17 @@
           "price": 0.00003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00035
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
@@ -1441,7 +1459,7 @@
           "price": 0.000015
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.000175
         }
       }
     }
@@ -1525,13 +1543,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1574,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1605,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1614,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1639,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1648,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1699,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1733,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1872,29 +1890,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00025
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1903,29 +1924,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00035
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000175
         }
       }
     }
@@ -1934,32 +1958,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -1968,32 +1992,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2080,10 +2104,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2114,10 +2138,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2281,10 +2305,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2312,10 +2339,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2343,10 +2373,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2374,10 +2407,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2395,29 +2431,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2426,29 +2465,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.00075
         }
       }
     }
@@ -2463,20 +2505,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2494,20 +2536,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2519,29 +2561,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2550,29 +2592,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2581,29 +2623,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2612,29 +2654,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2650,10 +2692,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2678,10 +2720,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2820,7 +2862,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2885,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2908,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2931,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2954,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2977,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +3000,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +3023,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3046,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3069,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3087,10 +3129,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -3118,10 +3160,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -3292,7 +3334,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 3
+            "price": 5
           },
           "default_duration_seconds": {
             "price": 8
@@ -3309,7 +3351,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 3
+            "price": 5
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3052,9 +3052,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3072,9 +3069,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3155,10 +3149,10 @@
             "price": 0.045
           },
           "input_audio": {
-            "price": 0.065
+            "price": 0.65
           },
           "input_video": {
-            "price": 0.079
+            "price": 1.2
           }
         }
       }
@@ -3178,10 +3172,10 @@
             "price": 0.045
           },
           "input_audio": {
-            "price": 0.065
+            "price": 0.65
           },
           "input_video": {
-            "price": 0.079
+            "price": 1.2
           }
         }
       }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -168,6 +168,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -196,6 +199,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -280,6 +286,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000625
         }
       },
       "batch_config": {
@@ -308,6 +317,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
         }
       },
       "batch_config": {
@@ -336,6 +348,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -364,6 +379,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -392,6 +410,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -420,6 +441,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -448,6 +472,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000625
         }
       },
       "batch_config": {
@@ -476,6 +503,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
         }
       },
       "batch_config": {
@@ -504,6 +534,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.0000625
         }
       },
       "batch_config": {
@@ -532,6 +565,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.00003125
         }
       },
       "batch_config": {
@@ -2347,6 +2383,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         }
       },
@@ -2378,6 +2417,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         }
       },
@@ -2409,6 +2451,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         }
       },
@@ -2440,6 +2485,9 @@
           },
           "search": {
             "price": 1.4
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         }
       },
@@ -3287,64 +3335,82 @@
       }
     }
   },
-  "nano-banana-pro-preview-lte-128k": {
+  "gemini-1.0-pro-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
+          "price": 0.00015
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.000075
         }
       }
     }
   },
-  "nano-banana-pro-preview-gt-128k": {
+  "gemini-1.0-pro-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
+          "price": 0.00015
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.000075
+        }
+      }
+    }
+  },
+  "gemini-1.0-pro-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000075
+        }
+      }
+    }
+  },
+  "gemini-1.0-pro-001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000075
         }
       }
     }
@@ -3366,6 +3432,102 @@
       "pay_as_you_go": {
         "request_token": {
           "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-005-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-005-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-004-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-004-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "textembedding-gecko@003-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "textembedding-gecko@003-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "textembedding-gecko-multilingual@001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "textembedding-gecko-multilingual@001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
         },
         "response_token": {
           "price": 0

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -864,10 +864,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -927,9 +927,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -961,9 +958,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1208,10 +1202,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }
@@ -1413,7 +1407,7 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0
+            "price": 0.00025
           }
         },
         "cache_read_input_token": {
@@ -1447,7 +1441,7 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0
+            "price": 0.00025
           }
         },
         "cache_read_input_token": {
@@ -1709,6 +1703,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00004
           }
         }
       },
@@ -1743,6 +1740,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00004
           }
         }
       },
@@ -1896,10 +1896,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1907,18 +1907,21 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00025
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1927,10 +1930,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1938,18 +1941,21 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00025
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1975,6 +1981,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00015
           }
         }
       },
@@ -2009,6 +2018,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00015
           }
         }
       },
@@ -2108,6 +2120,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0003
           }
         }
       },
@@ -2142,6 +2157,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0003
           }
         }
       },
@@ -2345,10 +2363,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }
@@ -2407,37 +2425,6 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0009
-        }
-      }
-    }
-  },
-  "gemini-pro-latest-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "cache_read_input_token": {
-          "price": 0.00002
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 0.35
-          },
-          "search": {
-            "price": 0.35
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
           "price": 0.0001
         },
         "response_token": {
@@ -2446,17 +2433,17 @@
       }
     }
   },
-  "gemini-pro-latest-gt-128k": {
+  "gemini-pro-latest-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
@@ -2469,10 +2456,41 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-pro-latest-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.0015
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.35
+          },
+          "search": {
+            "price": 0.35
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.00075
         }
       }
     }
@@ -2495,6 +2513,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00015
           }
         }
       },
@@ -2526,6 +2547,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00015
           }
         }
       },
@@ -2674,10 +2698,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -2705,10 +2729,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -3117,10 +3141,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -3138,115 +3162,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.0018
         },
         "cache_read_input_token": {
           "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
         "request_token": {
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 0.35
-          },
-          "search": {
-            "price": 0.35
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 0.35
-          },
-          "search": {
-            "price": 0.35
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "gemini-embedding-2-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "gemini-embedding-2-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0009
         }
       }
     }
@@ -3281,6 +3219,30 @@
           "default_sample_count": {
             "price": 1
           }
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -917,10 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1749,10 +1749,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1783,10 +1783,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2591,10 +2591,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2622,10 +2622,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -3052,6 +3052,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3069,6 +3072,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3146,13 +3152,13 @@
         },
         "additional_units": {
           "input_image": {
-            "price": 0.045
+            "price": 0.45
           },
           "input_audio": {
-            "price": 0.65
+            "price": 6.5
           },
           "input_video": {
-            "price": 1.2
+            "price": 12
           }
         }
       }
@@ -3169,13 +3175,13 @@
         },
         "additional_units": {
           "input_image": {
-            "price": 0.045
+            "price": 0.45
           },
           "input_audio": {
-            "price": 0.65
+            "price": 6.5
           },
           "input_video": {
-            "price": 1.2
+            "price": 12
           }
         }
       }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -3051,10 +3051,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }
@@ -3071,10 +3068,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }
@@ -3289,6 +3283,68 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -924,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -1533,6 +1533,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1564,6 +1567,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1943,7 +1949,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -1956,7 +1962,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -1977,7 +1983,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -1990,7 +1996,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2463,7 +2469,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2476,7 +2482,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2494,7 +2500,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2507,7 +2513,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2519,10 +2525,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
@@ -2538,10 +2544,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2550,10 +2556,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
@@ -2569,10 +2575,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2581,10 +2587,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2612,10 +2618,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2650,10 +2656,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2678,10 +2684,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -3051,10 +3057,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }
@@ -3071,10 +3074,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -1174,16 +1174,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.0018
         },
         "cache_write_input_token": {
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -1196,10 +1196,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -838,6 +838,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -866,6 +869,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -941,10 +947,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.001
         },
         "additional_units": {
           "web_search": {
@@ -955,7 +961,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -1153,10 +1159,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1174,32 +1180,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }
@@ -1395,10 +1401,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1432,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1531,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1562,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1593,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1602,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1627,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1636,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1687,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1721,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1872,21 +1878,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1903,29 +1909,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         }
       }
     }
@@ -1934,16 +1940,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -1968,16 +1974,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -1990,10 +1996,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2080,10 +2086,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2101,32 +2107,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         }
       }
     }
@@ -2281,10 +2287,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2302,29 +2308,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }
@@ -2395,20 +2401,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2426,20 +2432,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2463,7 +2469,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2488,13 +2494,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2507,10 +2513,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2581,29 +2587,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2612,29 +2618,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2655,6 +2661,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2683,6 +2692,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2820,7 +2832,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2855,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2878,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2901,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2924,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2947,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2970,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2993,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3016,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3039,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3135,102 +3147,6 @@
       }
     }
   },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "veo-3.1-lite-generate-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 3
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
-        }
-      }
-    }
-  },
-  "veo-3.1-lite-generate-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 3
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
-        }
-      }
-    }
-  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3251,6 +3167,40 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 0
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 0
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -917,14 +917,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -948,10 +951,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1140,32 +1146,35 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -1174,32 +1183,35 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -1395,10 +1407,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1441,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1543,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1574,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1605,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1614,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1639,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1648,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1699,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1733,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1872,17 +1890,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1891,10 +1909,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -1903,17 +1921,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1922,10 +1940,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -1934,32 +1952,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -1968,32 +1986,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2067,10 +2085,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2080,19 +2098,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -2101,10 +2119,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2114,19 +2132,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -2271,29 +2289,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2302,29 +2323,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -2333,29 +2357,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2364,29 +2391,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -2395,29 +2425,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2426,29 +2459,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -2457,29 +2493,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2488,20 +2524,51 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00004
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.35
+          },
+          "search": {
+            "price": 0.35
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.000025
         },
         "response_token": {
           "price": 0.00015
         },
-        "cache_read_input_token": {
-          "price": 0.0000025
-        },
         "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2515,64 +2582,33 @@
       }
     }
   },
-  "gemini-3.1-flash-image-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.006
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "gemini-3.1-flash-image-preview-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2591,10 +2627,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2622,10 +2658,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2650,10 +2686,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -2678,10 +2714,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -2820,7 +2856,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2879,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2902,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2925,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2948,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2971,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2994,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +3017,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3043,7 +3079,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3051,10 +3087,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }
@@ -3063,7 +3096,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3071,10 +3104,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }
@@ -3141,6 +3171,86 @@
       }
     }
   },
+  "gemini-2.5-flash-preview-tts-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-flash-preview-tts-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-tts-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.002
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "gemini-2.5-pro-preview-tts-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.002
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3149,6 +3259,17 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.00012
+          },
+          "input_video": {
+            "price": 0.00079
+          },
+          "input_audio": {
+            "price": 0.00016
+          }
         }
       }
     }
@@ -3161,6 +3282,65 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.00012
+          },
+          "input_video": {
+            "price": 0.00079
+          },
+          "input_audio": {
+            "price": 0.00016
+          }
+        }
+      }
+    }
+  },
+  "gemini-robotics-er-1.5-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        }
+      }
+    }
+  },
+  "gemini-robotics-er-1.5-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        }
+      }
+    }
+  },
+  "gemini-2.5-computer-use-preview-10-2025-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "gemini-2.5-computer-use-preview-10-2025-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.001
         }
       }
     }
@@ -3170,7 +3350,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 5
+            "price": 3
           },
           "default_duration_seconds": {
             "price": 8
@@ -3187,7 +3367,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 5
+            "price": 3
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -838,6 +838,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -866,6 +869,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -917,10 +923,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -948,10 +957,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1165,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1187,10 +1202,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1395,10 +1413,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00025
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1447,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00025
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1549,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1580,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1611,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1620,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1645,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1654,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1705,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00004
           }
         }
       },
@@ -1715,10 +1742,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00004
           }
         }
       },
@@ -1872,21 +1902,24 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00025
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1903,21 +1936,24 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00025
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1934,10 +1970,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
@@ -1947,10 +1983,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00004
           }
         }
       },
@@ -1968,10 +2007,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
@@ -1981,10 +2020,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00004
           }
         }
       },
@@ -2080,10 +2122,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0003
           }
         }
       },
@@ -2114,10 +2159,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0003
           }
         }
       },
@@ -2281,10 +2329,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2312,10 +2363,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2395,20 +2449,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2426,20 +2483,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2467,10 +2527,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00015
           }
         }
       },
@@ -2498,10 +2561,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00015
           }
         }
       },
@@ -2519,29 +2585,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2550,29 +2616,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2591,10 +2657,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2622,10 +2688,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2655,6 +2721,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2683,6 +2752,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2912,7 +2984,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +3007,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +3030,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +3053,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3076,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3099,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3051,10 +3123,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }
@@ -3071,10 +3140,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }
@@ -3141,272 +3207,12 @@
       }
     }
   },
-  "imagen-3.0-generate-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 4
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-3.0-generate-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 4
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-3.0-fast-generate-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 2
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-3.0-fast-generate-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 2
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagegeneration@006-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 2
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagegeneration@006-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 2
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagegeneration@005-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 2
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagegeneration@005-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 2
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-4.0-upscaler-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 6
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-4.0-upscaler-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 6
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-2.0-upscaler-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 0.3
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-2.0-upscaler-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 0.3
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-visual-captioning-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 0.15
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-visual-captioning-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 0.15
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-vqa-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 0.15
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-vqa-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 0.15
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-product-recontext-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 12
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-product-recontext-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 12
-            }
-          }
-        }
-      }
-    }
-  },
-  "vertex-virtual-try-on-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 6
-            }
-          }
-        }
-      }
-    }
-  },
-  "vertex-virtual-try-on-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 6
-            }
-          }
-        }
-      }
-    }
-  },
-  "veo-3.1-generate-001-lte-128k": {
+  "veo-3.1-lite-generate-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -3418,12 +3224,12 @@
       }
     }
   },
-  "veo-3.1-generate-001-gt-128k": {
+  "veo-3.1-lite-generate-preview-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 0
           },
           "default_duration_seconds": {
             "price": 8
@@ -3435,281 +3241,7 @@
       }
     }
   },
-  "veo-3.1-fast-generate-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 10
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
-        }
-      }
-    }
-  },
-  "veo-3.1-fast-generate-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 10
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
-        }
-      }
-    }
-  },
-  "text-embedding-005-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "text-embedding-005-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "text-multilingual-embedding-002-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "text-multilingual-embedding-002-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "textembedding-gecko@003-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "textembedding-gecko@003-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "text-embedding-large-exp-03-07-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "text-embedding-large-exp-03-07-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "multilingual-e5-small-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000015
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00000075
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "multilingual-e5-small-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000015
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00000075
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "multilingual-e5-large-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00000125
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "multilingual-e5-large-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00000125
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "gemini-embedding-2-0-lte-128k": {
+  "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -3721,31 +3253,7 @@
       }
     }
   },
-  "gemini-embedding-2-0-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "multimodalembedding@001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "multimodalembedding@001-gt-128k": {
+  "gemini-embedding-2-preview-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -833,11 +833,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -861,11 +864,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -923,11 +929,11 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00003125
         }
       },
       "batch_config": {
@@ -951,14 +957,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000625
         }
       },
       "batch_config": {
@@ -1156,10 +1165,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1190,10 +1199,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1398,10 +1407,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
@@ -1429,10 +1441,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
@@ -1536,6 +1551,9 @@
           "search": {
             "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1567,6 +1585,9 @@
           "search": {
             "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1684,10 +1705,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1718,10 +1739,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1752,10 +1773,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1786,10 +1807,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1875,10 +1896,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1886,18 +1907,21 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1906,10 +1930,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1917,18 +1941,21 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1937,32 +1964,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -1971,32 +1998,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2070,10 +2097,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2087,6 +2114,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0003
           }
         }
       },
@@ -2104,10 +2134,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2121,6 +2151,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0003
           }
         }
       },
@@ -2274,13 +2307,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2288,9 +2321,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
@@ -2308,13 +2338,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2322,9 +2352,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
@@ -2342,13 +2369,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2356,9 +2383,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
@@ -2376,13 +2400,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2390,9 +2414,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
@@ -2416,7 +2437,7 @@
           "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00003125
         },
         "additional_units": {
           "web_search": {
@@ -2426,16 +2447,16 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0.0001
+            "price": 0.00035
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2447,10 +2468,10 @@
           "price": 0.00025
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.0000625
         },
         "additional_units": {
           "web_search": {
@@ -2460,16 +2481,16 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0.0001
+            "price": 0.00035
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.00075
         }
       }
     }
@@ -2488,10 +2509,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2519,10 +2540,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2612,10 +2633,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2643,10 +2664,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2671,11 +2692,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2699,11 +2723,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2841,7 +2868,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2864,7 +2891,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2887,7 +2914,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2910,7 +2937,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2933,7 +2960,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2956,7 +2983,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2979,7 +3006,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3002,7 +3029,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3025,7 +3052,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3048,7 +3075,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3064,7 +3091,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3081,7 +3108,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3160,7 +3187,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
@@ -3172,7 +3199,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
           "price": 0

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -917,10 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1556,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1681,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1715,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2591,10 +2591,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2622,10 +2622,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -3219,7 +3219,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
@@ -3231,7 +3231,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
@@ -3291,7 +3291,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
@@ -3303,7 +3303,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00002
         },
         "response_token": {
           "price": 0

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -838,9 +838,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -869,9 +866,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -930,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1202,10 +1196,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }
@@ -1539,9 +1533,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1573,9 +1564,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1884,10 +1872,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -1898,7 +1886,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1915,10 +1903,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -1929,7 +1917,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1946,16 +1934,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1968,7 +1956,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1980,16 +1968,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2002,7 +1990,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2333,10 +2321,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }
@@ -2395,10 +2383,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }
@@ -2407,13 +2395,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2438,13 +2426,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2475,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2488,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2506,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2519,7 +2507,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2531,10 +2519,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2550,10 +2538,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2562,10 +2550,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2581,10 +2569,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2593,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2612,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2624,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2643,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2667,9 +2655,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2698,9 +2683,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2838,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2861,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2884,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2907,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2930,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2953,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2976,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2999,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3022,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3045,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3069,7 +3051,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3086,7 +3071,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,29 +736,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,29 +767,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,11 +833,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -861,11 +864,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -917,17 +923,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -951,13 +954,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1146,10 +1146,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0.00002
@@ -1159,13 +1159,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
@@ -1183,10 +1180,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_write_input_token": {
           "price": 0.00004
@@ -1196,13 +1193,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
@@ -1407,17 +1401,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1434,32 +1425,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0007
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00035
+          "price": 0.000125
         }
       }
     }
@@ -1543,13 +1531,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1574,13 +1562,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1605,7 +1593,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1614,7 +1602,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1639,7 +1627,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1648,7 +1636,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1699,10 +1687,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1733,10 +1721,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1890,17 +1878,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1921,17 +1909,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1952,29 +1940,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1986,29 +1974,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2085,10 +2073,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2098,10 +2086,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2119,10 +2107,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2132,10 +2120,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2289,23 +2277,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
@@ -2323,23 +2308,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
@@ -2357,23 +2339,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
@@ -2391,23 +2370,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
@@ -2425,23 +2401,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
@@ -2459,23 +2432,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
@@ -2493,26 +2463,26 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2524,26 +2494,26 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2555,29 +2525,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2586,29 +2556,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2617,29 +2587,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2648,29 +2618,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2686,11 +2656,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2714,11 +2687,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2902,7 +2878,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2925,7 +2901,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2994,7 +2970,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3017,7 +2993,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3079,7 +3055,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3096,7 +3072,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3255,7 +3231,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
@@ -3267,7 +3243,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
@@ -3323,12 +3299,74 @@
       }
     }
   },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
   "veo-3.1-lite-generate-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 3
           },
           "default_duration_seconds": {
             "price": 8
@@ -3345,7 +3383,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 3
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -833,14 +833,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -864,14 +861,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -923,10 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -954,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1159,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1193,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1401,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1432,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1539,9 +1533,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1573,9 +1564,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1693,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1727,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1761,10 +1749,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1795,10 +1783,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1891,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1922,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1959,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1993,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2092,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2126,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2293,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2324,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2355,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2386,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2417,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2448,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2479,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2510,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2550,10 +2538,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2581,10 +2569,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2603,10 +2591,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2634,10 +2622,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2662,14 +2650,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2693,14 +2678,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -3161,6 +3143,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.012
+          },
+          "input_video_plus": {
+            "price": 0.079
+          }
         }
       }
     }
@@ -3173,6 +3163,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.012
+          },
+          "input_video_plus": {
+            "price": 0.079
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3141,46 +3141,6 @@
       }
     }
   },
-  "gemini-robotics-er-1.5-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      }
-    }
-  },
-  "gemini-robotics-er-1.5-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      }
-    }
-  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3152,13 +3152,13 @@
         },
         "additional_units": {
           "input_image": {
-            "price": 0.000045
+            "price": 0.45
           },
           "input_audio": {
-            "price": 0.00065
+            "price": 6.5
           },
           "input_video": {
-            "price": 0.0012
+            "price": 12
           }
         }
       }
@@ -3175,13 +3175,13 @@
         },
         "additional_units": {
           "input_image": {
-            "price": 0.000045
+            "price": 0.45
           },
           "input_audio": {
-            "price": 0.00065
+            "price": 6.5
           },
           "input_video": {
-            "price": 0.0012
+            "price": 12
           }
         }
       }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -156,10 +156,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00000375
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.000015
         },
         "additional_units": {
           "web_search": {
@@ -184,10 +184,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000001875
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -268,10 +268,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -296,10 +296,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00003125
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.000125
         },
         "additional_units": {
           "web_search": {
@@ -324,10 +324,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000001875
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -352,10 +352,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00000375
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.000015
         },
         "additional_units": {
           "web_search": {
@@ -380,10 +380,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000001875
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -408,10 +408,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00000375
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.000015
         },
         "additional_units": {
           "web_search": {
@@ -436,10 +436,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -464,10 +464,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00003125
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.000125
         },
         "additional_units": {
           "web_search": {
@@ -492,10 +492,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -520,10 +520,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00003125
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.000125
         },
         "additional_units": {
           "web_search": {
@@ -921,10 +921,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.00003125
         }
       },
       "batch_config": {
@@ -952,10 +955,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000625
         }
       },
       "batch_config": {
@@ -1149,7 +1155,7 @@
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -1183,7 +1189,7 @@
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0001
         },
         "additional_units": {
           "web_search": {
@@ -1399,10 +1405,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1430,10 +1439,13 @@
           },
           "search": {
             "price": 3.5
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1677,7 +1689,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -1711,7 +1723,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -1943,7 +1955,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -1956,7 +1968,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -1977,7 +1989,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -1990,7 +2002,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2277,7 +2289,7 @@
           "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2308,7 +2320,7 @@
           "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0001
         },
         "additional_units": {
           "web_search": {
@@ -2401,7 +2413,7 @@
           "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {
@@ -2432,7 +2444,7 @@
           "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0001
         },
         "additional_units": {
           "web_search": {
@@ -2463,7 +2475,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2476,7 +2488,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2494,7 +2506,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2507,7 +2519,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2820,7 +2832,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2855,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2878,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2901,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2924,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2947,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2970,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2993,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3135,6 +3147,92 @@
       }
     }
   },
+  "gemini-2.0-flash-image-generation-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-image-generation-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.003
+          },
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gemini-1.0-pro-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000125
+        },
+        "response_token": {
+          "price": 0.0000375
+        }
+      }
+    }
+  },
+  "gemini-1.0-pro-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000125
+        },
+        "response_token": {
+          "price": 0.0000375
+        }
+      }
+    }
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3155,6 +3253,58 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "imagen-3.0-generate-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-3.0-generate-001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-3.0-fast-generate-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 2
+            }
+          }
+        }
+      }
+    }
+  },
+  "imagen-3.0-fast-generate-001-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 2
+            }
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,29 +736,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,29 +767,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -864,10 +864,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -923,10 +923,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -954,10 +954,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1159,10 +1159,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1193,10 +1193,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1401,10 +1401,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1432,10 +1432,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1531,14 +1531,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1562,14 +1565,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1593,7 +1599,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1602,7 +1608,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1627,7 +1633,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1636,7 +1642,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1687,10 +1693,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1721,10 +1727,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1755,10 +1761,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1789,10 +1795,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1878,21 +1884,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1909,21 +1915,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1940,23 +1946,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1974,23 +1980,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2086,10 +2092,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2120,10 +2126,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2287,10 +2293,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2318,10 +2324,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2349,10 +2355,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2380,10 +2386,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2401,20 +2407,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2432,20 +2438,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2469,14 +2475,14 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2500,14 +2506,14 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2525,20 +2531,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2556,20 +2562,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2587,29 +2593,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2618,29 +2624,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2656,10 +2662,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -2687,10 +2693,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -2832,7 +2838,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2855,7 +2861,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2878,7 +2884,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2901,7 +2907,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2924,7 +2930,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2947,7 +2953,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2970,7 +2976,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2993,7 +2999,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3016,7 +3022,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3039,7 +3045,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3135,30 +3135,6 @@
       }
     }
   },
-  "gemini-embedding-2-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "gemini-embedding-2-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "gemini-robotics-er-1.5-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3195,6 +3171,30 @@
           "search": {
             "price": 3.5
           }
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -917,14 +917,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 0.14
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 0.14
           }
         }
       },
@@ -1681,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1749,10 +1749,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1783,10 +1783,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1872,21 +1872,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1903,21 +1903,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1934,29 +1934,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1968,29 +1968,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2401,23 +2401,23 @@
           "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2436,19 +2436,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.00075
         }
       }
     }
@@ -2463,20 +2463,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2494,20 +2494,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2519,29 +2519,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 0.14
           },
           "search": {
-            "price": 0.35
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2550,29 +2550,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 0.14
           },
           "search": {
-            "price": 0.35
+            "price": 0.14
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2581,29 +2581,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,29 +2612,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3143,14 +3143,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.012
-          },
-          "input_video_plus": {
-            "price": 0.079
-          }
         }
       }
     }
@@ -3163,14 +3155,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.012
-          },
-          "input_video_plus": {
-            "price": 0.079
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -750,7 +750,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         }
       },
       "batch_config": {
@@ -781,7 +781,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         }
       },
       "batch_config": {
@@ -838,9 +838,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -869,9 +866,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2593,7 +2587,7 @@
           "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2624,7 +2618,7 @@
           "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2661,9 +2655,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2692,9 +2683,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -3295,68 +3283,6 @@
         },
         "response_token": {
           "price": 0.001
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3149,17 +3149,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.45
-          },
-          "input_audio": {
-            "price": 6.5
-          },
-          "input_video": {
-            "price": 12
-          }
         }
       }
     }
@@ -3172,17 +3161,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.45
-          },
-          "input_audio": {
-            "price": 6.5
-          },
-          "input_video": {
-            "price": 12
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -833,14 +833,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -864,14 +861,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -923,10 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -954,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1159,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1193,19 +1187,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }
@@ -1401,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1432,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1531,17 +1525,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1565,17 +1556,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1599,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1608,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1633,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1642,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1693,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1727,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1761,10 +1749,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1795,10 +1783,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1884,21 +1872,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1915,26 +1903,26 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.00001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00015
@@ -1946,23 +1934,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1980,23 +1968,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2092,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2113,7 +2101,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0001
         },
         "response_token": {
           "price": 0.0003
@@ -2122,20 +2110,20 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.00001
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.00015
@@ -2293,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2324,19 +2312,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }
@@ -2355,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2386,19 +2374,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }
@@ -2407,20 +2395,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2438,20 +2426,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2479,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2510,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2531,29 +2519,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2562,29 +2550,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2603,10 +2591,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2634,10 +2622,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2662,14 +2650,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2693,14 +2678,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -3070,6 +3052,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3087,6 +3072,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3173,6 +3161,108 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "gemini-robotics-er-1.5-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "gemini-robotics-er-1.5-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -924,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1903,7 +1903,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.0003
@@ -1917,12 +1917,12 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
           "price": 0.00015
@@ -1943,7 +1943,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1956,7 +1956,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1977,7 +1977,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1990,7 +1990,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2101,7 +2101,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00005
         },
         "response_token": {
           "price": 0.0003
@@ -2110,7 +2110,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -2123,7 +2123,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
           "price": 0.00015
@@ -2463,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2476,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2494,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2507,7 +2507,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2581,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2612,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3051,7 +3051,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
         },
         "response_token": {
           "price": 0
@@ -3071,7 +3071,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
         },
         "response_token": {
           "price": 0
@@ -3161,108 +3161,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "gemini-robotics-er-1.5-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      }
-    }
-  },
-  "gemini-robotics-er-1.5-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -751,14 +751,17 @@
         },
         "cache_read_input_token": {
           "price": 0.0000025
+        },
+        "request_audio_token": {
+          "price": 0.0001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +770,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -782,14 +785,17 @@
         },
         "cache_read_input_token": {
           "price": 0.0000025
+        },
+        "request_audio_token": {
+          "price": 0.0001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -921,13 +927,10 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -955,9 +958,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1163,9 +1163,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -1200,9 +1197,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -1411,9 +1405,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1445,9 +1436,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1890,10 +1878,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -1901,21 +1889,18 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00015
         }
       }
     }
@@ -1924,10 +1909,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -1935,21 +1920,18 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00015
         }
       }
     }
@@ -1958,16 +1940,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -1992,16 +1974,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2309,9 +2291,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2343,9 +2322,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2377,9 +2353,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2411,9 +2384,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2431,13 +2401,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2445,18 +2415,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2465,13 +2432,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2479,18 +2446,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.0009
         }
       }
     }
@@ -2561,10 +2525,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2580,10 +2544,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2592,10 +2556,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2611,10 +2575,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2623,10 +2587,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2638,14 +2602,17 @@
           "search": {
             "price": 0.35
           }
+        },
+        "request_audio_token": {
+          "price": 0.0001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2654,10 +2621,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2669,14 +2636,17 @@
           "search": {
             "price": 0.35
           }
+        },
+        "request_audio_token": {
+          "price": 0.0001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2862,7 +2832,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2885,7 +2855,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2908,7 +2878,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2931,7 +2901,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2954,7 +2924,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2977,7 +2947,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -3000,7 +2970,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3023,7 +2993,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3046,7 +3016,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3069,7 +3039,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3206,7 +3176,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 5
           },
           "default_duration_seconds": {
             "price": 8
@@ -3223,7 +3193,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 5
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -750,7 +750,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         }
       },
       "batch_config": {
@@ -781,7 +781,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         }
       },
       "batch_config": {
@@ -838,9 +838,6 @@
           "search": {
             "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -869,9 +866,6 @@
           "search": {
             "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -1439,7 +1433,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1717,7 +1711,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -1785,7 +1779,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -2593,7 +2587,7 @@
           "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2624,7 +2618,7 @@
           "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2661,9 +2655,6 @@
           "search": {
             "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2692,9 +2683,6 @@
           "search": {
             "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2832,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2855,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2878,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2901,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2924,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2947,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2970,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2993,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3063,10 +3051,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }
@@ -3083,10 +3068,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3230,6 +3230,14 @@
         "response_token": {
           "price": 0
         }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
       }
     }
   },
@@ -3238,6 +3246,14 @@
       "pay_as_you_go": {
         "request_token": {
           "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -3289,6 +3305,68 @@
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,29 +736,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,29 +767,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -864,10 +864,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -923,14 +923,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -954,10 +954,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1159,10 +1159,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1193,19 +1193,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }
@@ -1401,10 +1401,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1432,10 +1432,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1531,14 +1531,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1562,14 +1565,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1593,7 +1599,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1602,7 +1608,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1627,7 +1633,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1636,7 +1642,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1687,10 +1693,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1721,10 +1727,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1755,10 +1761,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1789,10 +1795,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1885,10 +1891,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1897,10 +1903,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00015
         }
       }
     }
@@ -1916,10 +1922,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1928,10 +1934,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00015
         }
       }
     }
@@ -1953,19 +1959,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -1987,19 +1993,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -2086,10 +2092,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2120,10 +2126,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2287,10 +2293,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2318,19 +2324,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }
@@ -2349,10 +2355,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2380,19 +2386,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }
@@ -2407,23 +2413,23 @@
           "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2442,19 +2448,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.0009
         }
       }
     }
@@ -2469,20 +2475,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2500,20 +2506,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2525,29 +2531,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2556,29 +2562,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2587,29 +2593,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2618,29 +2624,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2656,10 +2662,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -2687,10 +2693,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -2832,7 +2838,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2855,7 +2861,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2878,7 +2884,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2901,7 +2907,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2924,7 +2930,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2947,7 +2953,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2970,7 +2976,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2993,7 +2999,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3016,7 +3022,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3039,7 +3045,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3149,17 +3149,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.000045
-          },
-          "input_audio": {
-            "price": 0.00065
-          },
-          "input_video": {
-            "price": 0.0012
-          }
         }
       }
     }
@@ -3172,17 +3161,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.000045
-          },
-          "input_audio": {
-            "price": 0.00065
-          },
-          "input_video": {
-            "price": 0.0012
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,29 +736,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,29 +767,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -833,14 +833,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -864,14 +861,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -923,14 +917,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -954,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1159,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1193,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1401,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1432,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1531,14 +1525,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1562,14 +1559,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1593,7 +1593,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1602,7 +1602,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1627,7 +1627,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1636,7 +1636,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1687,10 +1687,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1721,10 +1721,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1878,29 +1878,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1909,29 +1909,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1940,29 +1940,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -1974,29 +1974,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2086,10 +2086,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2120,10 +2120,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2287,10 +2287,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2318,10 +2318,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2349,10 +2349,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2380,10 +2380,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2401,29 +2401,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2432,20 +2432,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2469,20 +2469,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2500,20 +2500,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2525,29 +2525,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2556,29 +2556,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2587,29 +2587,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2618,29 +2618,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00000375
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2656,14 +2656,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2687,14 +2684,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2832,7 +2826,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2855,7 +2849,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2878,7 +2872,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2901,7 +2895,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2924,7 +2918,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2947,7 +2941,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2970,7 +2964,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2993,7 +2987,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3016,7 +3010,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3039,7 +3033,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3063,10 +3057,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }
@@ -3083,10 +3074,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -924,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -1174,16 +1174,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -1196,10 +1196,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }
@@ -1956,7 +1956,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -1990,7 +1990,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2476,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2507,7 +2507,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2581,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2612,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3052,6 +3052,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3069,6 +3072,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3164,7 +3170,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 5
           },
           "default_duration_seconds": {
             "price": 8
@@ -3181,7 +3187,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 5
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -838,6 +838,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -866,6 +869,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -924,7 +930,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -1872,21 +1878,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1903,21 +1909,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1934,29 +1940,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -1968,29 +1974,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2395,20 +2401,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2426,20 +2432,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
@@ -2463,7 +2469,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2476,7 +2482,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2494,7 +2500,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2507,7 +2513,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2519,10 +2525,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
@@ -2550,10 +2556,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
@@ -2581,10 +2587,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2606,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2612,10 +2618,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2637,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2655,6 +2661,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2683,6 +2692,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2820,7 +2832,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2855,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2878,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2901,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2924,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2947,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2970,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2993,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 8
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3016,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3039,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3223,6 +3235,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 1.2
+          },
+          "input_video_plus": {
+            "price": 7.9
+          }
         }
       }
     }
@@ -3235,6 +3255,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 1.2
+          },
+          "input_video_plus": {
+            "price": 7.9
+          }
         }
       }
     }
@@ -3295,6 +3323,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 1.2
+          },
+          "input_video_plus": {
+            "price": 7.9
+          }
         }
       }
     }
@@ -3307,6 +3343,14 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 1.2
+          },
+          "input_video_plus": {
+            "price": 7.9
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -917,14 +917,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000031
         }
       },
       "batch_config": {
@@ -948,14 +951,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.000031
         }
       },
       "batch_config": {
@@ -1140,32 +1146,35 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_write_input_token": {
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00003125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -1174,32 +1183,35 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_write_input_token": {
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.0000625
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -1395,14 +1407,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1426,14 +1441,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1525,13 +1543,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1556,13 +1574,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1587,7 +1605,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1614,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1639,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1648,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1699,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1733,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1872,17 +1890,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1891,10 +1909,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -1903,17 +1921,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1922,10 +1940,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -1934,10 +1952,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
@@ -1947,19 +1965,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -1968,10 +1986,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
@@ -1981,19 +1999,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2067,10 +2085,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2080,19 +2098,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -2101,10 +2119,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2114,19 +2132,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00002
         }
       }
     }
@@ -2271,29 +2289,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2302,29 +2323,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -2333,29 +2357,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2364,29 +2391,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -2395,29 +2425,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000045
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2426,29 +2459,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.002
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000009
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.001
         }
       }
     }
@@ -2457,29 +2493,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2488,20 +2524,51 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
+          "web_search": {
+            "price": 0.35
+          },
+          "search": {
+            "price": 0.35
           }
         }
       },
@@ -2515,64 +2582,33 @@
       }
     }
   },
-  "gemini-3.1-flash-image-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.006
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "gemini-3.1-flash-image-preview-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2591,10 +2627,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2622,10 +2658,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -2650,10 +2686,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2678,10 +2714,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
         }
       },
@@ -2820,7 +2856,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2879,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2902,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2925,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2948,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2971,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2994,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +3017,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3040,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3063,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3043,7 +3079,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3052,9 +3088,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3063,7 +3096,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000001
         },
         "response_token": {
           "price": 0
@@ -3072,9 +3105,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3230,14 +3260,6 @@
         "response_token": {
           "price": 0
         }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
       }
     }
   },
@@ -3246,14 +3268,6 @@
       "pay_as_you_go": {
         "request_token": {
           "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -3309,74 +3323,12 @@
       }
     }
   },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
   "veo-3.1-lite-generate-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 5
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3393,7 +3345,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 5
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -3051,7 +3051,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3068,7 +3071,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -917,10 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1556,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1681,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1715,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1749,10 +1749,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1783,10 +1783,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2591,10 +2591,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -2622,10 +2622,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.035
           },
           "search": {
-            "price": 3.5
+            "price": 0.035
           }
         }
       },
@@ -3149,17 +3149,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.45
-          },
-          "input_audio": {
-            "price": 6.5
-          },
-          "input_video": {
-            "price": 12
-          }
         }
       }
     }
@@ -3172,17 +3161,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.45
-          },
-          "input_audio": {
-            "price": 6.5
-          },
-          "input_video": {
-            "price": 12
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -924,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -1943,7 +1943,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -1956,7 +1956,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -1977,7 +1977,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -1990,7 +1990,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2463,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2476,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2494,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2507,7 +2507,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2581,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2600,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2612,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2631,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0
           },
           "search": {
-            "price": 3.5
+            "price": 0
           }
         }
       },
@@ -2820,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3051,7 +3051,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.0000075
         },
         "response_token": {
           "price": 0
@@ -3071,7 +3071,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.0000075
         },
         "response_token": {
           "price": 0

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -917,13 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -951,13 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1159,13 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -1196,13 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -1407,13 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00025
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1437,17 +1422,14 @@
           "price": 0.00003
         },
         "response_token": {
-          "price": 0.00035
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1459,7 +1441,7 @@
           "price": 0.000015
         },
         "response_token": {
-          "price": 0.000175
+          "price": 0.000125
         }
       }
     }
@@ -1543,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1574,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1605,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1614,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1639,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1648,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1699,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1733,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1890,32 +1872,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00025
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00015
         }
       }
     }
@@ -1924,32 +1903,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00035
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000175
+          "price": 0.00015
         }
       }
     }
@@ -1958,32 +1934,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -1992,32 +1968,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -2104,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2138,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2305,13 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -2339,13 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -2373,13 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -2407,13 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 1.4
           }
         }
       },
@@ -2431,32 +2395,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2465,32 +2426,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.0009
         }
       }
     }
@@ -2509,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2540,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2561,29 +2519,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2592,29 +2550,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2633,10 +2591,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2664,10 +2622,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2692,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -2720,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
         }
       },
@@ -2908,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2931,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3000,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3023,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3094,6 +3052,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3111,6 +3072,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3129,10 +3093,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -3160,10 +3124,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -833,11 +833,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -861,11 +864,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -947,7 +953,7 @@
           "price": 0.00025
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0015
         },
         "additional_units": {
           "web_search": {
@@ -969,7 +975,7 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.00075
         }
       }
     }
@@ -1397,7 +1403,7 @@
           "price": 0.00003
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1411,7 +1417,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1419,7 +1425,7 @@
           "price": 0.000015
         },
         "response_token": {
-          "price": 0.0000625
+          "price": 0.000125
         }
       }
     }
@@ -1428,7 +1434,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.00003
         },
         "response_token": {
           "price": 0.00025
@@ -1445,12 +1451,12 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.000125
@@ -1545,6 +1551,9 @@
           "search": {
             "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1576,6 +1585,9 @@
           "search": {
             "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1884,10 +1896,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -1915,10 +1927,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -2079,10 +2091,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2113,10 +2125,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2283,13 +2295,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2297,18 +2309,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2317,13 +2326,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2331,18 +2340,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0009
         }
       }
     }
@@ -2351,13 +2357,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2365,18 +2371,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2385,13 +2388,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2399,18 +2402,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0009
         }
       }
     }
@@ -2419,13 +2419,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2433,18 +2433,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2453,13 +2450,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2467,18 +2464,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0009
         }
       }
     }
@@ -2680,11 +2674,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2708,11 +2705,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 0
           },
           "search": {
-            "price": 0.35
+            "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2850,7 +2850,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2873,7 +2873,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2896,7 +2896,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 13
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2919,7 +2919,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 13
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2942,7 +2942,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2965,7 +2965,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2988,7 +2988,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3011,7 +3011,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3034,7 +3034,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3057,7 +3057,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3073,7 +3073,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3090,7 +3090,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3117,10 +3117,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -3138,29 +3138,91 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0012
         },
         "cache_read_input_token": {
           "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 0.35
+          },
+          "search": {
+            "price": 0.35
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 0.35
+          },
+          "search": {
+            "price": 0.35
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
         }
       }
     }
@@ -3169,7 +3231,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
@@ -3181,62 +3243,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00002
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "imagen-3.0-generate-002-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 4
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-3.0-generate-002-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 4
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-3.0-fast-generate-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 2
-            }
-          }
-        }
-      }
-    }
-  },
-  "imagen-3.0-fast-generate-001-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 2
-            }
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -921,13 +921,10 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000031
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -955,13 +952,10 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000031
+          "price": 0.000025
         }
       },
       "batch_config": {
@@ -1146,16 +1140,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.00003125
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -1163,18 +1157,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -1183,16 +1174,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_write_input_token": {
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.0000625
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -1200,18 +1191,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0009
         }
       }
     }
@@ -1411,13 +1399,10 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1445,13 +1430,10 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1890,10 +1872,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -1909,10 +1891,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00015
         }
       }
     }
@@ -1921,10 +1903,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -1940,10 +1922,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00015
         }
       }
     }
@@ -1952,16 +1934,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1974,10 +1956,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -1986,16 +1968,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2008,10 +1990,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -2085,10 +2067,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2107,10 +2089,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00015
         }
       }
     }
@@ -2119,10 +2101,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2141,10 +2123,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00015
         }
       }
     }
@@ -2289,13 +2271,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2303,18 +2285,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2323,13 +2302,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2337,18 +2316,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0009
         }
       }
     }
@@ -2357,32 +2333,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2391,32 +2364,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0009
         }
       }
     }
@@ -2425,13 +2395,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2439,18 +2409,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2459,13 +2426,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2473,18 +2440,15 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0009
         }
       }
     }
@@ -2493,13 +2457,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2512,10 +2476,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -2524,13 +2488,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2543,10 +2507,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -2555,10 +2519,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2574,10 +2538,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2586,10 +2550,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2605,10 +2569,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2617,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2636,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2648,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2667,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2902,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2925,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2994,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3017,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3079,7 +3043,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3096,7 +3060,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3255,7 +3219,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3267,7 +3231,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3323,36 +3287,26 @@
       }
     }
   },
-  "veo-3.1-lite-generate-preview-lte-128k": {
+  "gemini-embedding-2-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 10
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
   },
-  "veo-3.1-lite-generate-preview-gt-128k": {
+  "gemini-embedding-2-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 10
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.14
           },
           "search": {
-            "price": 1.4
+            "price": 0.14
           }
         }
       },
@@ -3183,6 +3183,30 @@
           "input_video": {
             "price": 12
           }
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3149,6 +3149,17 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.45
+          },
+          "input_audio": {
+            "price": 6.5
+          },
+          "input_video": {
+            "price": 12
+          }
         }
       }
     }
@@ -3161,6 +3172,17 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.45
+          },
+          "input_audio": {
+            "price": 6.5
+          },
+          "input_video": {
+            "price": 12
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -838,6 +838,9 @@
           "search": {
             "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -866,6 +869,9 @@
           "search": {
             "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -923,11 +929,11 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -957,7 +963,7 @@
             "price": 0.35
           },
           "thinking_token": {
-            "price": 0
+            "price": 0.00035
           }
         },
         "cache_read_input_token": {
@@ -1163,9 +1169,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -1200,9 +1203,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -1411,9 +1411,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1445,13 +1442,10 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1551,6 +1545,9 @@
           "search": {
             "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1582,6 +1579,9 @@
           "search": {
             "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1729,7 +1729,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -1890,10 +1890,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1904,7 +1904,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1921,10 +1921,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
@@ -1935,7 +1935,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1952,16 +1952,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -1974,7 +1974,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -1986,16 +1986,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
@@ -2008,7 +2008,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2128,7 +2128,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -2303,9 +2303,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2337,9 +2334,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2367,10 +2361,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2398,10 +2392,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2419,13 +2413,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
@@ -2433,9 +2427,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2453,13 +2444,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
@@ -2467,9 +2458,6 @@
           },
           "search": {
             "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
           }
         }
       },
@@ -2493,7 +2481,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2506,7 +2494,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2524,7 +2512,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2537,7 +2525,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.0000125
         },
         "response_token": {
           "price": 0.000075
@@ -2549,10 +2537,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
@@ -2568,10 +2556,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2580,10 +2568,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
@@ -2599,10 +2587,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2611,10 +2599,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2630,10 +2618,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2642,10 +2630,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2661,10 +2649,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2685,6 +2673,9 @@
           "search": {
             "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2713,6 +2704,9 @@
           "search": {
             "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2850,7 +2844,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2873,7 +2867,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2896,7 +2890,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2919,7 +2913,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2942,7 +2936,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2965,7 +2959,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2988,7 +2982,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3011,7 +3005,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3034,7 +3028,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3057,7 +3051,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3081,10 +3075,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }
@@ -3101,10 +3092,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000075
         }
       }
     }
@@ -3171,40 +3159,6 @@
       }
     }
   },
-  "veo-3.1-lite-generate-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 3
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
-        }
-      }
-    }
-  },
-  "veo-3.1-lite-generate-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 3
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
-        }
-      }
-    }
-  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3225,6 +3179,40 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 0
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 0
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -838,6 +838,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -866,6 +869,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -917,14 +923,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000013
+          "price": 0.0000125
         }
       },
       "batch_config": {
@@ -948,10 +954,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1159,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1187,10 +1193,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1395,10 +1401,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1432,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
@@ -1525,14 +1531,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1556,14 +1565,17 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1587,7 +1599,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1608,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1621,7 +1633,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1642,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1681,10 +1693,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1715,10 +1727,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
@@ -1872,21 +1884,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1903,21 +1915,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000075
         }
       },
       "batch_config": {
@@ -1934,23 +1946,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -1968,23 +1980,23 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2080,10 +2092,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2114,10 +2126,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2281,10 +2293,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2312,10 +2324,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2343,10 +2355,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2374,10 +2386,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2395,20 +2407,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000125
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2426,20 +2438,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2463,14 +2475,14 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2494,14 +2506,14 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
@@ -2519,29 +2531,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2550,29 +2562,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00015
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 1.4
+            "price": 0.35
           },
           "search": {
-            "price": 1.4
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000075
         }
       }
     }
@@ -2581,29 +2593,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2612,29 +2624,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 0.35
           },
           "search": {
-            "price": 3.5
+            "price": 0.35
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2655,6 +2667,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2683,6 +2698,9 @@
           "search": {
             "price": 0
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2820,7 +2838,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2843,7 +2861,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2866,7 +2884,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2889,7 +2907,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2912,7 +2930,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2935,7 +2953,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2958,7 +2976,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2981,7 +2999,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3004,7 +3022,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3027,7 +3045,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3135,30 +3153,6 @@
       }
     }
   },
-  "gemini-embedding-2-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "gemini-embedding-2-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "veo-3.1-lite-generate-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3189,6 +3183,30 @@
           "default_sample_count": {
             "price": 1
           }
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-embedding-2-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -917,14 +917,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1525,17 +1525,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1559,17 +1556,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1593,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.012
@@ -1602,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1627,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.012
@@ -1636,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1687,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1721,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1878,29 +1872,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00015
         }
       }
     }
@@ -1909,29 +1903,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00015
         }
       }
     }
@@ -1940,29 +1934,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1974,29 +1968,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2086,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2120,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2287,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2318,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2349,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2380,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2401,29 +2395,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2432,20 +2426,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2469,20 +2463,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2500,20 +2494,20 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2525,29 +2519,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2556,29 +2550,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2587,29 +2581,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2618,29 +2612,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2656,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2684,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2826,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2849,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2872,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2895,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2918,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2941,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2964,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2987,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3010,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3033,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,14 +833,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -864,14 +861,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -923,14 +917,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -954,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1159,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1193,19 +1187,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }
@@ -1401,13 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00025
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1435,13 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00025
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1537,17 +1525,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1571,17 +1556,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1605,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1614,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1639,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1648,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1699,13 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00004
+            "price": 3.5
           }
         }
       },
@@ -1736,13 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00004
+            "price": 3.5
           }
         }
       },
@@ -1896,32 +1872,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00025
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00015
         }
       }
     }
@@ -1930,32 +1903,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00025
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000125
+          "price": 0.00015
         }
       }
     }
@@ -1977,13 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00015
+            "price": 1.4
           }
         }
       },
@@ -2014,13 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00015
+            "price": 1.4
           }
         }
       },
@@ -2116,13 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0003
+            "price": 1.4
           }
         }
       },
@@ -2153,13 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0003
+            "price": 1.4
           }
         }
       },
@@ -2323,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2354,19 +2312,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }
@@ -2385,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2416,10 +2374,41 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0009
+        }
+      }
+    }
+  },
+  "gemini-pro-latest-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
           }
         }
       },
@@ -2433,64 +2422,33 @@
       }
     }
   },
-  "gemini-pro-latest-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000125
-        },
-        "response_token": {
-          "price": 0.001
-        },
-        "cache_read_input_token": {
-          "price": 0.0000125
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 0.35
-          },
-          "search": {
-            "price": 0.35
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000625
-        },
-        "response_token": {
-          "price": 0.0005
-        }
-      }
-    }
-  },
   "gemini-pro-latest-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.0009
         }
       }
     }
@@ -2509,13 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00015
+            "price": 1.4
           }
         }
       },
@@ -2543,13 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.00015
+            "price": 1.4
           }
         }
       },
@@ -2567,29 +2519,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2598,29 +2550,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
             "price": 0.006
           },
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2629,29 +2581,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2660,29 +2612,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2698,14 +2650,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2729,14 +2678,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -3058,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3081,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3105,7 +3051,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3122,7 +3071,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3189,40 +3141,6 @@
       }
     }
   },
-  "veo-3.1-lite-generate-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 0
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
-        }
-      }
-    }
-  },
-  "veo-3.1-lite-generate-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "additional_units": {
-          "video_seconds": {
-            "price": 0
-          },
-          "default_duration_seconds": {
-            "price": 8
-          },
-          "default_sample_count": {
-            "price": 1
-          }
-        }
-      }
-    }
-  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3243,6 +3161,40 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 5
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -1943,7 +1943,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -1977,7 +1977,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2463,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -2494,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
@@ -3131,68 +3131,6 @@
         },
         "response_token": {
           "price": 0.0009
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,7 +736,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00004
@@ -767,7 +767,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00004
@@ -1174,10 +1174,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.0018
         },
         "cache_write_input_token": {
           "price": 0.00004
@@ -1196,10 +1196,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0009
         }
       }
     }
@@ -2581,7 +2581,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00004
@@ -2612,7 +2612,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00004
@@ -3052,9 +3052,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3072,9 +3069,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3141,6 +3135,102 @@
       }
     }
   },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 0
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "video_seconds": {
+            "price": 0
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3161,46 +3251,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "gemini-robotics-er-1.5-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      }
-    }
-  },
-  "gemini-robotics-er-1.5-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -750,7 +750,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -781,7 +781,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -838,6 +838,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -866,6 +869,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -1533,9 +1539,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1567,9 +1570,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1949,7 +1949,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1983,7 +1983,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2469,7 +2469,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2500,7 +2500,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2525,10 +2525,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2544,10 +2544,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2556,10 +2556,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2575,10 +2575,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2587,13 +2587,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         },
         "additional_units": {
           "web_search": {
@@ -2618,13 +2618,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         },
         "additional_units": {
           "web_search": {
@@ -2661,6 +2661,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2689,6 +2692,9 @@
           "search": {
             "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -750,7 +750,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -781,7 +781,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         }
       },
       "batch_config": {
@@ -833,11 +833,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -861,11 +864,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -1872,29 +1878,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1903,29 +1909,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.000003
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.000125
         }
       }
     }
@@ -1934,32 +1940,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -1968,32 +1974,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00004
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000001
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00002
         }
       }
     }
@@ -2395,29 +2401,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0.001
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.000013
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000625
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0005
         }
       }
     }
@@ -2426,29 +2432,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 0.000025
         },
         "additional_units": {
           "web_search": {
-            "price": 1.4
+            "price": 3.5
           },
           "search": {
-            "price": 1.4
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.00075
         }
       }
     }
@@ -2587,7 +2593,7 @@
           "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         },
         "additional_units": {
           "web_search": {
@@ -2618,7 +2624,7 @@
           "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.00000375
         },
         "additional_units": {
           "web_search": {
@@ -2650,11 +2656,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2678,11 +2687,14 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
+        },
+        "cache_read_input_token": {
+          "price": 0.000001875
         }
       },
       "batch_config": {

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -917,10 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1556,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -1681,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1715,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1749,10 +1749,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1783,10 +1783,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.014
+            "price": 1.4
           },
           "search": {
-            "price": 0.014
+            "price": 1.4
           }
         }
       },
@@ -2591,10 +2591,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -2622,10 +2622,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -3141,68 +3141,6 @@
       }
     }
   },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 0.014
-          },
-          "search": {
-            "price": 0.014
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 0.014
-          },
-          "search": {
-            "price": 0.014
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3211,17 +3149,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.45
-          },
-          "input_audio": {
-            "price": 6.5
-          },
-          "input_video": {
-            "price": 12
-          }
         }
       }
     }
@@ -3234,17 +3161,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.45
-          },
-          "input_audio": {
-            "price": 6.5
-          },
-          "input_video": {
-            "price": 12
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -833,14 +833,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -864,14 +861,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -927,10 +921,13 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -958,6 +955,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1163,6 +1163,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1197,6 +1200,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -1405,6 +1411,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
@@ -1436,10 +1445,13 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.00001
         }
       },
       "batch_config": {
@@ -1539,9 +1551,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1573,9 +1582,6 @@
           "search": {
             "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
         }
       },
       "batch_config": {
@@ -1723,7 +1729,7 @@
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1884,10 +1890,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -1898,7 +1904,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1915,10 +1921,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
@@ -1929,7 +1935,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.00001
         }
       },
       "batch_config": {
@@ -1946,16 +1952,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -1968,7 +1974,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1980,16 +1986,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -2002,7 +2008,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2122,7 +2128,7 @@
           "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.00001
         },
         "additional_units": {
           "web_search": {
@@ -2297,6 +2303,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2328,6 +2337,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2355,10 +2367,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2386,10 +2398,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -2407,13 +2419,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -2421,6 +2433,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2438,13 +2453,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -2452,6 +2467,9 @@
           },
           "search": {
             "price": 0.35
+          },
+          "thinking_token": {
+            "price": 0
           }
         }
       },
@@ -2475,7 +2493,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2488,7 +2506,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2506,7 +2524,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000005
         },
         "additional_units": {
           "web_search": {
@@ -2519,7 +2537,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2531,10 +2549,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2550,10 +2568,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2562,10 +2580,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2581,10 +2599,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.00015
         }
       }
     }
@@ -2593,10 +2611,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2612,10 +2630,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2624,10 +2642,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2643,10 +2661,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2662,14 +2680,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2693,14 +2708,11 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 0.35
           },
           "search": {
-            "price": 0
+            "price": 0.35
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2838,7 +2850,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2861,7 +2873,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2884,7 +2896,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2907,7 +2919,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2930,7 +2942,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2953,7 +2965,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2976,7 +2988,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -2999,7 +3011,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3022,7 +3034,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3045,7 +3057,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3069,7 +3081,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3086,7 +3101,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3158,7 +3176,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 3
           },
           "default_duration_seconds": {
             "price": 8
@@ -3175,7 +3193,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 0
+            "price": 3
           },
           "default_duration_seconds": {
             "price": 8
@@ -3207,68 +3225,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 0.35
-          },
-          "search": {
-            "price": 0.35
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 0.35
-          },
-          "search": {
-            "price": 0.35
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3141,68 +3141,6 @@
       }
     }
   },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 1.4
-          },
-          "search": {
-            "price": 1.4
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3211,6 +3149,17 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.045
+          },
+          "input_audio": {
+            "price": 0.065
+          },
+          "input_video": {
+            "price": 0.079
+          }
         }
       }
     }
@@ -3223,6 +3172,17 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.045
+          },
+          "input_audio": {
+            "price": 0.065
+          },
+          "input_video": {
+            "price": 0.079
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -743,10 +743,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -774,10 +774,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -917,10 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -948,10 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1395,10 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1426,10 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1525,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1556,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1681,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1715,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1749,10 +1749,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1783,10 +1783,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 0.14
+            "price": 1.4
           },
           "search": {
-            "price": 0.14
+            "price": 1.4
           }
         }
       },
@@ -2591,10 +2591,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },
@@ -2622,10 +2622,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.035
+            "price": 3.5
           },
           "search": {
-            "price": 0.035
+            "price": 3.5
           }
         }
       },

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3052,6 +3052,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3069,6 +3072,9 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3159,6 +3165,46 @@
       }
     }
   },
+  "gemini-robotics-er-1.5-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-robotics-er-1.5-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          }
+        }
+      }
+    }
+  },
   "veo-3.1-lite-generate-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3188,6 +3234,50 @@
           },
           "default_sample_count": {
             "price": 1
+          }
+        }
+      }
+    }
+  },
+  "lyria-3-clip-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "default": {
+            "price": 4
+          }
+        }
+      }
+    }
+  },
+  "lyria-3-clip-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "default": {
+            "price": 4
+          }
+        }
+      }
+    }
+  },
+  "lyria-3-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "default": {
+            "price": 8
+          }
+        }
+      }
+    }
+  },
+  "lyria-3-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "default": {
+            "price": 8
           }
         }
       }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -833,10 +833,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -861,10 +861,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -1153,10 +1153,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -1187,10 +1187,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -1587,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1596,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -1621,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1630,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -1879,10 +1879,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1910,10 +1910,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1947,10 +1947,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -1981,10 +1981,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2080,10 +2080,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2114,10 +2114,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2281,10 +2281,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2312,10 +2312,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2343,10 +2343,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2374,10 +2374,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2405,10 +2405,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2436,10 +2436,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2467,10 +2467,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2498,10 +2498,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2529,10 +2529,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2560,10 +2560,10 @@
             "price": 0.006
           },
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2650,10 +2650,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -2678,10 +2678,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0
+            "price": 3.5
           },
           "search": {
-            "price": 0
+            "price": 3.5
           }
         }
       },
@@ -3283,68 +3283,6 @@
         },
         "response_token": {
           "price": 0.001
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
-        }
-      }
-    }
-  },
-  "nano-banana-pro-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002
-        },
-        "response_token": {
-          "price": 0.0012
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.012
-          },
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0001
-        },
-        "response_token": {
-          "price": 0.0006
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3052,9 +3052,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3072,9 +3069,6 @@
       "batch_config": {
         "request_token": {
           "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3137,46 +3131,6 @@
         },
         "response_token": {
           "price": 0.0009
-        }
-      }
-    }
-  },
-  "gemini-robotics-er-1.5-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
-        }
-      }
-    }
-  },
-  "gemini-robotics-er-1.5-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 3.5
-          },
-          "search": {
-            "price": 3.5
-          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -1174,10 +1174,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0004
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0018
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0.00004
@@ -1196,10 +1196,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0009
+          "price": 0.0006
         }
       }
     }
@@ -3161,6 +3161,46 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "gemini-robotics-er-1.5-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-robotics-er-1.5-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3141,6 +3141,46 @@
       }
     }
   },
+  "gemini-robotics-er-1.5-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          }
+        }
+      }
+    }
+  },
+  "gemini-robotics-er-1.5-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 3.5
+          },
+          "search": {
+            "price": 3.5
+          }
+        }
+      }
+    }
+  },
   "gemini-embedding-2-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3149,6 +3189,17 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.45
+          },
+          "input_audio": {
+            "price": 6.5
+          },
+          "input_video": {
+            "price": 12
+          }
         }
       }
     }
@@ -3161,6 +3212,17 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.45
+          },
+          "input_audio": {
+            "price": 6.5
+          },
+          "input_video": {
+            "price": 12
+          }
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,17 +736,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -767,17 +767,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -917,13 +917,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -951,13 +948,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1146,35 +1140,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_write_input_token": {
           "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -1183,35 +1174,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_write_input_token": {
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0009
         }
       }
     }
@@ -1407,13 +1395,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1441,13 +1426,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0
+            "price": 3.5
           }
         },
         "cache_read_input_token": {
@@ -1543,13 +1525,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1574,13 +1556,13 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "image_token": {
             "price": 0.003
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1605,7 +1587,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1614,7 +1596,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1639,7 +1621,7 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "image_token": {
             "price": 0.012
@@ -1648,7 +1630,7 @@
             "price": 0.0011
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
@@ -1699,10 +1681,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1733,10 +1715,10 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -1890,17 +1872,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1909,10 +1891,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00015
         }
       }
     }
@@ -1921,17 +1903,17 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
@@ -1940,10 +1922,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00015
         }
       }
     }
@@ -1952,32 +1934,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -1986,32 +1968,32 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -2085,10 +2067,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2098,19 +2080,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00015
         }
       }
     }
@@ -2119,10 +2101,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0003
         },
         "cache_write_input_token": {
           "price": 0.00005
@@ -2132,19 +2114,19 @@
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00015
         }
       }
     }
@@ -2289,32 +2271,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2323,32 +2302,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0009
         }
       }
     }
@@ -2357,32 +2333,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2391,32 +2364,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0009
         }
       }
     }
@@ -2425,32 +2395,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000045
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0006
         }
       }
     }
@@ -2459,32 +2426,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.002
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000009
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
-          },
-          "thinking_token": {
-            "price": 0.0001
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0009
         }
       }
     }
@@ -2493,29 +2457,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 1.4
           },
           "search": {
-            "price": 0.35
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000125
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.000075
         }
       }
     }
@@ -2524,20 +2488,113 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        },
+        "cache_read_input_token": {
+          "price": 0.0000025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000125
+        },
+        "response_token": {
+          "price": 0.000075
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "gemini-2.0-flash-001-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.00001
         },
         "response_token": {
           "price": 0.00004
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
@@ -2551,126 +2608,33 @@
       }
     }
   },
-  "gemini-3.1-flash-image-preview-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.00015
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.006
-          },
-          "web_search": {
-            "price": 0.35
-          },
-          "search": {
-            "price": 0.35
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000125
-        },
-        "response_token": {
-          "price": 0.000075
-        }
-      }
-    }
-  },
-  "gemini-3.1-flash-image-preview-gt-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.00015
-        },
-        "additional_units": {
-          "image_token": {
-            "price": 0.006
-          },
-          "web_search": {
-            "price": 0.35
-          },
-          "search": {
-            "price": 0.35
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000125
-        },
-        "response_token": {
-          "price": 0.000075
-        }
-      }
-    }
-  },
-  "gemini-2.0-flash-001-lte-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000025
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 0.35
-          },
-          "search": {
-            "price": 0.35
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
   "gemini-2.0-flash-001-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.0000025
         },
         "additional_units": {
           "web_search": {
-            "price": 0.35
+            "price": 3.5
           },
           "search": {
-            "price": 0.35
+            "price": 3.5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         }
       }
     }
@@ -2856,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2879,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2902,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2925,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -2948,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2971,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 20
+            "price": 40
           },
           "default_duration_seconds": {
             "price": 8
@@ -2994,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3017,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 10
+            "price": 15
           },
           "default_duration_seconds": {
             "price": 8
@@ -3040,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3063,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 50
+            "price": 35
           },
           "default_duration_seconds": {
             "price": 8
@@ -3079,7 +3043,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3096,7 +3060,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000001
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
@@ -3259,17 +3223,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.00012
-          },
-          "input_video": {
-            "price": 0.00079
-          },
-          "input_audio": {
-            "price": 0.00016
-          }
         }
       }
     }
@@ -3282,17 +3235,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 0.00012
-          },
-          "input_video": {
-            "price": 0.00079
-          },
-          "input_audio": {
-            "price": 0.00016
-          }
         }
       }
     }
@@ -3345,12 +3287,74 @@
       }
     }
   },
+  "nano-banana-pro-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "nano-banana-pro-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.012
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
   "veo-3.1-lite-generate-preview-lte-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 3
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3367,7 +3371,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "video_seconds": {
-            "price": 3
+            "price": 10
           },
           "default_duration_seconds": {
             "price": 8
@@ -3375,6 +3379,30 @@
           "default_sample_count": {
             "price": 1
           }
+        }
+      }
+    }
+  },
+  "gemini-robotics-er-1.6-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gemini-robotics-er-1.6-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3152,13 +3152,13 @@
         },
         "additional_units": {
           "input_image": {
-            "price": 0.45
+            "price": 0.000045
           },
           "input_audio": {
-            "price": 6.5
+            "price": 0.00065
           },
           "input_video": {
-            "price": 12
+            "price": 0.0012
           }
         }
       }
@@ -3175,13 +3175,13 @@
         },
         "additional_units": {
           "input_image": {
-            "price": 0.45
+            "price": 0.000045
           },
           "input_audio": {
-            "price": 6.5
+            "price": 0.00065
           },
           "input_video": {
-            "price": 12
+            "price": 0.0012
           }
         }
       }

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -736,10 +736,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -755,10 +755,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -767,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "additional_units": {
           "web_search": {
@@ -786,10 +786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -838,9 +838,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -869,9 +866,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -930,7 +924,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.000013
         }
       },
       "batch_config": {
@@ -1878,21 +1872,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1909,21 +1903,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0003
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000005
         }
       },
       "batch_config": {
@@ -1940,29 +1934,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -1974,29 +1968,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00015
         },
         "cache_write_input_token": {
           "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2401,20 +2395,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0012
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2432,20 +2426,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0018
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
-            "price": 3.5
+            "price": 1.4
           },
           "search": {
-            "price": 3.5
+            "price": 1.4
           }
         }
       },
@@ -2469,7 +2463,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2482,7 +2476,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2500,7 +2494,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.000003
         },
         "additional_units": {
           "web_search": {
@@ -2513,7 +2507,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 0.000013
         },
         "response_token": {
           "price": 0.000075
@@ -2525,10 +2519,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2556,10 +2550,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0003
         },
         "additional_units": {
           "image_token": {
@@ -2587,10 +2581,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2606,10 +2600,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2618,10 +2612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "cache_read_input_token": {
           "price": 0.0000025
@@ -2637,10 +2631,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -2661,9 +2655,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2692,9 +2683,6 @@
           "search": {
             "price": 3.5
           }
-        },
-        "cache_read_input_token": {
-          "price": 0.000001875
         }
       },
       "batch_config": {
@@ -2832,7 +2820,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2855,7 +2843,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2878,7 +2866,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2901,7 +2889,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2924,7 +2912,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2947,7 +2935,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 40
+            "price": 20
           },
           "default_duration_seconds": {
             "price": 8
@@ -2970,7 +2958,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -2993,7 +2981,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 15
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8
@@ -3016,7 +3004,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3039,7 +3027,7 @@
         },
         "additional_units": {
           "video_seconds": {
-            "price": 35
+            "price": 50
           },
           "default_duration_seconds": {
             "price": 8
@@ -3055,7 +3043,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -3063,7 +3051,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3072,7 +3063,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -3080,7 +3071,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3235,14 +3229,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 1.2
-          },
-          "input_video_plus": {
-            "price": 7.9
-          }
         }
       }
     }
@@ -3255,14 +3241,6 @@
         },
         "response_token": {
           "price": 0
-        },
-        "additional_units": {
-          "input_image": {
-            "price": 1.2
-          },
-          "input_video_plus": {
-            "price": 7.9
-          }
         }
       }
     }
@@ -3319,18 +3297,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000012
         },
-        "additional_units": {
-          "input_image": {
-            "price": 1.2
-          },
-          "input_video_plus": {
-            "price": 7.9
-          }
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3339,18 +3317,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000015
         },
         "response_token": {
           "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000012
         },
-        "additional_units": {
-          "input_image": {
-            "price": 1.2
-          },
-          "input_video_plus": {
-            "price": 7.9
-          }
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: google

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 25 |

### ➕ New Models
- `gemini-embedding-2-lte-128k`
- `gemini-embedding-2-gt-128k`

### 🔄 Updated Models
- `gemini-2.5-pro-lte-128k`
- `gemini-2.0-flash-lte-128k`
- `gemini-2.0-flash-gt-128k`
- `gemini-2.0-flash-001-lte-128k`
- `gemini-2.0-flash-001-gt-128k`
- `gemini-2.0-flash-lite-lte-128k`
- `gemini-2.0-flash-lite-gt-128k`
- `gemini-2.0-flash-lite-001-lte-128k`
- `gemini-2.0-flash-lite-001-gt-128k`
- `gemini-3.1-flash-lite-preview-lte-128k`
- `gemini-3.1-flash-lite-preview-gt-128k`
- `gemini-flash-lite-latest-lte-128k`
- `gemini-flash-lite-latest-gt-128k`
- `gemini-embedding-001-lte-128k`
- `gemini-embedding-001-gt-128k`
- `veo-2.0-generate-001-lte-128k`
- `veo-2.0-generate-001-gt-128k`
- `veo-3.0-generate-001-lte-128k`
- `veo-3.0-generate-001-gt-128k`
- `veo-3.0-fast-generate-001-lte-128k`
- `veo-3.0-fast-generate-001-gt-128k`
- `veo-3.1-generate-preview-lte-128k`
- `veo-3.1-generate-preview-gt-128k`
- `veo-3.1-fast-generate-preview-lte-128k`
- `veo-3.1-fast-generate-preview-gt-128k`


### Model → pricing page mapping

Pricing source: `https://cloud.google.com/vertex-ai/generative-ai/pricing`
Model list source: `get_gemini_models` API (50 models, 29 included after filtering)

#### Excluded models (with reason)
- `gemini-2.5-flash-preview-tts`, `gemini-2.5-pro-preview-tts`, `gemini-3.1-flash-tts-preview` → TTS (excluded by rule)
- `gemma-3-1b-it`, `gemma-3-4b-it`, `gemma-3-12b-it`, `gemma-3-27b-it`, `gemma-3n-e4b-it`, `gemma-3n-e2b-it`, `gemma-4-26b-a4b-it`, `gemma-4-31b-it` → Gemma (excluded by rule)
- `nano-banana-pro-preview` → contains "nano" (excluded by `*nano*` rule)
- `gemini-2.5-computer-use-preview-10-2025` → computer-use model (excluded by rule)
- `gemini-robotics-er-1.5-preview`, `gemini-robotics-er-1.6-preview` → Robotics (excluded by rule)
- `lyria-3-clip-preview`, `lyria-3-pro-preview` → not Gemini/Imagen/Veo/Embedding category
- `deep-research-max-preview-04-2026`, `deep-research-preview-04-2026`, `deep-research-pro-preview-12-2025` → not in include list
- `aqa` → excluded by rule

#### Gemini 2.5 Models

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-2.5-pro-lte-128k | Gemini 2.5 Pro, ≤200K tier | input $1.25, output $10, cache_read $0.13; batch $0.625/$5; web_search 3.5¢ |
| gemini-2.5-pro-gt-128k | Gemini 2.5 Pro, >200K tier | input $2.50, output $15, cache_read $0.25; batch $1.25/$7.5; web_search 3.5¢ |
| gemini-2.5-flash-lte-128k | Gemini 2.5 Flash, flat pricing | input $0.30, output $2.50, cache_read $0.03; batch $0.15/$1.25; web_search 3.5¢ |
| gemini-2.5-flash-gt-128k | Gemini 2.5 Flash, flat pricing | same as lte (no context tiers) |
| gemini-2.5-flash-lite-lte-128k | Gemini 2.5 Flash Lite, flat pricing | input $0.10, output $0.40, cache_read $0.01; batch $0.05/$0.20; web_search 3.5¢ |
| gemini-2.5-flash-lite-gt-128k | Gemini 2.5 Flash Lite, flat pricing | same as lte (no context tiers) |
| gemini-2.5-flash-image-lte-128k | Gemini 2.5 Flash Image, flat pricing | input $0.30, text output $2.50, image_token $30; batch $0.15/$1.25; batch image $15/1M noted |
| gemini-2.5-flash-image-gt-128k | Gemini 2.5 Flash Image, flat pricing | same as lte (no context tiers) |

#### Gemini 2.0 Models

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-2.0-flash-lte-128k | Gemini 2.0 Flash, flat pricing | input $0.15, output $0.60; batch $0.075/$0.30; web_search 3.5¢ |
| gemini-2.0-flash-gt-128k | Gemini 2.0 Flash, flat pricing | same as lte (no context tiers) |
| gemini-2.0-flash-001-lte-128k | Gemini 2.0 Flash (versioned alias) | same pricing as gemini-2.0-flash |
| gemini-2.0-flash-001-gt-128k | Gemini 2.0 Flash (versioned alias) | same as lte |
| gemini-2.0-flash-lite-lte-128k | Gemini 2.0 Flash Lite, flat pricing | input $0.075, output $0.30; batch $0.0375/$0.15; web_search 3.5¢ |
| gemini-2.0-flash-lite-gt-128k | Gemini 2.0 Flash Lite, flat pricing | same as lte (no context tiers) |
| gemini-2.0-flash-lite-001-lte-128k | Gemini 2.0 Flash Lite (versioned alias) | same pricing as gemini-2.0-flash-lite |
| gemini-2.0-flash-lite-001-gt-128k | Gemini 2.0 Flash Lite (versioned alias) | same as lte |

#### Gemini 3.x Models

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-3.1-pro-preview-lte-128k | Gemini 3.1 Pro Preview, ≤200K tier | input $2, output $12, cache_read $0.2; batch $1/$6; web_search 1.4¢ ($14/1K) |
| gemini-3.1-pro-preview-gt-128k | Gemini 3.1 Pro Preview, >200K tier | input $4, output $18, cache_read $0.4; batch $2/$9; web_search 1.4¢ |
| gemini-3.1-pro-preview-customtools-lte-128k | Gemini 3.1 Pro Preview (custom tools variant) | same pricing as gemini-3.1-pro-preview |
| gemini-3.1-pro-preview-customtools-gt-128k | Gemini 3.1 Pro Preview, >200K tier | same as 3.1-pro-preview gt |
| gemini-3.1-flash-lite-preview-lte-128k | Gemini 3.1 Flash-Lite Preview, flat pricing | input $0.25, output $1.50, cache_read $0.03; batch $0.13/$0.75; web_search 1.4¢ |
| gemini-3.1-flash-lite-preview-gt-128k | Gemini 3.1 Flash-Lite Preview, flat pricing | same as lte (no context tiers) |
| gemini-3.1-flash-image-preview-lte-128k | Gemini 3.1 Flash Image Preview, flat pricing | input $0.50, text output $3, image_token $60; batch $0.25/$1.50; batch image $30/1M noted; web_search 1.4¢ |
| gemini-3.1-flash-image-preview-gt-128k | Gemini 3.1 Flash Image Preview, flat pricing | same as lte (no context tiers) |
| gemini-3-pro-preview-lte-128k | Gemini 3 Pro Preview, ≤200K tier | input $2, output $12, cache_read $0.2; batch $1/$6; web_search 1.4¢ (same prices as 3.1 Pro) |
| gemini-3-pro-preview-gt-128k | Gemini 3 Pro Preview, >200K tier | input $4, output $18, cache_read $0.4; batch $2/$9 |
| gemini-3-flash-preview-lte-128k | Gemini 3 Flash Preview, flat pricing | input $0.5, output $3, cache_read $0.05; batch $0.25/$1.5; web_search 1.4¢ |
| gemini-3-flash-preview-gt-128k | Gemini 3 Flash Preview, flat pricing | same as lte (no context tiers) |
| gemini-3-pro-image-preview-lte-128k | Gemini 3 Pro Image Preview, flat pricing | input $2, text output $12, image_token $120; batch $1/$6; batch image $60/1M noted; web_search 1.4¢ |
| gemini-3-pro-image-preview-gt-128k | Gemini 3 Pro Image Preview, flat pricing | same as lte (no context tiers) |

#### *-latest Alias Resolution

| Model ID | Resolved to | Pricing source |
|----------|-------------|----------------|
| gemini-flash-latest-lte-128k | gemini-3-flash-preview (newest Flash on pricing page) | input $0.5, output $3, cache $0.05; batch $0.25/$1.5; web_search 1.4¢ |
| gemini-flash-latest-gt-128k | gemini-3-flash-preview | same as lte |
| gemini-flash-lite-latest-lte-128k | gemini-3.1-flash-lite-preview (newest Flash-Lite on pricing page) | input $0.25, output $1.50, cache $0.03; batch $0.13/$0.75; web_search 1.4¢ |
| gemini-flash-lite-latest-gt-128k | gemini-3.1-flash-lite-preview | same as lte |
| gemini-pro-latest-lte-128k | gemini-3.1-pro-preview (newest Pro on pricing page) | input $2, output $12, cache $0.2; batch $1/$6; web_search 1.4¢ |
| gemini-pro-latest-gt-128k | gemini-3.1-pro-preview, >200K tier | input $4, output $18, cache $0.4; batch $2/$9 |

#### Embedding Models

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| gemini-embedding-001-lte-128k | Embeddings for Text (excl. Gemini Embedding), online | $0.000025/1K chars ≈ $0.10/1M tokens; batch ≈ $0.08/1M tokens |
| gemini-embedding-001-gt-128k | Embeddings for Text, flat pricing | same as lte |
| gemini-embedding-2-lte-128k | Gemini Embedding (standard), online | $0.00015/1K tokens = $0.15/1M; batch $0.12/1M |
| gemini-embedding-2-gt-128k | Gemini Embedding, flat pricing | same as lte |
| gemini-embedding-2-preview-lte-128k | Gemini Embedding 2 Unified Multimodal Preview | text input $0.2/1M; image $0.00012/image; video $0.00079/frame; audio $0.00016/sec (image/video/audio priced separately, not captured in token fields) |
| gemini-embedding-2-preview-gt-128k | Gemini Embedding 2 Unified Multimodal Preview | same as lte |

#### Imagen Models

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| imagen-4.0-generate-001-lte-128k | Imagen 4 (standard generation) | $0.04/image |
| imagen-4.0-generate-001-gt-128k | Imagen 4, flat pricing | same as lte |
| imagen-4.0-ultra-generate-001-lte-128k | Imagen 4 Ultra | $0.06/image |
| imagen-4.0-ultra-generate-001-gt-128k | Imagen 4 Ultra, flat pricing | same as lte |
| imagen-4.0-fast-generate-001-lte-128k | Imagen 4 Fast | $0.02/image |
| imagen-4.0-fast-generate-001-gt-128k | Imagen 4 Fast, flat pricing | same as lte |

#### Veo Models

| Model ID | Pricing page section | Notes |
|----------|----------------------|-------|
| veo-2.0-generate-001-lte-128k | Veo 2 | $0.50/sec = 50¢/sec; default 8s, 1 sample |
| veo-2.0-generate-001-gt-128k | Veo 2, flat pricing | same as lte |
| veo-3.0-generate-001-lte-128k | Veo 3 (video only, 720p/1080p) | $0.20/sec = 20¢/sec; default 8s, 1 sample |
| veo-3.0-generate-001-gt-128k | Veo 3, flat pricing | same as lte |
| veo-3.0-fast-generate-001-lte-128k | Veo 3 Fast (video only, 720p baseline) | $0.08/sec = 8¢/sec; default 8s, 1 sample |
| veo-3.0-fast-generate-001-gt-128k | Veo 3 Fast, flat pricing | same as lte |
| veo-3.1-generate-preview-lte-128k | Veo 3.1 (video only, 720p/1080p) | $0.20/sec = 20¢/sec; default 8s, 1 sample |
| veo-3.1-generate-preview-gt-128k | Veo 3.1, flat pricing | same as lte |
| veo-3.1-fast-generate-preview-lte-128k | Veo 3.1 Fast (video only, 720p baseline) | $0.08/sec = 8¢/sec; default 8s, 1 sample |
| veo-3.1-fast-generate-preview-gt-128k | Veo 3.1 Fast, flat pricing | same as lte |

#### Web Search Pricing Notes
- Gemini 3.x models: $14 per 1,000 search queries = 1.4¢/query (includes 5,000 free queries/month)
- Gemini 2.0/2.5 models: $35 per 1,000 grounded prompts = 3.5¢/prompt
- Both `web_search` and `search` keys always set to the same value per skill requirements

#### Thinking Token Notes
- No models have thinking tokens as a separate line item on the pricing page
- All models show "text output (response and reasoning)" — reasoning/thinking is included in the output price
- Therefore `thinking_token` additional field is not added to any model

#### Context Tier Mapping
- Gemini 2.5 Pro and Gemini 3.x Pro models: ≤200K vs >200K tiers → mapped to lte-128k/gt-128k entries respectively
- All other models (Flash, Lite, Image, Embedding, Imagen, Veo): flat pricing → lte-128k and gt-128k entries are identical

---
*Generated by Pricing Agent on 2026-04-27*