### PR TITLE
chore: Update openrouter pricing and config

### DIFF
--- a/general/openrouter.json
+++ b/general/openrouter.json
@@ -5359,5 +5359,14 @@
         "maxValue": 65000
       }
     ]
+  },
+  "google/gemini-embedding-2-preview": {
+    "type": {
+      "primary": "embedding",
+      "supported": [
+        "image"
+      ]
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5332,10 +5332,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000008
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000035
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5548,10 +5548,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000009
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.000045
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -4108,10 +4108,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003827
+          "price": 0
         },
         "response_token": {
-          "price": 0.000172
+          "price": 0
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -4108,10 +4108,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00003827
         },
         "response_token": {
-          "price": 0
+          "price": 0.000172
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -3028,10 +3028,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000012
         },
         "response_token": {
-          "price": 0.000032
+          "price": 0.000038
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -256,10 +256,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": undefined
         },
         "response_token": {
-          "price": 0.0012
+          "price": undefined
         }
       }
     }
@@ -520,10 +520,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": undefined
         },
         "response_token": {
-          "price": 0.0002
+          "price": undefined
         }
       }
     }
@@ -568,10 +568,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": undefined
         },
         "response_token": {
-          "price": 0.001
+          "price": undefined
         }
       }
     }
@@ -628,10 +628,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": undefined
         },
         "response_token": {
-          "price": 0.00025
+          "price": undefined
         }
       }
     }
@@ -3940,10 +3940,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": undefined
         },
         "response_token": {
-          "price": 0
+          "price": undefined
         }
       }
     }
@@ -4840,10 +4840,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": undefined
         },
         "response_token": {
-          "price": 0.0003
+          "price": undefined
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -160,10 +160,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.0000259
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.000042
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5627,5 +5627,17 @@
         }
       }
     }
+  },
+  "google/gemini-embedding-2-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
   }
 }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -2788,10 +2788,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00008
+          "price": 0.000075
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -1420,10 +1420,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001495
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.0001495
+          "price": 0.00006
         }
       }
     }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5272,7 +5272,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.00001
         },
         "response_token": {
           "price": 0.000015


### PR DESCRIPTION
## 🔄 Models Update: openrouter

### 📊 Summary

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 1 |
| 🔄 Prices updated | 13 |
| 📋 General configs added | 1 |

### ➕ New Models
- `google/gemini-embedding-2-preview`

### 🔄 Updated Prices
- `google/gemma-4-26b-a4b-it`
- `nvidia/nemotron-3-super-120b-a12b`
- `qwen/qwen3.5-9b`
- `google/gemini-3.1-flash-image-preview`
- `deepseek/deepseek-v3.2`
- `google/gemini-3-pro-image-preview`
- `openai/gpt-5-image-mini`
- `openai/gpt-5-image`
- `google/gemini-2.5-flash-image`
- `qwen/qwen3-235b-a22b-thinking-2507`
- `qwen/qwen2.5-vl-72b-instruct`
- `meta-llama/llama-3.3-70b-instruct`
- `openrouter/auto`

### 📋 New General Configs
- `google/gemini-embedding-2-preview`


---
*Generated by Direct Converter on 2026-04-19*