### PR TITLE
chore(pricing): Update fireworks-ai pricing

### DIFF
--- a/general/fireworks-ai.json
+++ b/general/fireworks-ai.json
@@ -648,5 +648,99 @@
     "name": "qwen3-embedding-8b",
     "type": { "primary": "embedding" },
     "disablePlayground": true
+  },
+  "deepseek-v3p1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3p2": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-4p7": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "glm-5p1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-oss-120b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "gpt-oss-20b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-8b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3p6-plus": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "flux-1-dev-fp8": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "flux-1-schnell-fp8": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "flux-kontext-pro": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "flux-kontext-max": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "image"
+    }
+  },
+  "qwen3-embedding-8b": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
   }
 }

--- a/general/fireworks-ai.json
+++ b/general/fireworks-ai.json
@@ -742,5 +742,10 @@
     "type": {
       "primary": "embedding"
     }
+  },
+  "kimi-k2p6": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,52 +412,6 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -546,6 +500,52 @@
         },
         "response_token": {
           "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -56,6 +56,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -112,10 +123,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -124,10 +135,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -136,10 +147,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 8e-7
+          "price": 0.0000008
         },
         "response_token": {
-          "price": 8e-7
+          "price": 0.0000008
         }
       }
     }
@@ -236,6 +247,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -260,6 +282,17 @@
         },
         "response_token": {
           "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
         }
       }
     }
@@ -272,6 +305,353 @@
         },
         "response_token": {
           "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "deepseek-v3p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "deepseek-v3p2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "glm-4p7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    }
+  },
+  "glm-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00016
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-oss-120b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.0000035
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "minimax-m2p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "minimax-m2p5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "flux-1-dev-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.05
+          }
+        }
+      }
+    }
+  },
+  "flux-1-schnell-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.035
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 8
+            }
+          }
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -330,7 +330,7 @@
           "price": 0.000168
         },
         "cache_read_input_token": {
-          "price": 0.000028
+          "price": 0.00003
         }
       },
       "batch_config": {
@@ -399,7 +399,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00001
         }
       },
       "batch_config": {
@@ -439,21 +439,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }
@@ -601,7 +601,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.05
+            "price": 0.025
           }
         }
       }
@@ -612,7 +612,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.035
+            "price": 0.0175
           }
         }
       }
@@ -648,7 +648,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000008
+          "price": 0.0000016
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -601,7 +601,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.025
+            "price": 0.05
           }
         }
       }
@@ -648,7 +648,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000008
+          "price": 0.00001
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -115,7 +115,7 @@
           "price": 0.0000008
         },
         "response_token": {
-          "price": 0.0000008
+          "price": 0
         }
       }
     }
@@ -208,21 +208,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.000095
         },
         "response_token": {
-          "price": 0.00032
+          "price": 0.000315
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.0000475
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000475
         },
         "response_token": {
-          "price": 0.00016
+          "price": 0.0001575
         }
       }
     }
@@ -249,7 +249,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000015
         }
       },
       "batch_config": {
@@ -272,7 +272,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.000015
         }
       },
       "batch_config": {
@@ -441,82 +441,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00044
-        },
-        "cache_read_input_token": {
-          "price": 0.000026
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00007
-        },
-        "response_token": {
-          "price": 0.00022
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "kimi-k2p6": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
           "price": 0.000095
         },
         "response_token": {
-          "price": 0.0004
+          "price": 0.000315
         },
         "cache_read_input_token": {
-          "price": 0.000016
+          "price": 0.0000475
         }
       },
       "batch_config": {
@@ -524,7 +455,7 @@
           "price": 0.0000475
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.0001575
         }
       }
     }
@@ -556,21 +487,44 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "kimi-k2p6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000095
+        },
+        "response_token": {
+          "price": 0.0004
+        },
+        "cache_read_input_token": {
+          "price": 0.000016
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000475
+        },
+        "response_token": {
+          "price": 0.0002
         }
       }
     }
@@ -625,21 +579,67 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000045
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00018
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000225
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.0000225
         },
         "response_token": {
-          "price": 0.000025
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
@@ -649,7 +649,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.05
+            "price": 0.025
           }
         }
       }
@@ -696,7 +696,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000008
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -214,7 +214,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00002
         }
       },
       "batch_config": {
@@ -272,7 +272,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000006
         }
       },
       "batch_config": {
@@ -441,159 +441,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00032
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.000026
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.00016
-        }
-      }
-    }
-  },
-  "gpt-oss-120b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "gpt-oss-20b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.0000025
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "kimi-k2p6": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "qwen3p6-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00012
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.00006
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00006
+          "price": 0.00022
         }
       }
     }
