### PR TITLE
chore(pricing): Update cohere pricing

### DIFF
--- a/general/cohere.json
+++ b/general/cohere.json
@@ -243,5 +243,21 @@
     "type": {
       "primary": "chat"
     }
+  },
+  "command-r-plus-04-2024": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "command-r-03-2024": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
   }
 }

--- a/general/cohere.json
+++ b/general/cohere.json
@@ -259,5 +259,11 @@
         "tools"
       ]
     }
+  },
+  "cohere-transcribe-03-2026": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
   }
 }

--- a/general/cohere.json
+++ b/general/cohere.json
@@ -223,5 +223,25 @@
     "type": {
       "primary": "embedding"
     }
+  },
+  "tiny-aya-earth": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-fire": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-global": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "tiny-aya-water": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/general/cohere.json
+++ b/general/cohere.json
@@ -194,5 +194,34 @@
     "type": {
       "primary": "chat"
     }
+  },
+  "command-r7b-arabic-02-2025": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "embed-english-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
   }
 }

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -256,7 +256,307 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.25
+          "price": 0.2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "command-a-03-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-vision-07-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-reasoning-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-translate-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-plus-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
+  "command-r-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "command-r7b-12-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r7b-arabic-02-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "c4ai-aya-expanse-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-expanse-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-vision-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-vision-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-fire": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-water": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-earth": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-global": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "embed-v4.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
         },
         "response_token": {
           "price": 0

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -396,31 +396,19 @@
       }
     }
   },
-  "embed-english-light-v3.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-light-v3.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -445,6 +433,18 @@
     }
   },
   "embed-multilingual-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -324,6 +324,18 @@
       }
     }
   },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -332,6 +344,18 @@
         },
         "response_token": {
           "price": 0.00006
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
         }
       }
     }
@@ -373,54 +397,6 @@
     }
   },
   "c4ai-aya-vision-32b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
-  "tiny-aya-earth": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
-  "tiny-aya-fire": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
-  "tiny-aya-global": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
-  "tiny-aya-water": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -256,7 +256,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.2
+          "price": 0.25
         },
         "response_token": {
           "price": 0
@@ -340,7 +340,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000037
+          "price": 0.00000375
         },
         "response_token": {
           "price": 0.000015
@@ -352,7 +352,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000037
+          "price": 0.00000375
         },
         "response_token": {
           "price": 0.000015
@@ -384,23 +384,59 @@
       }
     }
   },
+  "tiny-aya-earth": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-fire": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-global": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "tiny-aya-water": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
   "embed-v4.0": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
           "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-english-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -420,43 +456,7 @@
       }
     }
   },
-  "embed-english-light-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "embed-multilingual-light-v3.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -324,6 +324,18 @@
       }
     }
   },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -332,6 +344,18 @@
         },
         "response_token": {
           "price": 0.00006
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
         }
       }
     }
@@ -384,54 +408,6 @@
       }
     }
   },
-  "tiny-aya-earth": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "tiny-aya-fire": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "tiny-aya-global": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "tiny-aya-water": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "embed-v4.0": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -444,7 +420,7 @@
       }
     }
   },
-  "embed-english-v3.0-image": {
+  "embed-english-light-v3.0": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -456,7 +432,19 @@
       }
     }
   },
-  "embed-english-light-v3.0": {
+  "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -492,35 +480,11 @@
       }
     }
   },
-  "embed-multilingual-light-v3.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
           "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "cohere-transcribe-03-2026": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
         },
         "response_token": {
           "price": 0

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -324,18 +324,6 @@
       }
     }
   },
-  "command-r-plus-04-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0003
-        },
-        "response_token": {
-          "price": 0.0015
-        }
-      }
-    }
-  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -344,18 +332,6 @@
         },
         "response_token": {
           "price": 0.00006
-        }
-      }
-    }
-  },
-  "command-r-03-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
         }
       }
     }
@@ -380,6 +356,30 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
         }
       }
     }
@@ -432,54 +432,6 @@
       }
     }
   },
-  "tiny-aya-fire": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "tiny-aya-water": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "tiny-aya-earth": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "tiny-aya-global": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "embed-v4.0": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -520,7 +472,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000012
         },
         "response_token": {
           "price": 0
@@ -532,7 +484,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000012
         },
         "response_token": {
           "price": 0

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -324,6 +324,18 @@
       }
     }
   },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -332,6 +344,18 @@
         },
         "response_token": {
           "price": 0.00006
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
         }
       }
     }