@@ -644,12 +506,150 @@
       }
     }
   },
+  "kimi-k2p6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000095
+        },
+        "response_token": {
+          "price": 0.0004
+        },
+        "cache_read_input_token": {
+          "price": 0.000016
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000475
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "gpt-oss-120b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.0000035
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00005
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000025
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
   "flux-1-dev-fp8": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.025
+            "price": 0.05
           }
         }
       }
@@ -660,7 +660,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.0175
+            "price": 0.035
           }
         }
       }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -126,7 +126,7 @@
           "price": 0.0000008
         },
         "response_token": {
-          "price": 0.0000008
+          "price": 0
         }
       }
     }
@@ -439,21 +439,44 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
         }
       }
     }
@@ -504,6 +527,52 @@
       }
     }
   },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00005
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000025
+        }
+      }
+    }
+  },
   "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -550,93 +619,12 @@
       }
     }
   },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "qwen3p6-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
-  "qwen3-embedding-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000008
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "flux-1-dev-fp8": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.05
+            "price": 0.025
           }
         }
       }
@@ -647,7 +635,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.035
+            "price": 0.0035
           }
         }
       }
@@ -675,6 +663,18 @@
               "price": 8
             }
           }
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -56,6 +56,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -388,7 +399,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00002
         }
       },
       "batch_config": {
@@ -397,144 +408,6 @@
         },
         "response_token": {
           "price": 0.00016
-        }
-      }
-    }
-  },
-  "gpt-oss-120b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "gpt-oss-20b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.0000025
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "minimax-m2p1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "minimax-m2p5": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.000015
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "mixtral-8x22b-instruct-hf": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00012
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.00006
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
         }
       }
     }
@@ -585,6 +458,121 @@
       }
     }
   },
+  "gpt-oss-120b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.0000035
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "minimax-m2p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "minimax-m2p5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
   "qwen3-8b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -613,7 +601,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.025
+            "price": 0.05
           }
         }
       }
@@ -624,7 +612,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.0175
+            "price": 0.035
           }
         }
       }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -126,7 +126,7 @@
           "price": 0.0000008
         },
         "response_token": {
-          "price": 0
+          "price": 0.0000008
         }
       }
     }
@@ -439,44 +439,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000035
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.0000035
         },
         "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
+          "price": 0.000015
         }
       }
     }
@@ -527,52 +504,6 @@
       }
     }
   },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "qwen3p6-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00005
-        },
-        "cache_read_input_token": {
-          "price": 0.000025
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.000025
-        }
-      }
-    }
-  },
   "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -619,12 +550,81 @@
       }
     }
   },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00005
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000025
+        }
+      }
+    }
+  },
   "flux-1-dev-fp8": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.025
+            "price": 0.05
           }
         }
       }
@@ -635,7 +635,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.0035
+            "price": 0.035
           }
         }
       }
@@ -671,7 +671,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00001
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,6 +412,52 @@
       }
     }
   },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -504,52 +550,6 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
   "llama-v3p3-70b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -592,6 +592,18 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -640,18 +652,6 @@
               "price": 8
             }
           }
-        }
-      }
-    }
-  },
-  "qwen3-embedding-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -272,7 +272,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -441,44 +441,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.000026
+          "price": 0.00002
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00022
-        }
-      }
-    }
-  },
-  "kimi-k2p6": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000095
-        },
-        "response_token": {
-          "price": 0.0004
-        },
-        "cache_read_input_token": {
-          "price": 0.000016
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000475
-        },
-        "response_token": {
-          "price": 0.0002
+          "price": 0.00016
         }
       }
     }
@@ -529,48 +506,25 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
+  "kimi-k2p6": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
           "price": 0.00006
         },
+        "response_token": {
+          "price": 0.0003
+        },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.00001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
           "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
+          "price": 0.00015
         }
       }
     }
@@ -625,33 +579,67 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00009
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00009
+          "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.000045
+          "price": 0.000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000045
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000045
+          "price": 0.000025
         }
       }
     }
   },
-  "qwen3-embedding-8b": {
+  "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
@@ -678,6 +666,19 @@
       }
     }
   },
+  "flux-kontext-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 8
+            }
+          }
+        }
+      }
+    }
+  },
   "flux-kontext-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -691,15 +692,14 @@
       }
     }
   },
-  "flux-kontext-max": {
+  "qwen3-embedding-8b": {
     "pricing_config": {
       "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 8
-            }
-          }
+        "request_token": {
+          "price": 0.0000008
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -460,29 +460,6 @@
       }
     }
   },
-  "kimi-k2p6": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000095
-        },
-        "response_token": {
-          "price": 0.0004
-        },
-        "cache_read_input_token": {
-          "price": 0.000016
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000475
-        },
-        "response_token": {
-          "price": 0.0002
-        }
-      }
-    }
-  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -529,48 +506,25 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
+  "kimi-k2p6": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000095
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.0004
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000016
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.0000475
         },
         "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
+          "price": 0.0002
         }
       }
     }
@@ -625,21 +579,79 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00012
+          "price": 0.00009
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.00009
         },
         "cache_read_input_token": {
-          "price": 0.00006
+          "price": 0.000045
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -688,18 +700,6 @@
               "price": 8
             }
           }
-        }
-      }
-    }
-  },
-  "qwen3-embedding-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -56,17 +56,6 @@
         },
         "response_token": {
           "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.00006
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00006
         }
       }
     }
@@ -246,17 +235,6 @@
         },
         "response_token": {
           "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
         }
       }
     }
@@ -294,7 +272,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000006
         }
       },
       "batch_config": {
@@ -339,17 +317,6 @@
         },
         "response_token": {
           "price": 0.00025
-        },
-        "cache_read_input_token": {
-          "price": 0.00003
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.000125
         }
       }
     }
@@ -374,17 +341,6 @@
         },
         "response_token": {
           "price": 0.00025
-        },
-        "cache_read_input_token": {
-          "price": 0.00003
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.000125
         }
       }
     }
@@ -485,21 +441,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00032
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.000026
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.00016
+          "price": 0.00022
         }
       }
     }
@@ -550,48 +506,25 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
+  "kimi-k2p6": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000099
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.000494
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.000016
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.0000495
         },
         "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
+          "price": 0.000247
         }
       }
     }
@@ -646,21 +579,67 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00012
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.00006
+          "price": 0.000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000025
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
@@ -717,7 +696,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000008
+          "price": 0.00001
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -330,7 +330,7 @@
           "price": 0.000168
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 0.000028
         }
       },
       "batch_config": {
@@ -399,7 +399,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.00002
         }
       },
       "batch_config": {
@@ -439,44 +439,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000035
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.0000035
         },
         "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
+          "price": 0.000015
         }
       }
     }
@@ -527,29 +504,6 @@
       }
     }
   },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -596,12 +550,58 @@
       }
     }
   },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "flux-1-dev-fp8": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.025
+            "price": 0.05
           }
         }
       }
@@ -612,7 +612,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.0175
+            "price": 0.035
           }
         }
       }
@@ -648,7 +648,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000016
+          "price": 0.0000008
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -458,6 +458,29 @@
       }
     }
   },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
   "minimax-m2p1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -500,29 +523,6 @@
         },
         "response_token": {
           "price": 0.00006
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,52 +412,6 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -592,6 +546,52 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,52 +412,6 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -500,6 +454,29 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
         }
       }
     }
@@ -550,29 +527,6 @@
       }
     }
   },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
   "qwen3-8b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -592,6 +546,52 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,6 +412,52 @@
       }
     }
   },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -454,29 +500,6 @@
         },
         "response_token": {
           "price": 0.000015
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
         }
       }
     }
@@ -527,6 +550,29 @@
       }
     }
   },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
   "qwen3-8b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -550,48 +596,14 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
+  "qwen3-embedding-8b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
+          "price": 0
         }
       }
     }
@@ -640,18 +652,6 @@
               "price": 8
             }
           }
-        }
-      }
-    }
-  },
-  "qwen3-embedding-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -56,17 +56,6 @@
         },
         "response_token": {
           "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.00006
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00006
         }
       }
     }
@@ -399,7 +388,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         }
       },
       "batch_config": {
@@ -439,21 +428,44 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
         }
       }
     }
@@ -491,7 +503,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000015
         }
       },
       "batch_config": {
@@ -504,71 +516,25 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
+  "mixtral-8x22b-instruct-hf": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00012
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
         },
         "response_token": {
           "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
         }
       }
     }
@@ -619,12 +585,58 @@
       }
     }
   },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
   "flux-1-dev-fp8": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.05
+            "price": 0.025
           }
         }
       }
@@ -635,7 +647,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.035
+            "price": 0.0035
           }
         }
       }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -460,52 +460,6 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
   "kimi-k2p6": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -575,6 +529,75 @@
       }
     }
   },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
   "qwen3-8b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -602,44 +625,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00006
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.000025
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
+          "price": 0.00006
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -460,6 +460,29 @@
       }
     }
   },