@@ -408,6 +432,54 @@
       }
     }
   },
+  "tiny-aya-fire": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-water": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-earth": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-global": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
   "embed-v4.0": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -448,7 +520,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -456,7 +528,7 @@
       }
     }
   },
-  "embed-english-light-v3.0-image": {
+  "embed-multilingual-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -468,7 +540,7 @@
       }
     }
   },
-  "embed-multilingual-v3.0-image": {
+  "embed-english-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -324,18 +324,6 @@
       }
     }
   },
-  "command-r-plus-04-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0003
-        },
-        "response_token": {
-          "price": 0.0015
-        }
-      }
-    }
-  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -344,18 +332,6 @@
         },
         "response_token": {
           "price": 0.00006
-        }
-      }
-    }
-  },
-  "command-r-03-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
         }
       }
     }
@@ -380,6 +356,30 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
         }
       }
     }
@@ -516,23 +516,11 @@
       }
     }
   },
-  "embed-english-light-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "embed-english-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -544,7 +532,19 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -556,7 +556,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.00001
         },
         "response_token": {
           "price": 0

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -468,7 +468,19 @@
       }
     }
   },
-  "embed-multilingual-light-v3.0-image": {
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -492,19 +504,7 @@
       }
     }
   },
-  "embed-english-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-v3.0-image": {
+  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -276,7 +276,7 @@
       }
     }
   },
-  "command-r-plus-08-2024": {
+  "command-a-vision-07-2025": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -288,14 +288,38 @@
       }
     }
   },
-  "command-r-plus-04-2024": {
+  "command-a-reasoning-08-2025": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-translate-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-plus-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
         }
       }
     }
@@ -312,23 +336,23 @@
       }
     }
   },
-  "command-r-03-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "command-r7b-12-2024": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00000375
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r7b-arabic-02-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
         },
         "response_token": {
           "price": 0.000015
@@ -349,6 +373,30 @@
     }
   },
   "c4ai-aya-expanse-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-vision-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-vision-32b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -385,6 +433,54 @@
     }
   },
   "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -276,7 +276,7 @@
       }
     }
   },
-  "command-a-reasoning-08-2025": {
+  "command-a-vision-07-2025": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -288,7 +288,7 @@
       }
     }
   },
-  "command-a-vision-07-2025": {
+  "command-a-reasoning-08-2025": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -324,6 +324,18 @@
       }
     }
   },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -332,6 +344,18 @@
         },
         "response_token": {
           "price": 0.00006
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
         }
       }
     }
@@ -448,7 +472,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -460,7 +484,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.00001
         },
         "response_token": {
           "price": 0

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -280,10 +280,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         }
       }
     }
@@ -292,10 +292,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         }
       }
     }
@@ -304,10 +304,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         }
       }
     }
@@ -324,18 +324,6 @@
       }
     }
   },
-  "command-r-plus-04-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0003
-        },
-        "response_token": {
-          "price": 0.0015
-        }
-      }
-    }
-  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -348,23 +336,11 @@
       }
     }
   },
-  "command-r-03-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "command-r7b-12-2024": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000037
+          "price": 0.00000375
         },
         "response_token": {
           "price": 0.000015
@@ -376,10 +352,34 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000037
+          "price": 0.00000375
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
         }
       }
     }
@@ -412,10 +412,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0
         }
       }
     }
@@ -424,10 +424,58 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0
+        }
+      }
+    }
+  },
+  "tiny-aya-fire": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tiny-aya-water": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tiny-aya-earth": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tiny-aya-global": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -480,7 +528,7 @@
       }
     }
   },
-  "embed-multilingual-v3.0-image": {
+  "embed-english-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -492,7 +540,7 @@
       }
     }
   },
-  "embed-english-light-v3.0-image": {
+  "embed-multilingual-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -264,6 +264,18 @@
       }
     }
   },
+  "command-a": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
   "command-a-03-2025": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -324,6 +336,18 @@
       }
     }
   },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -332,6 +356,18 @@
         },
         "response_token": {
           "price": 0.00006
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
         }
       }
     }
@@ -433,54 +469,6 @@
     }
   },
   "embed-multilingual-light-v3.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-english-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-english-light-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -276,7 +276,7 @@
       }
     }
   },
-  "command-r-plus-08-2024": {
+  "command-a-reasoning-08-2025": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -288,14 +288,38 @@
       }
     }
   },