+  "kimi-k2p6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000099
+        },
+        "response_token": {
+          "price": 0.000494
+        },
+        "cache_read_input_token": {
+          "price": 0.000016
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000495
+        },
+        "response_token": {
+          "price": 0.000247
+        }
+      }
+    }
+  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -502,98 +525,6 @@
         },
         "response_token": {
           "price": 0.000015
-        }
-      }
-    }
-  },
-  "kimi-k2p6": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000099
-        },
-        "response_token": {
-          "price": 0.000494
-        },
-        "cache_read_input_token": {
-          "price": 0.000016
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000495
-        },
-        "response_token": {
-          "price": 0.000247
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "qwen3p6-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
         }
       }
     }
@@ -644,6 +575,87 @@
       }
     }
   },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00012
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "flux-1-dev-fp8": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -688,18 +700,6 @@
               "price": 8
             }
           }
-        }
-      }
-    }
-  },
-  "qwen3-embedding-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,52 +412,6 @@
       }
     }
   },
-  "gpt-oss-120b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "gpt-oss-20b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000007
-        },
-        "response_token": {
-          "price": 0.00003
-        },
-        "cache_read_input_token": {
-          "price": 0.0000035
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000035
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "minimax-m2p1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -500,6 +454,52 @@
         },
         "response_token": {
           "price": 0.00006
+        }
+      }
+    }
+  },
+  "gpt-oss-120b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.0000035
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -458,29 +458,6 @@
       }
     }
   },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
   "minimax-m2p1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -523,52 +500,6 @@
         },
         "response_token": {
           "price": 0.00006
-        }
-      }
-    }
-  },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "qwen3p6-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
         }
       }
     }
@@ -619,14 +550,71 @@
       }
     }
   },
-  "qwen3-embedding-8b": {
+  "llama-v3p3-70b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
         "request_token": {
           "price": 0.00001
         },
         "response_token": {
-          "price": 0
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
         }
       }
     }
@@ -675,6 +663,18 @@
               "price": 8
             }
           }
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -214,7 +214,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         }
       },
       "batch_config": {
@@ -447,7 +447,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         }
       },
       "batch_config": {
@@ -487,21 +487,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }
@@ -525,52 +525,6 @@
         },
         "response_token": {
           "price": 0.00015
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
         }
       }
     }
@@ -625,21 +579,67 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00006
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.000025
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
@@ -660,7 +660,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.035
+            "price": 0.0175
           }
         }
       }
@@ -696,7 +696,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000008
+          "price": 0.00001
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -458,6 +458,29 @@
       }
     }
   },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
   "minimax-m2p1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -504,6 +527,29 @@
       }
     }
   },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -546,52 +592,6 @@
         },
         "response_token": {
           "price": 0.00003
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -596,18 +596,6 @@
       }
     }
   },
-  "qwen3-embedding-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "flux-1-dev-fp8": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -652,6 +640,18 @@
               "price": 8
             }
           }
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -272,7 +272,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000006
         }
       },
       "batch_config": {
@@ -441,21 +441,44 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00032
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.000026
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.00016
+          "price": 0.00022
+        }
+      }
+    }
+  },
+  "kimi-k2p6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000095
+        },
+        "response_token": {
+          "price": 0.0004
+        },
+        "cache_read_input_token": {
+          "price": 0.000016
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000475
+        },
+        "response_token": {
+          "price": 0.0002
         }
       }
     }
@@ -506,25 +529,48 @@
       }
     }
   },
-  "kimi-k2p6": {
+  "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.0000075
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
@@ -579,67 +625,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 0.00006
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.000005
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
+          "price": 0.00006
         },
         "response_token": {
           "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
         }
       }
     }
@@ -696,7 +696,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000008
+          "price": 0.00001
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -460,6 +460,29 @@
       }
     }
   },
+  "kimi-k2p6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000095
+        },
+        "response_token": {
+          "price": 0.0004
+        },
+        "cache_read_input_token": {
+          "price": 0.000016
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000475
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -506,25 +529,48 @@
       }
     }
   },
-  "kimi-k2p6": {
+  "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000095
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0004
+          "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.000016
+          "price": 0.0000075
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000475
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
@@ -594,52 +640,6 @@
         },
         "response_token": {
           "price": 0.000045
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -441,21 +441,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.00014
         },
         "response_token": {
-          "price": 0.00032
+          "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00007
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.00016
+          "price": 0.00022
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -56,6 +56,17 @@
         },
         "response_token": {
           "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -196,10 +207,102 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00009
+          "price": 0.000056
         },
         "response_token": {
-          "price": 0.00009
+          "price": 0.000168
+        }
+      }
+    }
+  },
+  "glm-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00016
+        }
+      }
+    }
+  },
+  "minimax-m2p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "minimax-m2p5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "minimax-m2p7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }
@@ -378,7 +481,7 @@
       }
     }
   },
-  "glm-5": {
+  "glm-5p1": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -388,7 +491,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00002
         }
       },
       "batch_config": {
@@ -428,159 +531,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.0000025
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000025
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
-  "minimax-m2p1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
           "price": 0.00003
         },
-        "response_token": {
-          "price": 0.00012
-        },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.0000035
         }
       },
       "batch_config": {
         "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
           "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "minimax-m2p5": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.000015
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "mixtral-8x22b-instruct-hf": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00012
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.00006
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "qwen3p6-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00005
-        },
-        "cache_read_input_token": {
-          "price": 0.000025
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.000025
         }
       }
     }
@@ -631,12 +596,81 @@
       }
     }
   },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00012
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
   "flux-1-dev-fp8": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.025
+            "price": 0.05
           }
         }
       }
@@ -647,7 +681,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.0035
+            "price": 0.035
           }
         }
       }
@@ -683,7 +717,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000008
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -579,21 +579,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00009
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00009
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.000045
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.000045
         },
         "response_token": {
-          "price": 0.000025
+          "price": 0.000045
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -56,17 +56,6 @@
         },
         "response_token": {
           "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.00006
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00006
         }
       }
     }
@@ -399,7 +388,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00005
         }
       },
       "batch_config": {
@@ -439,21 +428,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0000025
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00001
         }
       }
     }
@@ -491,7 +480,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000015
         }
       },
       "batch_config": {
@@ -500,6 +489,52 @@
         },
         "response_token": {
           "price": 0.00006
+        }
+      }
+    }
+  },
+  "mixtral-8x22b-instruct-hf": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00012
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
         }
       }
     }
@@ -550,29 +585,6 @@
       }
     }
   },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
   "qwen3-8b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -601,7 +613,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.05
+            "price": 0.025
           }
         }
       }
@@ -612,7 +624,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.035
+            "price": 0.0175
           }
         }
       }
@@ -648,7 +660,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000008
+          "price": 0.00001
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -458,29 +458,6 @@
       }
     }
   },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
   "minimax-m2p1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -527,29 +504,6 @@
       }
     }
   },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -592,6 +546,52 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -460,6 +460,52 @@
       }
     }
   },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
   "kimi-k2p6": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -529,52 +575,6 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
   "llama-v3p3-70b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -625,21 +625,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00012
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.00005
         },
         "cache_read_input_token": {
-          "price": 0.00006
+          "price": 0.000025
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.000025
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,48 +412,48 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
+  "minimax-m2p1": {
     "pricing_config": {
       "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
         "request_token": {
           "price": 0.000015
         },
         "response_token": {
           "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
         }
       }
     }
   },
-  "qwen3-vl-30b-a3b-thinking": {
+  "minimax-m2p5": {
     "pricing_config": {
       "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
         "request_token": {
           "price": 0.000015
         },
         "response_token": {
           "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
         }
       }
     }
@@ -504,48 +504,48 @@
       }
     }
   },
-  "minimax-m2p1": {
+  "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
-        }
-      },
-      "batch_config": {
         "request_token": {
           "price": 0.000015
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
   },
-  "minimax-m2p5": {
+  "qwen3-vl-30b-a3b-thinking": {
     "pricing_config": {
       "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
-        }
-      },
-      "batch_config": {
         "request_token": {
           "price": 0.000015
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
@@ -648,7 +648,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000008
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,6 +412,52 @@
       }
     }
   },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -500,52 +546,6 @@
         },
         "response_token": {
           "price": 0.00006
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -619,6 +619,18 @@
       }
     }
   },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000008
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "flux-1-dev-fp8": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -663,18 +675,6 @@
               "price": 8
             }
           }
-        }
-      }
-    }
-  },
-  "qwen3-embedding-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,52 +412,6 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -546,6 +500,52 @@
         },
         "response_token": {
           "price": 0.00006
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
@@ -648,7 +648,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000008
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -272,7 +272,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -441,44 +441,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.000026
+          "price": 0.00002
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00022
-        }
-      }
-    }
-  },
-  "kimi-k2p6": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000095
-        },
-        "response_token": {
-          "price": 0.0004
-        },
-        "cache_read_input_token": {
-          "price": 0.000016
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000475
-        },
-        "response_token": {
-          "price": 0.0002
+          "price": 0.00016
         }
       }
     }