-  "command-r-plus-04-2024": {
+  "command-a-vision-07-2025": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.00025
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-translate-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-r-plus-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
         }
       }
     }
@@ -312,23 +336,23 @@
       }
     }
   },
-  "command-r-03-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "command-r7b-12-2024": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00000375
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r7b-arabic-02-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
         },
         "response_token": {
           "price": 0.000015
@@ -349,6 +373,30 @@
     }
   },
   "c4ai-aya-expanse-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-vision-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "c4ai-aya-vision-32b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -385,6 +433,54 @@
     }
   },
   "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -264,18 +264,6 @@
       }
     }
   },
-  "command-a": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00025
-        },
-        "response_token": {
-          "price": 0.001
-        }
-      }
-    }
-  },
   "command-a-03-2025": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -336,18 +324,6 @@
       }
     }
   },
-  "command-r-plus-04-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0003
-        },
-        "response_token": {
-          "price": 0.0015
-        }
-      }
-    }
-  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -356,18 +332,6 @@
         },
         "response_token": {
           "price": 0.00006
-        }
-      }
-    }
-  },
-  "command-r-03-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
         }
       }
     }
@@ -396,31 +360,7 @@
       }
     }
   },
-  "c4ai-aya-expanse-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "c4ai-aya-expanse-32b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
-  "c4ai-aya-vision-8b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -469,6 +409,54 @@
     }
   },
   "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -256,7 +256,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.25
+          "price": 0.2
         },
         "response_token": {
           "price": 0
@@ -360,30 +360,6 @@
       }
     }
   },
-  "command-r-plus-04-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0003
-        },
-        "response_token": {
-          "price": 0.0015
-        }
-      }
-    }
-  },
-  "command-r-03-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "c4ai-aya-expanse-32b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -408,6 +384,54 @@
       }
     }
   },
+  "tiny-aya-earth": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-fire": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-global": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-water": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
   "embed-v4.0": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -420,31 +444,19 @@
       }
     }
   },
-  "embed-english-light-v3.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-light-v3.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -480,11 +492,35 @@
       }
     }
   },
+  "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
           "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cohere-transcribe-03-2026": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
         },
         "response_token": {
           "price": 0

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -276,42 +276,6 @@
       }
     }
   },
-  "command-a-vision-07-2025": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "command-a-reasoning-08-2025": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "command-a-translate-08-2025": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "command-r-plus-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -320,42 +284,6 @@
         },
         "response_token": {
           "price": 0.001
-        }
-      }
-    }
-  },
-  "command-r-08-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "command-r7b-12-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00000375
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "command-r7b-arabic-02-2025": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00000375
-        },
-        "response_token": {
-          "price": 0.000015
         }
       }
     }
@@ -372,6 +300,18 @@
       }
     }
   },
+  "command-r-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
   "command-r-03-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -380,6 +320,18 @@
         },
         "response_token": {
           "price": 0.00015
+        }
+      }
+    }
+  },
+  "command-r7b-12-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00000375
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }
@@ -404,78 +356,6 @@
         },
         "response_token": {
           "price": 0.00015
-        }
-      }
-    }
-  },
-  "c4ai-aya-vision-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "c4ai-aya-vision-32b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "tiny-aya-fire": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "tiny-aya-water": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "tiny-aya-earth": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "tiny-aya-global": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -505,54 +385,6 @@
     }
   },
   "embed-multilingual-light-v3.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-english-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-english-light-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -324,18 +324,6 @@
       }
     }
   },
-  "command-r-plus-04-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0003
-        },
-        "response_token": {
-          "price": 0.0015
-        }
-      }
-    }
-  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -348,23 +336,11 @@
       }
     }
   },
-  "command-r-03-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "command-r7b-12-2024": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00000375
+          "price": 0.0000037
         },
         "response_token": {
           "price": 0.000015
@@ -376,10 +352,34 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00000375
+          "price": 0.0000037
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    }
+  },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
         }
       }
     }
@@ -433,6 +433,54 @@
     }
   },
   "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -468,23 +468,11 @@
       }
     }
   },
-  "embed-english-v3.0-image": {
+  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000012
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -504,7 +492,19 @@
       }
     }
   },
-  "embed-multilingual-light-v3.0-image": {
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -256,7 +256,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.25
+          "price": 0.2
         },
         "response_token": {
           "price": 0
@@ -288,42 +288,6 @@
       }
     }
   },
-  "command-r-08-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "command-r7b-12-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00000375
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "command-r7b-arabic-02-2025": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00000375
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "command-r-plus-04-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -336,6 +300,18 @@
       }
     }
   },
+  "command-r-08-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
   "command-r-03-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -344,6 +320,18 @@
         },
         "response_token": {
           "price": 0.00015
+        }
+      }
+    }
+  },
+  "command-r7b-12-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00000375
+        },
+        "response_token": {
+          "price": 0.000015
         }
       }
     }

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -324,6 +324,18 @@
       }
     }
   },
+  "command-r-plus-04-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -332,6 +344,18 @@
         },
         "response_token": {
           "price": 0.00006
+        }
+      }
+    }
+  },
+  "command-r-03-2024": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00015
         }
       }
     }
@@ -444,23 +468,11 @@
       }
     }
   },
-  "embed-english-v3.0-image": {
+  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000012
+          "price": 0.00001
         },
         "response_token": {
           "price": 0
@@ -480,7 +492,19 @@
       }
     }
   },
-  "embed-multilingual-light-v3.0-image": {
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -360,30 +360,6 @@
       }
     }
   },
-  "command-r-plus-04-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0003
-        },
-        "response_token": {
-          "price": 0.0015
-        }
-      }
-    }
-  },
-  "command-r-03-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
   "c4ai-aya-expanse-8b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -468,7 +444,19 @@
       }
     }
   },
-  "embed-multilingual-light-v3.0-image": {
+  "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-multilingual-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -492,19 +480,7 @@
       }
     }
   },
-  "embed-english-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-v3.0-image": {
+  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -256,7 +256,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.2
+          "price": 0.25
         },
         "response_token": {
           "price": 0
@@ -265,42 +265,6 @@
     }
   },
   "command-a-03-2025": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00025
-        },
-        "response_token": {
-          "price": 0.001
-        }
-      }
-    }
-  },
-  "command-a-vision-07-2025": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00025
-        },
-        "response_token": {
-          "price": 0.001
-        }
-      }
-    }
-  },
-  "command-a-reasoning-08-2025": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00025
-        },
-        "response_token": {
-          "price": 0.001
-        }
-      }
-    }
-  },
-  "command-a-translate-08-2025": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -340,7 +304,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000037
+          "price": 0.00000375
         },
         "response_token": {
           "price": 0.000015
@@ -352,7 +316,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000037
+          "price": 0.00000375
         },
         "response_token": {
           "price": 0.000015
@@ -408,78 +372,6 @@
       }
     }
   },
-  "c4ai-aya-vision-8b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
-  "c4ai-aya-vision-32b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
-        }
-      }
-    }
-  },
-  "tiny-aya-fire": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "tiny-aya-water": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "tiny-aya-earth": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
-  "tiny-aya-global": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000037
-        },
-        "response_token": {
-          "price": 0.000015
-        }
-      }
-    }
-  },
   "embed-v4.0": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -505,54 +397,6 @@
     }
   },
   "embed-multilingual-light-v3.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-english-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-english-light-v3.0-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -276,18 +276,6 @@
       }
     }
   },
-  "command-a-vision-07-2025": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00025
-        },
-        "response_token": {
-          "price": 0.001
-        }
-      }
-    }
-  },
   "command-a-reasoning-08-2025": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -301,6 +289,18 @@
     }
   },
   "command-a-translate-08-2025": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "command-a-vision-07-2025": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -432,7 +432,7 @@
       }
     }
   },
-  "embed-multilingual-v3.0-image": {
+  "embed-english-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -444,7 +444,7 @@
       }
     }
   },
-  "embed-english-light-v3.0-image": {
+  "embed-multilingual-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -324,18 +324,6 @@
       }
     }
   },
-  "command-r-plus-04-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0003
-        },
-        "response_token": {
-          "price": 0.0015
-        }
-      }
-    }
-  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -344,18 +332,6 @@
         },
         "response_token": {
           "price": 0.00006
-        }
-      }
-    }
-  },
-  "command-r-03-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
         }
       }
     }
@@ -472,7 +448,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000012
         },
         "response_token": {
           "price": 0
@@ -484,7 +460,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000012
         },
         "response_token": {
           "price": 0

--- a/pricing/cohere.json
+++ b/pricing/cohere.json
@@ -324,18 +324,6 @@
       }
     }
   },