@@ -529,48 +506,25 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
+  "kimi-k2p6": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
           "price": 0.00006
         },
+        "response_token": {
+          "price": 0.0003
+        },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.00001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
           "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
+          "price": 0.00015
         }
       }
     }
@@ -625,21 +579,67 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00012
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.00001
         },
         "cache_read_input_token": {
-          "price": 0.00006
+          "price": 0.000005
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
         },
         "response_token": {
           "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
@@ -696,7 +696,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000008
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,52 +412,6 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -500,6 +454,29 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
         }
       }
     }
@@ -550,29 +527,6 @@
       }
     }
   },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
   "qwen3-8b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -596,12 +550,58 @@
       }
     }
   },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
   "flux-1-dev-fp8": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.05
+            "price": 0.025
           }
         }
       }
@@ -648,7 +648,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000008
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -115,7 +115,7 @@
           "price": 0.0000008
         },
         "response_token": {
-          "price": 0
+          "price": 0.0000008
         }
       }
     }
@@ -208,21 +208,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000095
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.000315
+          "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.0000475
+          "price": 0.00002
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000475
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0001575
+          "price": 0.00016
         }
       }
     }
@@ -249,7 +249,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -272,7 +272,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.000006
         }
       },
       "batch_config": {
@@ -441,13 +441,36 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.000026
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00007
+        },
+        "response_token": {
+          "price": 0.00022
+        }
+      }
+    }
+  },
+  "kimi-k2p6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.000095
         },
         "response_token": {
-          "price": 0.000315
+          "price": 0.0004
         },
         "cache_read_input_token": {
-          "price": 0.0000475
+          "price": 0.000016
         }
       },
       "batch_config": {
@@ -455,7 +478,7 @@
           "price": 0.0000475
         },
         "response_token": {
-          "price": 0.0001575
+          "price": 0.0002
         }
       }
     }
@@ -487,44 +510,67 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 0.0000035
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000025
+          "price": 0.0000035
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000015
         }
       }
     }
   },
-  "kimi-k2p6": {
+  "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000095
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0004
+          "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.000016
+          "price": 0.0000075
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000475
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
@@ -579,67 +625,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000045
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.00018
+          "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.0000225
+          "price": 0.00006
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000225
-        },
-        "response_token": {
-          "price": 0.00009
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
+          "price": 0.00006
         },
         "response_token": {
           "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
         }
       }
     }
@@ -649,7 +649,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.025
+            "price": 0.05
           }
         }
       }
@@ -696,7 +696,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000008
+          "price": 0.00001
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,6 +412,52 @@
       }
     }
   },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -454,29 +500,6 @@
         },
         "response_token": {
           "price": 0.000015
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
         }
       }
     }
@@ -527,6 +550,29 @@
       }
     }
   },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
   "qwen3-8b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -546,52 +592,6 @@
         },
         "response_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,52 +412,6 @@
       }
     }
   },
-  "minimax-m2p1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "minimax-m2p5": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -500,6 +454,52 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "minimax-m2p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "minimax-m2p5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,52 +412,6 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -500,6 +454,29 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
         }
       }
     }
@@ -550,29 +527,6 @@
       }
     }
   },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
   "qwen3-8b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -592,6 +546,64 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -640,18 +652,6 @@
               "price": 8
             }
           }
-        }
-      }
-    }
-  },
-  "qwen3-embedding-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,6 +412,75 @@
       }
     }
   },
+  "gpt-oss-120b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.0000035
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
   "minimax-m2p1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -458,48 +527,48 @@
       }
     }
   },
-  "gpt-oss-120b": {
+  "qwen3-8b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00002
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.00001
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00001
         }
       }
     }
   },
-  "gpt-oss-20b": {
+  "qwen3p6-plus": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.00009
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00009
         },
         "cache_read_input_token": {
-          "price": 0.0000035
+          "price": 0.000045
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.000045
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.000045
         }
       }
     }
@@ -550,48 +619,14 @@
       }
     }
   },
-  "llama-v3p3-70b-instruct": {
+  "qwen3-embedding-8b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
           "price": 0.00001
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0
         }
       }
     }
@@ -640,18 +675,6 @@
               "price": 8
             }
           }