-  "command-r-plus-04-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0003
-        },
-        "response_token": {
-          "price": 0.0015
-        }
-      }
-    }
-  },
   "command-r-08-2024": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -344,18 +332,6 @@
         },
         "response_token": {
           "price": 0.00006
-        }
-      }
-    }
-  },
-  "command-r-03-2024": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.00015
         }
       }
     }
@@ -408,6 +384,54 @@
       }
     }
   },
+  "tiny-aya-earth": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-fire": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-global": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
+  "tiny-aya-water": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000037
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
   "embed-v4.0": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -420,31 +444,19 @@
       }
     }
   },
-  "embed-english-light-v3.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "embed-multilingual-light-v3.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "embed-english-v3.0-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "embed-english-light-v3.0": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -480,11 +492,35 @@
       }
     }
   },
+  "embed-multilingual-light-v3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "embed-multilingual-light-v3.0-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
           "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cohere-transcribe-03-2026": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.2
         },
         "response_token": {
           "price": 0


### PR DESCRIPTION
## 🔄 Pricing Update: cohere

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 22 |
| 🔄 Models updated (merged) | 1 |

### ➕ New Models
- `command-a-03-2025`
- `command-a-reasoning-08-2025`
- `command-a-translate-08-2025`
- `command-a-vision-07-2025`
- `command-r-plus-08-2024`
- `command-r-08-2024`
- `command-r7b-12-2024`
- `command-r7b-arabic-02-2025`
- `c4ai-aya-expanse-32b`
- `c4ai-aya-vision-32b`
- `tiny-aya-earth`
- `tiny-aya-fire`
- `tiny-aya-global`
- `tiny-aya-water`
- `embed-v4.0`
- `embed-english-v3.0-image`
- `embed-english-light-v3.0`
- `embed-english-light-v3.0-image`
- `embed-multilingual-v3.0-image`
- `embed-multilingual-light-v3.0`
- ... and 2 more

### 🔄 Updated Models
- `rerank-v4.0-pro`


## Model-to-Pricing Mapping

### Generative / Chat Models ($2.50/$10.00 per 1M tokens — Command A family)
- `command-a-03-2025` → Command A
- `command-a-reasoning-08-2025` → Command A (reasoning variant)
- `command-a-translate-08-2025` → Command A (translate variant)
- `command-a-vision-07-2025` → Command A (vision variant)
- `command-r-plus-08-2024` → Command R+ 08-2024

### Generative / Chat Models ($0.15/$0.60 per 1M tokens — Command R)
- `command-r-08-2024` → Command R 08-2024

### Generative / Chat Models ($0.037/$0.15 per 1M tokens — Command R7B / Tiny Aya)
- `command-r7b-12-2024` → Command R7B 12-2024
- `command-r7b-arabic-02-2025` → Command R7B Arabic (same tier)
- `tiny-aya-earth`, `tiny-aya-fire`, `tiny-aya-global`, `tiny-aya-water` → Tiny Aya variants (same tier as R7B)

### Aya Expanse ($0.50/$1.50 per 1M tokens)
- `c4ai-aya-expanse-32b` → Aya Expanse 32B
- `c4ai-aya-vision-32b` → Aya Vision 32B (same tier)

### Embed Models
- `embed-v4.0` → $0.12/1M tokens (input only)
- `embed-english-v3.0`, `embed-english-v3.0-image`, `embed-english-light-v3.0`, `embed-english-light-v3.0-image` → $0.10/1M tokens
- `embed-multilingual-v3.0`, `embed-multilingual-v3.0-image`, `embed-multilingual-light-v3.0`, `embed-multilingual-light-v3.0-image` → $0.10/1M tokens

### Rerank Models ($2.00/1K searches = $0.002/search)
- `rerank-v3.5`, `rerank-v4.0-fast`, `rerank-v4.0-pro`, `rerank-english-v3.0`, `rerank-multilingual-v3.0`

### Transcription (per_request placeholder — no public pricing found)
- `cohere-transcribe-03-2026` → Used $0.002/request as placeholder; needs verification

## Notes
- Firecrawl credits were insufficient; reference pricing from skill doc used
- `command-a-reasoning-08-2025`, `command-a-translate-08-2025`, `command-a-vision-07-2025` are new models assumed to share Command A pricing — verify
- `rerank-v4.0-fast` and `rerank-v4.0-pro` are new models assumed to share rerank v3.5 pricing — verify
- `cohere-transcribe-03-2026` pricing is a placeholder — no public pricing found

---
*Generated by Pricing Agent on 2026-04-27*