-        }
-      }
-    }
-  },
-  "qwen3-embedding-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000008
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -272,7 +272,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 0.000003
         }
       },
       "batch_config": {
@@ -441,44 +441,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00044
+          "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.000026
+          "price": 0.00002
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00022
-        }
-      }
-    }
-  },
-  "kimi-k2p6": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000099
-        },
-        "response_token": {
-          "price": 0.000494
-        },
-        "cache_read_input_token": {
-          "price": 0.000016
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000495
-        },
-        "response_token": {
-          "price": 0.000247
+          "price": 0.00016
         }
       }
     }
@@ -529,6 +506,29 @@
       }
     }
   },
+  "kimi-k2p6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
   "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -571,29 +571,6 @@
         },
         "response_token": {
           "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3p6-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00012
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.00006
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00006
         }
       }
     }
@@ -644,14 +621,25 @@
       }
     }
   },
-  "qwen3-embedding-8b": {
+  "qwen3p6-plus": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0
+          "price": 0.00005
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000025
         }
       }
     }
@@ -661,7 +649,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.05
+            "price": 0.025
           }
         }
       }
@@ -700,6 +688,18 @@
               "price": 8
             }
           }
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000008
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,98 +412,6 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "minimax-m2p1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "minimax-m2p5": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        },
-        "cache_read_input_token": {
-          "price": 0.000003
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -573,6 +481,52 @@
       }
     }
   },
+  "minimax-m2p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "minimax-m2p5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
   "qwen3-8b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -596,12 +550,58 @@
       }
     }
   },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
   "flux-1-dev-fp8": {
     "pricing_config": {
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.025
+            "price": 0.05
           }
         }
       }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -458,6 +458,29 @@
       }
     }
   },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
   "minimax-m2p1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -504,6 +527,29 @@
       }
     }
   },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -546,52 +592,6 @@
         },
         "response_token": {
           "price": 0.00003
-        }
-      }
-    }
-  },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
         }
       }
     }
@@ -648,7 +648,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000008
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,7 +412,7 @@
       }
     }
   },
-  "gpt-oss-120b": {
+  "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -435,25 +435,25 @@
       }
     }
   },
-  "gpt-oss-20b": {
+  "qwen3-vl-30b-a3b-thinking": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.0000035
+          "price": 0.0000075
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.000015
+          "price": 0.00003
         }
       }
     }
@@ -504,7 +504,7 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
+  "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -527,25 +527,25 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-thinking": {
+  "gpt-oss-20b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00003
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 0.0000035
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.0000035
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.000015
         }
       }
     }
@@ -601,7 +601,7 @@
       "pay_as_you_go": {
         "additional_units": {
           "image_inference_step": {
-            "price": 0.05
+            "price": 0.025
           }
         }
       }
@@ -648,7 +648,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000008
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -458,29 +458,6 @@
       }
     }
   },
-  "llama-v3p3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00009
-        },
-        "response_token": {
-          "price": 0.00009
-        },
-        "cache_read_input_token": {
-          "price": 0.000045
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.000045
-        },
-        "response_token": {
-          "price": 0.000045
-        }
-      }
-    }
-  },
   "minimax-m2p1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -527,29 +504,6 @@
       }
     }
   },
-  "qwen3-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00002
-        },
-        "cache_read_input_token": {
-          "price": 0.00001
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
   "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -592,6 +546,52 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
         }
       }
     }
@@ -648,7 +648,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000008
+          "price": 0.00001
         },
         "response_token": {
           "price": 0

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -412,52 +412,6 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
   "gpt-oss-120b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -550,6 +504,52 @@
       }
     }
   },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
   "llama-v3p3-70b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -592,18 +592,6 @@
         },
         "response_token": {
           "price": 0.00001
-        }
-      }
-    }
-  },
-  "qwen3-embedding-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -652,6 +640,18 @@
               "price": 8
             }
           }
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -272,7 +272,7 @@
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 0.000006
         }
       },
       "batch_config": {
@@ -447,7 +447,7 @@
           "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.00007
+          "price": 0.000026
         }
       },
       "batch_config": {
@@ -456,6 +456,29 @@
         },
         "response_token": {
           "price": 0.00022
+        }
+      }
+    }
+  },
+  "kimi-k2p6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000095
+        },
+        "response_token": {
+          "price": 0.0004
+        },
+        "cache_read_input_token": {
+          "price": 0.000016
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000475
+        },
+        "response_token": {
+          "price": 0.0002
         }
       }
     }
@@ -506,25 +529,48 @@
       }
     }
   },
-  "kimi-k2p6": {
+  "qwen3-vl-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00006
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 0.0000075
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.0000075
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
         }
       }
     }
@@ -598,48 +644,14 @@
       }
     }
   },
-  "qwen3-vl-30b-a3b-instruct": {
+  "qwen3-embedding-8b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
-        }
-      }
-    }
-  },
-  "qwen3-vl-30b-a3b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        },
-        "cache_read_input_token": {
-          "price": 0.0000075
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.0000075
-        },
-        "response_token": {
-          "price": 0.00003
+          "price": 0
         }
       }
     }
@@ -666,19 +678,6 @@
       }
     }
   },
-  "flux-kontext-max": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "image": {
-          "default": {
-            "default": {
-              "price": 8
-            }
-          }
-        }
-      }
-    }
-  },
   "flux-kontext-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -692,14 +691,15 @@
       }
     }
   },
-  "qwen3-embedding-8b": {
+  "flux-kontext-max": {
     "pricing_config": {
       "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000008
-        },
-        "response_token": {
-          "price": 0
+        "image": {
+          "default": {
+            "default": {
+              "price": 8
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: fireworks-ai

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 17 |
| 🔄 Models updated (merged) | 4 |

### ➕ New Models
- `deepseek-v3p1`
- `deepseek-v3p2`
- `glm-4p7`
- `glm-5p1`
- `kimi-k2p6`
- `gpt-oss-120b`
- `gpt-oss-20b`
- `qwen3-vl-30b-a3b-instruct`
- `qwen3-vl-30b-a3b-thinking`
- `llama-v3p3-70b-instruct`
- `qwen3-8b`
- `qwen3p6-plus`
- `qwen3-embedding-8b`
- `flux-1-dev-fp8`
- `flux-1-schnell-fp8`
- `flux-kontext-pro`
- `flux-kontext-max`

### 🔄 Updated Models
- `glm-5`
- `kimi-k2p5`
- `minimax-m2p5`
- `minimax-m2p7`


## Model → Pricing Mapping

| Model ID | Category | Input | Cache Read | Output |
|---|---|---|---|---|
| deepseek-v3p1 | Named: DeepSeek V3 family | $0.56 | $0.28 | $1.68 |
| deepseek-v3p2 | Named: DeepSeek V3 family | $0.56 | $0.28 | $1.68 |
| glm-4p7 | Named: GLM-4.7 | $0.60 | $0.30 | $2.20 |
| glm-5 | Named: GLM-5 | $1.00 | $0.20 | $3.20 |
| glm-5p1 | Named: GLM-5.1 | $1.40 | $0.26 | $4.40 |
| kimi-k2p5 | Named: Kimi K2.5 | $0.60 | $0.10 | $3.00 |
| kimi-k2p6 | Named: Kimi K2.6 | $0.95 | $0.16 | $4.00 |
| gpt-oss-120b | Named: OpenAI GPT-OSS-120B | $0.15 | $0.075 | $0.60 |
| gpt-oss-20b | Named: OpenAI GPT-OSS-20B | $0.07 | $0.035 | $0.30 |
| minimax-m2p5 | Named: MiniMax 2.5 | $0.30 | $0.03 | $1.20 |
| minimax-m2p7 | Named: MiniMax 2.7 | $0.30 | $0.06 | $1.20 |
| qwen3-vl-30b-a3b-instruct | Named: Qwen3 VL 30B A3B | $0.15 | $0.075 | $0.60 |
| qwen3-vl-30b-a3b-thinking | Named: Qwen3 VL 30B A3B | $0.15 | $0.075 | $0.60 |
| llama-v3p3-70b-instruct | Tier: >16B dense | $0.90 | $0.45 | $0.90 |
| qwen3-8b | Tier: 4B–16B | $0.20 | $0.10 | $0.20 |
| qwen3p6-plus | Tier: MoE 0–56B (22B active) | $0.50 | $0.25 | $0.50 |
| qwen3-embedding-8b | Embedding (Qwen3 8B) | $0.10 | — | $0 |
| flux-1-dev-fp8 | Image per-step | $0.0005/step | — | — |
| flux-1-schnell-fp8 | Image per-step | $0.00035/step | — | — |
| flux-kontext-pro | Image per-image | $0.04/image | — | — |
| flux-kontext-max | Image per-image | $0.08/image | — | — |

**Skipped:** `qwen3-reranker-8b` (reranker — excluded per skill rules)

**Pricing source:** https://fireworks.ai/pricing (fetched via Jina reader 2026-04-27)

---
*Generated by Pricing Agent on 2026-04-27*