### PR TITLE
chore(pricing): Update dashscope pricing

### DIFF
--- a/general/dashscope.json
+++ b/general/dashscope.json
@@ -1804,5 +1804,33 @@
       "primary": "image"
     },
     "disablePlayground": true
+  },
+  "qwen3.5-omni-plus-realtime-2026-03-15": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-omni-flash-realtime-2026-03-15": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-vl-ocr-2025-04-13": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen-vl-ocr-2024-10-28": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
   }
 }

--- a/general/dashscope.json
+++ b/general/dashscope.json
@@ -1737,5 +1737,23 @@
     "type": {
       "primary": "chat"
     }
+  },
+  "qwen-tts": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "wan2.1-i2v-turbo": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-i2v-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
   }
 }

--- a/general/dashscope.json
+++ b/general/dashscope.json
@@ -1755,5 +1755,54 @@
       "primary": "video"
     },
     "disablePlayground": true
+  },
+  "qwen-flash-latest": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-3b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-1.5b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-0.5b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-math-1.5b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-tts-vd-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-vc-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-mt-image": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wanx2.1-imageedit": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
   }
 }

--- a/general/dashscope.json
+++ b/general/dashscope.json
@@ -632,5 +632,1110 @@
   "qwen-mt-lite": {
     "params": [{ "key": "max_tokens", "maxValue": 8192 }],
     "type": { "primary": "chat" }
+  },
+  "qwen-plus-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen-plus-2025-12-01-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen-flash-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen-flash-2025-07-28-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-omni-plus-2026-03-15": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen3.5-omni-flash-2026-03-15": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen3-omni-flash-2025-09-15-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-vl-flash-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen3-vl-flash-2026-01-22-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen3-vl-flash-2025-10-15-us": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen-vl-ocr-2025-08-28": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen-doc-turbo": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen-deep-research": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-27b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-235b-a22b-thinking-2507": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-30b-a3b-thinking-2507": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-30b-a3b-instruct-2507": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-4b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-1.7b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen3-0.6b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-14b-instruct-1m": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-7b-instruct-1m": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qvq-72b-preview": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2-vl-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2-vl-2b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools",
+        "image"
+      ]
+    }
+  },
+  "qwen2.5-math-72b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-coder-32b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-coder-14b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "qwen2.5-coder-7b-instruct": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-v3.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-r1-0528": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v3": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "deepseek-r1-distill-qwen-7b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-distill-qwen-14b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-r1-distill-qwen-32b": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-2.0-pro-2026-03-03": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-2.0": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-2.0-2026-03-03": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-max": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-max-2025-12-30": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-plus": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-plus-2026-01-09": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-edit-max": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-edit-max-2026-01-16": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-edit-plus": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-edit-plus-2025-12-15": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-edit-plus-2025-10-30": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "qwen-image-edit": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "z-image-turbo": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-t2i": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.5-t2i-preview": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-t2i-plus": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-t2i-flash": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-t2i-plus": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-t2i-turbo": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-image": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.5-i2i-preview": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "aitryon-plus": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "aitryon-parsing-v1": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-t2v": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-t2v-us": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.5-t2v-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-t2v-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-t2v-turbo": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-t2v-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-i2v-flash": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-i2v": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-i2v-us": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.5-i2v-preview": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-i2v-flash": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-i2v-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-kf2v-flash": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-kf2v-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.6-r2v": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan.6-r2v-flash": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.1-vace-plus": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-s2v": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-s2v-detect": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-animate-move": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "wan2.2-animate-mix": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "animate-anyone-detect-gen2": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "animate-anyone-template-gen2": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "animate-anyone-gen2": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "emo-detect-v1": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "emo-v1": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "liveportrait-detect": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "liveportrait": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "emoji-detect-v1": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "emoji-v1": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "videoretalk": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "video-style-transform": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
+  "qwen3-tts-instruct-flash": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-instruct-flash-2026-01-26": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-flash": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-flash-2025-11-27": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-flash-2025-09-18": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime-2026-01-22": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-vd-realtime-2026-01-15": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-vd-realtime-2025-12-16": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-vc-realtime-2026-01-15": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-vc-realtime-2025-11-27": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-flash-realtime-2025-11-27": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-flash-realtime-2025-09-18": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "cosyvoice-v3-flash": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "cosyvoice-v3.5-plus": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "cosyvoice-v3.5-flash": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "cosyvoice-v2": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "qwen-tts-flash": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-latest": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-2025-05-22": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-2025-04-10": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-realtime-latest": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-tts-realtime-2025-07-15": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-voice-enrollment": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "qwen-voice-design": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "qwen3-asr-flash-filetrans": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-filetrans-2025-11-17": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-2025-09-08": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-us": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-2025-09-08-us": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-realtime-2026-02-10": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-asr-flash-realtime-2025-10-27": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-2025-11-07": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-2025-08-25": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-mtl": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-mtl-2025-08-25": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-realtime-2025-11-07": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "fun-asr-flash-8k-realtime": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "paraformer-v2": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "paraformer-8k-v2": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "paraformer-realtime-v2": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-livetranslate-flash": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "text-embedding-v4": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "text-embedding-v3": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "qwen3-vl-embedding": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "embedding"
+    }
+  },
+  "qwen3-rerank": {
+    "type": {
+      "primary": "embedding"
+    },
+    "disablePlayground": true
+  },
+  "gte-rerank-v2": {
+    "type": {
+      "primary": "embedding"
+    },
+    "disablePlayground": true
+  },
+  "qwen3-vl-rerank": {
+    "type": {
+      "primary": "embedding"
+    },
+    "disablePlayground": true
+  },
+  "tongyi-intent-detect-v3": {
+    "type": {
+      "primary": "chat"
+    },
+    "disablePlayground": true
+  },
+  "deepseek-v3.2-exp": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/general/dashscope.json
+++ b/general/dashscope.json
@@ -1832,5 +1832,130 @@
         "image"
       ]
     }
+  },
+  "qwen3-235b-a22b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-235b-a22b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-32b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-30b-a3b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-30b-a3b-thinking": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-14b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-8b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-4b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-1.7b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3-0.6b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-397b-a17b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-122b-a10b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-27b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen3.5-35b-a3b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-coder-3b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-coder-1.5b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qwen2.5-coder-0.5b-instruct": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "qven-voice-enrollment": {
+    "type": {
+      "primary": "audio"
+    },
+    "disablePlayground": true
+  },
+  "qwen3-tts-vd-realtime-2026-01-26": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen3-tts-vc-realtime-2026-01-22": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
+  },
+  "qwen-vl-max-2024-11-19": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen-vl-plus-2024-08-09": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    }
+  },
+  "qwen3-asr-flash-realtime-2025-09-08": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "audio"
+    }
   }
 }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -59,10 +59,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000259
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.0001434
+          "price": 0.00048
         }
       }
     }
@@ -110,10 +110,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00016
+          "price": 0.0000345
         },
         "response_token": {
-          "price": 0.00064
+          "price": 0.0001377
         },
         "cache_read_input_token": {
           "price": 0.000032
@@ -149,10 +149,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000029
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000115
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.000444
@@ -284,10 +284,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000014
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.0000058
+          "price": 0.00002
         },
         "reasoning_token": {
           "price": 0.00005
@@ -335,10 +335,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000259
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0001036
+          "price": 0.00032
         }
       }
     }
@@ -359,10 +359,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000115
+          "price": 0.000021
         },
         "response_token": {
-          "price": 0.0000459
+          "price": 0.000063
         }
       }
     }
@@ -458,10 +458,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000072
+          "price": 0.0000144
         },
         "response_token": {
-          "price": 0.0000287
+          "price": 0.0000574
         },
         "reasoning_token": {
           "price": 0.00042
@@ -473,10 +473,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000359
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.0001434
+          "price": 0.0001147
         },
         "reasoning_token": {
           "price": 0.00084
@@ -488,10 +488,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000115
+          "price": 0.000016
         },
         "response_token": {
-          "price": 0.0000459
+          "price": 0.000064
         },
         "reasoning_token": {
           "price": 0.00084
@@ -503,10 +503,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000029
+          "price": 0.0000072
         },
         "response_token": {
-          "price": 0.0000115
+          "price": 0.0000287
         },
         "reasoning_token": {
           "price": 0.00021
@@ -518,10 +518,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0.0035
         },
         "response_token": {
-          "price": 0.0000035
+          "price": 0.0035
         }
       }
     }
@@ -530,10 +530,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000045
+          "price": 0.0000216
         },
         "response_token": {
-          "price": 0.000225
+          "price": 0.0000861
         }
       }
     }
@@ -542,10 +542,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00015
+          "price": 0.0000861
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.0003441
         }
       }
     }
@@ -650,10 +650,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000144
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.0000574
         }
       }
     }
@@ -662,10 +662,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000144
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0001434
         }
       }
     }
@@ -755,10 +755,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000359
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0001147
+          "price": 0.00024
         }
       }
     }
@@ -839,10 +839,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000259
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0001036
+          "price": 0.000058
         }
       }
     }
@@ -959,10 +959,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000029
+          "price": 0.0000108
         },
         "response_token": {
-          "price": 0.0000115
+          "price": 0.0000431
         },
         "reasoning_token": {
           "price": 0.00084
@@ -1139,10 +1139,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000259
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.0001434
+          "price": 0.00048
         }
       }
     }
@@ -1163,10 +1163,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000143
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.0000574
+          "price": 0.0000717
         }
       }
     }
@@ -1331,10 +1331,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.0004
+          "price": 0.0002867
         }
       }
     }
@@ -1343,10 +1343,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00016
+          "price": 0.0001147
         }
       }
     }
@@ -1391,10 +1391,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.0000108
         },
         "response_token": {
-          "price": 0.00008
+          "price": 0.0000431
         }
       }
     }
@@ -1403,10 +1403,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000018
+          "price": 0.0000072
         },
         "response_token": {
-          "price": 0.00021
+          "price": 0.0000717
         }
       }
     }
@@ -1709,10 +1709,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000115
+          "price": 0.0000574
         },
         "response_token": {
-          "price": 0.0000459
+          "price": 0.0001721
         }
       }
     }
@@ -1757,10 +1757,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000029
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.0000115
+          "price": 0.0000861
         }
       }
     }
@@ -1880,87 +1880,15 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000259
+          "price": 0.0000574
         },
         "response_token": {
-          "price": 0.0001434
-        }
-      }
-    }
-  },
-  "qwq-plus-2025-09-01": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000359
-        },
-        "response_token": {
-          "price": 0.0001147
+          "price": 0.0002294
         }
       }
     }
   },
   "qwen-long": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000022
-        },
-        "response_token": {
-          "price": 0.0000072
-        }
-      }
-    }
-  },
-  "qwen3-235b-a22b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000359
-        },
-        "response_token": {
-          "price": 0.0001434
-        }
-      }
-    }
-  },
-  "qwen3-32b-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000115
-        },
-        "response_token": {
-          "price": 0.0000459
-        }
-      }
-    }
-  },
-  "qwen2.5-72b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000259
-        },
-        "response_token": {
-          "price": 0.0001036
-        }
-      }
-    }
-  },
-  "qwen2.5-32b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000115
-        },
-        "response_token": {
-          "price": 0.0000459
-        }
-      }
-    }
-  },
-  "qwen2.5-14b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -1972,110 +1900,62 @@
       }
     }
   },
+  "qwen3-235b-a22b-thinking-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.00023
+        }
+      }
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00056
+        }
+      }
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00007
+        },
+        "response_token": {
+          "price": 0.00028
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.00014
+        }
+      }
+    }
+  },
   "qwen2.5-7b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000029
+          "price": 0.0000175
         },
         "response_token": {
-          "price": 0.0000115
-        }
-      }
-    }
-  },
-  "qwen2.5-3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000022
-        },
-        "response_token": {
-          "price": 0.0000072
-        }
-      }
-    }
-  },
-  "qwen2.5-coder-32b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000115
-        },
-        "response_token": {
-          "price": 0.0000459
-        }
-      }
-    }
-  },
-  "qwen2.5-coder-7b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000029
-        },
-        "response_token": {
-          "price": 0.0000115
-        }
-      }
-    }
-  },
-  "qwen2.5-math-72b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000259
-        },
-        "response_token": {
-          "price": 0.0001036
-        }
-      }
-    }
-  },
-  "qwen2.5-math-7b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000029
-        },
-        "response_token": {
-          "price": 0.0000115
-        }
-      }
-    }
-  },
-  "deepseek-v3": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000259
-        },
-        "response_token": {
-          "price": 0.0001147
-        }
-      }
-    }
-  },
-  "deepseek-r1-distill-llama-70b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000115
-        },
-        "response_token": {
-          "price": 0.0000459
-        }
-      }
-    }
-  },
-  "deepseek-r1-distill-qwen-32b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000115
-        },
-        "response_token": {
-          "price": 0.0000459
+          "price": 0.00007
         }
       }
     }
@@ -2087,7 +1967,7 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0
+          "price": 0.000007
         }
       }
     }
@@ -2099,343 +1979,55 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "text-embedding-async-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
           "price": 0.000007
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
   },
-  "text-embedding-async-v1": {
+  "qwen3-rerank": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0
+          "price": 0.00001
         }
       }
     }
   },
-  "multimodal-embedding-v1": {
+  "qwen3-tts-flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000143
+          "price": 0.001
         },
         "response_token": {
-          "price": 0
+          "price": 0.001
         }
       }
     }
   },
-  "qwen-omni-mini": {
+  "qwen3-tts-instruct-flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000014
+          "price": 0.00115
         },
         "response_token": {
-          "price": 0.0000058
+          "price": 0.00115
         }
       }
     }
   },
-  "moonshot-v1-8k": {
+  "qwen3-asr-flash-realtime": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001434
+          "price": 0.009
         },
         "response_token": {
-          "price": 0.0004301
-        }
-      }
-    }
-  },
-  "moonshot-v1-32k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0002294
-        },
-        "response_token": {
-          "price": 0.0006882
-        }
-      }
-    }
-  },
-  "moonshot-v1-128k": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0004588
-        },
-        "response_token": {
-          "price": 0.0013764
-        }
-      }
-    }
-  },
-  "glm-4-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000861
-        },
-        "response_token": {
-          "price": 0.0000861
-        }
-      }
-    }
-  },
-  "glm-4-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000072
-        },
-        "response_token": {
-          "price": 0.0000072
-        }
-      }
-    }
-  },
-  "glm-4v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000861
-        },
-        "response_token": {
-          "price": 0.0000861
-        }
-      }
-    }
-  },
-  "minimax-text-01": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000287
-        },
-        "response_token": {
-          "price": 0.0001147
-        }
-      }
-    }
-  },
-  "wan2.1-t2v-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.1-i2v-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-tts": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "cosyvoice-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "paraformer-realtime-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-asr": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen2.5-omni-7b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000029
-        },
-        "response_token": {
-          "price": 0.0000115
-        }
-      }
-    }
-  },
-  "llama3.3-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000259
-        },
-        "response_token": {
-          "price": 0.0001036
-        }
-      }
-    }
-  },
-  "llama3.1-405b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0001147
-        },
-        "response_token": {
-          "price": 0.0003441
-        }
-      }
-    }
-  },
-  "llama3.1-70b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000259
-        },
-        "response_token": {
-          "price": 0.0001036
-        }
-      }
-    }
-  },
-  "llama3.1-8b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000072
-        },
-        "response_token": {
-          "price": 0.0000287
-        }
-      }
-    }
-  },
-  "wan2.6-t2i": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.8671
-        },
-        "response_token": {
-          "price": 2.8671
-        }
-      }
-    }
-  },
-  "wan2.6-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.8671
-        },
-        "response_token": {
-          "price": 2.8671
-        }
-      }
-    }
-  },
-  "wanx-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.8671
-        },
-        "response_token": {
-          "price": 2.8671
-        }
-      }
-    }
-  },
-  "wanx2.1-t2i-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.8671
-        },
-        "response_token": {
-          "price": 2.8671
-        }
-      }
-    }
-  },
-  "wanx2.1-t2i-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.4336
-        },
-        "response_token": {
-          "price": 1.4336
-        }
-      }
-    }
-  },
-  "z-imagery-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.8671
-        },
-        "response_token": {
-          "price": 2.8671
+          "price": 0.009
         }
       }
     }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -159,12 +159,6 @@
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000021
-        },
-        "response_image_token": {
-          "price": 0.000063
         }
       }
     }
@@ -183,12 +177,6 @@
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000084
-        },
-        "response_image_token": {
-          "price": 0.000252
         }
       }
     }
@@ -533,7 +521,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
+          "price": 0
         }
       }
     }
@@ -624,9 +612,6 @@
         },
         "response_audio_token": {
           "price": 0.0038
-        },
-        "request_image_token": {
-          "price": 0.00013
         }
       }
     }
@@ -699,12 +684,6 @@
         },
         "response_audio_token": {
           "price": 0.001511
-        },
-        "request_image_token": {
-          "price": 0.000078
-        },
-        "response_image_token": {
-          "price": 0.000306
         }
       }
     }
@@ -723,12 +702,6 @@
         },
         "response_audio_token": {
           "price": 0.001813
-        },
-        "request_image_token": {
-          "price": 0.000094
-        },
-        "response_image_token": {
-          "price": 0.000367
         }
       }
     }
@@ -1346,10 +1319,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.0000043
         },
         "response_token": {
-          "price": 0.000016
+          "price": 0.0000072
         }
       }
     }
@@ -1478,10 +1451,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00028
+          "price": 0.0002294
         },
         "response_token": {
-          "price": 0.00084
+          "price": 0.0006881
         }
       }
     }
@@ -1500,12 +1473,6 @@
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000021
-        },
-        "response_image_token": {
-          "price": 0.000063
         }
       }
     }
@@ -1524,12 +1491,6 @@
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000021
-        },
-        "response_image_token": {
-          "price": 0.000063
         }
       }
     }
@@ -1548,12 +1509,6 @@
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000021
-        },
-        "response_image_token": {
-          "price": 0.000063
         }
       }
     }
@@ -1572,12 +1527,6 @@
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000084
-        },
-        "response_image_token": {
-          "price": 0.000252
         }
       }
     }
@@ -1596,12 +1545,6 @@
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000084
-        },
-        "response_image_token": {
-          "price": 0.000252
         }
       }
     }
@@ -1620,12 +1563,6 @@
         },
         "response_audio_token": {
           "price": 0.001511
-        },
-        "request_image_token": {
-          "price": 0.000078
-        },
-        "response_image_token": {
-          "price": 0.000306
         }
       }
     }
@@ -1644,12 +1581,6 @@
         },
         "response_audio_token": {
           "price": 0.001511
-        },
-        "request_image_token": {
-          "price": 0.000078
-        },
-        "response_image_token": {
-          "price": 0.000306
         }
       }
     }
@@ -1668,12 +1599,6 @@
         },
         "response_audio_token": {
           "price": 0.001813
-        },
-        "request_image_token": {
-          "price": 0.000094
-        },
-        "response_image_token": {
-          "price": 0.000367
         }
       }
     }
@@ -2073,12 +1998,6 @@
         },
         "response_audio_token": {
           "price": 0.001813
-        },
-        "request_image_token": {
-          "price": 0.000094
-        },
-        "response_image_token": {
-          "price": 0.000367
         }
       }
     }
@@ -2119,18 +2038,6 @@
       }
     }
   },
-  "qwen-vl-ocr-2025-08-28": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000007
-        },
-        "response_token": {
-          "price": 0.000016
-        }
-      }
-    }
-  },
   "qwen-doc-turbo": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2151,6 +2058,18 @@
         },
         "response_token": {
           "price": 0.0023367
+        }
+      }
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000058
+        },
+        "response_token": {
+          "price": 0.0000144
         }
       }
     }
@@ -2359,18 +2278,6 @@
       }
     }
   },
-  "qvq-72b-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0001721
-        },
-        "response_token": {
-          "price": 0.0005161
-        }
-      }
-    }
-  },
   "qwen2.5-vl-72b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2419,30 +2326,6 @@
       }
     }
   },
-  "qwen2-vl-7b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000035
-        },
-        "response_token": {
-          "price": 0.000105
-        }
-      }
-    }
-  },
-  "qwen2-vl-2b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000021
-        },
-        "response_token": {
-          "price": 0.000063
-        }
-      }
-    }
-  },
   "qwen2.5-omni-7b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2457,12 +2340,6 @@
         },
         "response_audio_token": {
           "price": 0.001351
-        },
-        "request_image_token": {
-          "price": 0.000028
-        },
-        "response_image_token": {
-          "price": 0.000084
         }
       }
     }
@@ -2527,1027 +2404,79 @@
       }
     }
   },
-  "deepseek-v3.1": {
+  "text-embedding-v4": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000574
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0001721
+          "price": 0
         }
       }
     }
   },
-  "deepseek-r1-0528": {
+  "text-embedding-v3": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000574
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0002294
+          "price": 0
         }
       }
     }
   },
-  "deepseek-v3": {
+  "tongyi-embedding-vision-plus": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.000009
         },
         "response_token": {
-          "price": 0.0001147
+          "price": 0
         }
       }
     }
   },
-  "deepseek-r1-distill-qwen-7b": {
+  "tongyi-embedding-vision-flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000072
+          "price": 0.000003
         },
         "response_token": {
-          "price": 0.0000144
+          "price": 0
         }
       }
     }
   },
-  "deepseek-r1-distill-qwen-14b": {
+  "qwen3-rerank": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000144
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0000431
+          "price": 0
         }
       }
     }
   },
-  "deepseek-r1-distill-qwen-32b": {
+  "gte-rerank-v2": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0
         }
       }
     }
   },
-  "qwen-image-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-2.0-pro-2026-03-03": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-2.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3.5
-        },
-        "response_token": {
-          "price": 3.5
-        }
-      }
-    }
-  },
-  "qwen-image-2.0-2026-03-03": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3.5
-        },
-        "response_token": {
-          "price": 3.5
-        }
-      }
-    }
-  },
-  "qwen-image-max": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-max-2025-12-30": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "qwen-image-plus-2026-01-09": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "qwen-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3.5
-        },
-        "response_token": {
-          "price": 3.5
-        }
-      }
-    }
-  },
-  "qwen-image-edit-max": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-edit-max-2026-01-16": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-edit-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "qwen-image-edit-plus-2025-12-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "qwen-image-edit-plus-2025-10-30": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "qwen-image-edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 4.5
-        },
-        "response_token": {
-          "price": 4.5
-        }
-      }
-    }
-  },
-  "z-image-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.5
-        },
-        "response_token": {
-          "price": 1.5
-        }
-      }
-    }
-  },
-  "wan2.6-t2i": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "wan2.5-t2i-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "wan2.2-t2i-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 5
-        },
-        "response_token": {
-          "price": 5
-        }
-      }
-    }
-  },
-  "wan2.2-t2i-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.5
-        },
-        "response_token": {
-          "price": 2.5
-        }
-      }
-    }
-  },
-  "wan2.1-t2i-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 5
-        },
-        "response_token": {
-          "price": 5
-        }
-      }
-    }
-  },
-  "wan2.1-t2i-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.5
-        },
-        "response_token": {
-          "price": 2.5
-        }
-      }
-    }
-  },
-  "wan2.6-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "wan2.5-i2i-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "aitryon-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.1677
-        },
-        "response_token": {
-          "price": 7.1677
-        }
-      }
-    }
-  },
-  "aitryon-parsing-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0.0574
-        }
-      }
-    }
-  },
-  "wan2.6-t2v": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.6-t2v-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.5-t2v-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 5
-        },
-        "response_token": {
-          "price": 5
-        }
-      }
-    }
-  },
-  "wan2.2-t2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2
-        },
-        "response_token": {
-          "price": 2
-        }
-      }
-    }
-  },
-  "wan2.1-t2v-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3.6
-        },
-        "response_token": {
-          "price": 3.6
-        }
-      }
-    }
-  },
-  "wan2.1-t2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.6-i2v-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 5
-        },
-        "response_token": {
-          "price": 5
-        }
-      }
-    }
-  },
-  "wan2.6-i2v": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.6-i2v-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.5-i2v-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 5
-        },
-        "response_token": {
-          "price": 5
-        }
-      }
-    }
-  },
-  "wan2.2-i2v-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.5
-        },
-        "response_token": {
-          "price": 1.5
-        }
-      }
-    }
-  },
-  "wan2.2-i2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2
-        },
-        "response_token": {
-          "price": 2
-        }
-      }
-    }
-  },
-  "wan2.2-kf2v-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.5
-        },
-        "response_token": {
-          "price": 1.5
-        }
-      }
-    }
-  },
-  "wan2.1-kf2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.6-r2v": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan.6-r2v-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 5
-        },
-        "response_token": {
-          "price": 5
-        }
-      }
-    }
-  },
-  "wan2.1-vace-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.2-s2v": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.1677
-        },
-        "response_token": {
-          "price": 7.1677
-        }
-      }
-    }
-  },
-  "wan2.2-s2v-detect": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0.0574
-        }
-      }
-    }
-  },
-  "wan2.2-animate-move": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 12
-        },
-        "response_token": {
-          "price": 12
-        }
-      }
-    }
-  },
-  "wan2.2-animate-mix": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 18
-        },
-        "response_token": {
-          "price": 18
-        }
-      }
-    }
-  },
-  "animate-anyone-detect-gen2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0.0574
-        }
-      }
-    }
-  },
-  "animate-anyone-template-gen2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 1.1469
-        }
-      }
-    }
-  },
-  "animate-anyone-gen2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 1.1469
-        }
-      }
-    }
-  },
-  "emo-detect-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0.0574
-        }
-      }
-    }
-  },
-  "emo-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 1.1469
-        }
-      }
-    }
-  },
-  "liveportrait-detect": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0.0574
-        }
-      }
-    }
-  },
-  "liveportrait": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.2868
-        },
-        "response_token": {
-          "price": 0.2868
-        }
-      }
-    }
-  },
-  "emoji-detect-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0.0574
-        }
-      }
-    }
-  },
-  "emoji-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 1.1469
-        }
-      }
-    }
-  },
-  "videoretalk": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 1.1469
-        }
-      }
-    }
-  },
-  "video-style-transform": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.8671
-        },
-        "response_token": {
-          "price": 2.8671
-        }
-      }
-    }
-  },
-  "qwen3-tts-instruct-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00115
-        },
-        "response_token": {
-          "price": 0.00115
-        }
-      }
-    }
-  },
-  "qwen3-tts-instruct-flash-2026-01-26": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00115
-        },
-        "response_token": {
-          "price": 0.00115
-        }
-      }
-    }
-  },
-  "qwen3-tts-vd-2026-01-26": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00115
-        },
-        "response_token": {
-          "price": 0.00115
-        }
-      }
-    }
-  },
-  "qwen3-tts-vc-2026-01-22": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00115
-        },
-        "response_token": {
-          "price": 0.00115
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.001
-        },
-        "response_token": {
-          "price": 0.001
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-2025-11-27": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.001
-        },
-        "response_token": {
-          "price": 0.001
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-2025-09-18": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.001
-        },
-        "response_token": {
-          "price": 0.001
-        }
-      }
-    }
-  },
-  "qwen3-tts-instruct-flash-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00143
-        },
-        "response_token": {
-          "price": 0.00143
-        }
-      }
-    }
-  },
-  "qwen3-tts-instruct-flash-realtime-2026-01-22": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00143
-        },
-        "response_token": {
-          "price": 0.00143
-        }
-      }
-    }
-  },
-  "qwen3-tts-vd-realtime-2026-01-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00143353
-        },
-        "response_token": {
-          "price": 0.00143353
-        }
-      }
-    }
-  },
-  "qwen3-tts-vd-realtime-2025-12-16": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00143353
-        },
-        "response_token": {
-          "price": 0.00143353
-        }
-      }
-    }
-  },
-  "qwen3-tts-vc-realtime-2026-01-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0.0013
-        }
-      }
-    }
-  },
-  "qwen3-tts-vc-realtime-2025-11-27": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0.0013
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0.0013
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-realtime-2025-11-27": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0.0013
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-realtime-2025-09-18": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0.0013
-        }
-      }
-    }
-  },
-  "cosyvoice-v3-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00286706
-        },
-        "response_token": {
-          "price": 0.00286706
-        }
-      }
-    }
-  },
-  "cosyvoice-v3-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0014335
-        },
-        "response_token": {
-          "price": 0.0014335
-        }
-      }
-    }
-  },
-  "cosyvoice-v3.5-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0022
-        },
-        "response_token": {
-          "price": 0.0022
-        }
-      }
-    }
-  },
-  "cosyvoice-v3.5-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00116
-        },
-        "response_token": {
-          "price": 0.00116
-        }
-      }
-    }
-  },
-  "cosyvoice-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00286706
-        },
-        "response_token": {
-          "price": 0.00286706
-        }
-      }
-    }
-  },
-  "qwen-tts-flash": {
+  "qwen-tts": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -3631,270 +2560,6 @@
       }
     }
   },
-  "qwen-voice-enrollment": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 100
-        },
-        "response_token": {
-          "price": 100
-        }
-      }
-    }
-  },
-  "qwen-voice-design": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2000
-        },
-        "response_token": {
-          "price": 2000
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-filetrans": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-filetrans-2025-11-17": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-2025-09-08": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-2025-09-08-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0.009
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-realtime-2026-02-10": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0.009
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-realtime-2025-10-27": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0.009
-        }
-      }
-    }
-  },
-  "fun-asr": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "fun-asr-2025-11-07": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "fun-asr-2025-08-25": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "fun-asr-mtl": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "fun-asr-mtl-2025-08-25": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "fun-asr-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0.009
-        }
-      }
-    }
-  },
-  "fun-asr-realtime-2025-11-07": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0.009
-        }
-      }
-    }
-  },
-  "fun-asr-flash-8k-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0.009
-        }
-      }
-    }
-  },
-  "paraformer-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0012
-        },
-        "response_token": {
-          "price": 0.0012
-        }
-      }
-    }
-  },
-  "paraformer-8k-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0012
-        },
-        "response_token": {
-          "price": 0.0012
-        }
-      }
-    }
-  },
-  "paraformer-realtime-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "paraformer-realtime-8k-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
   "qwen3-livetranslate-flash-realtime-2025-09-22": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3909,9 +2574,6 @@
         },
         "response_audio_token": {
           "price": 0.0038
-        },
-        "request_image_token": {
-          "price": 0.00013
         }
       }
     }
@@ -3930,129 +2592,1158 @@
         },
         "response_audio_token": {
           "price": 0.0006308
-        },
-        "request_image_token": {
-          "price": 0.0000631
         }
       }
     }
   },
-  "text-embedding-v4": {
+  "qwen-image-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 7.5
         },
         "response_token": {
-          "price": 0.000007
+          "price": 0
         }
       }
     }
   },
-  "text-embedding-v3": {
+  "qwen-image-2.0-pro-2026-03-03": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 7.5
         },
         "response_token": {
-          "price": 0.000007
+          "price": 0
         }
       }
     }
   },
-  "tongyi-embedding-vision-plus": {
+  "qwen-image-2.0": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000009
+          "price": 3.5
         },
         "response_token": {
-          "price": 0.000009
+          "price": 0
         }
       }
     }
   },
-  "tongyi-embedding-vision-flash": {
+  "qwen-image-2.0-2026-03-03": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 3.5
         },
         "response_token": {
-          "price": 0.000009
+          "price": 0
         }
       }
     }
   },
-  "qwen3-vl-embedding": {
+  "qwen-image-max": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000258
+          "price": 7.5
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0
         }
       }
     }
   },
-  "qwen3-rerank": {
+  "qwen-image-max-2025-12-30": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 7.5
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0
         }
       }
     }
   },
-  "gte-rerank-v2": {
+  "qwen-image-plus": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000115
+          "price": 3
         },
         "response_token": {
-          "price": 0.0000115
+          "price": 0
         }
       }
     }
   },
-  "qwen3-vl-rerank": {
+  "qwen-image-plus-2026-01-09": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000258
+          "price": 3
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0
         }
       }
     }
   },
-  "tongyi-intent-detect-v3": {
+  "qwen-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000058
+          "price": 3.5
         },
         "response_token": {
-          "price": 0.0000144
+          "price": 0
         }
       }
     }
   },
-  "deepseek-v3.2-exp": {
+  "qwen-image-edit-max": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 7.5
         },
         "response_token": {
-          "price": 0.0000431
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max-2026-01-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus-2025-12-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus-2025-10-30": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "z-image-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-t2i": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-t2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-i2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "aitryon-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.1677
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-t2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.6
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-t2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-i2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-i2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.6
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-kf2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-kf2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-r2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan.6-r2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-vace-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-s2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.1677
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-animate-move": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 12
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.2-animate-mix": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 18
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "animate-anyone-template-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "animate-anyone-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "emo-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "liveportrait": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.2868
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "emoji-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "videoretalk": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "video-style-transform": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.8671
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans-2025-11-17": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime-2026-02-10": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime-2025-10-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-2025-08-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-mtl": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-mtl-2025-08-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-realtime-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-realtime-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-09-18": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-realtime-2026-01-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143353
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-realtime-2025-12-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143353
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime-2026-01-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime-2025-09-18": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0026
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3.5-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0022
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v3.5-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00116
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00286706
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-voice-enrollment": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-voice-design": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 20
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -59,10 +59,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00012
+          "price": 0.0000259
         },
         "response_token": {
-          "price": 0.00048
+          "price": 0.0001434
         }
       }
     }
@@ -83,10 +83,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000022
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0000216
         },
         "cache_read_input_token": {
           "price": 0.000001
@@ -125,10 +125,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000246
+          "price": 0.0000259
         },
         "response_token": {
-          "price": 0.000737
+          "price": 0.0000775
         }
       }
     }
@@ -149,10 +149,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.0000029
         },
         "response_token": {
-          "price": 0.000027
+          "price": 0.0000115
         },
         "request_audio_token": {
           "price": 0.000444
@@ -185,10 +185,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.0000287
         },
         "reasoning_token": {
           "price": 0.0004
@@ -284,10 +284,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000014
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.0000058
         },
         "reasoning_token": {
           "price": 0.00005
@@ -335,10 +335,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 0.0000259
         },
         "response_token": {
-          "price": 0.00032
+          "price": 0.0001036
         }
       }
     }
@@ -347,10 +347,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.0000043
         },
         "response_token": {
-          "price": 0.000016
+          "price": 0.0000072
         }
       }
     }
@@ -359,10 +359,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000021
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0.000063
+          "price": 0.0000459
         }
       }
     }
@@ -458,10 +458,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000035
+          "price": 0.0000072
         },
         "response_token": {
-          "price": 0.00014
+          "price": 0.0000287
         },
         "reasoning_token": {
           "price": 0.00042
@@ -473,10 +473,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.0000359
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.0001434
         },
         "reasoning_token": {
           "price": 0.00084
@@ -488,10 +488,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.0000459
         },
         "reasoning_token": {
           "price": 0.00084
@@ -503,10 +503,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000018
+          "price": 0.0000029
         },
         "response_token": {
-          "price": 0.00007
+          "price": 0.0000115
         },
         "reasoning_token": {
           "price": 0.00021
@@ -554,10 +554,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.0000144
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0000574
         }
       }
     }
@@ -578,10 +578,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000574
         },
         "response_token": {
-          "price": 0.0005
+          "price": 0.0002294
         }
       }
     }
@@ -620,10 +620,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00012
+          "price": 0.0000359
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0001434
         },
         "cache_read_input_token": {
           "price": 0.000024
@@ -635,10 +635,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00012
+          "price": 0.0000861
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0003441
         },
         "cache_read_input_token": {
           "price": 0.000024
@@ -721,7 +721,6 @@
       }
     }
   },
-
   "qwen3-vl-30b-a3b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -741,10 +740,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.0000143
         },
         "response_token": {
-          "price": 0.00016
+          "price": 0.0001434
         },
         "reasoning_token": {
           "price": 0.00048
@@ -756,10 +755,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 0.0000359
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0001147
         }
       }
     }
@@ -768,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0000688
         }
       }
     }
@@ -840,10 +839,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.0000259
         },
         "response_token": {
-          "price": 0.000058
+          "price": 0.0001036
         }
       }
     }
@@ -960,10 +959,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.0000029
         },
         "response_token": {
-          "price": 0.00028
+          "price": 0.0000115
         },
         "reasoning_token": {
           "price": 0.00084
@@ -975,10 +974,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.0000029
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0000287
         }
       }
     }
@@ -1050,10 +1049,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000022
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0000215
         }
       }
     }
@@ -1140,10 +1139,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00012
+          "price": 0.0000259
         },
         "response_token": {
-          "price": 0.00048
+          "price": 0.0001434
         }
       }
     }
@@ -1164,10 +1163,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.0000143
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.0000574
         }
       }
     }
@@ -1710,10 +1709,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000574
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0.0001721
+          "price": 0.0000459
         }
       }
     }
@@ -1758,10 +1757,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.0000029
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.0000115
         }
       }
     }
@@ -1857,10 +1856,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000016
+          "price": 0.0000101
         },
         "response_token": {
-          "price": 0.000049
+          "price": 0.000028
         }
       }
     }
@@ -1869,10 +1868,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.0000086
         },
         "response_token": {
-          "price": 0.000036
+          "price": 0.0000229
         }
       }
     }
@@ -1881,10 +1880,562 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000574
+          "price": 0.0000259
         },
         "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwq-plus-2025-09-01": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000359
+        },
+        "response_token": {
+          "price": 0.0001147
+        }
+      }
+    }
+  },
+  "qwen-long": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000022
+        },
+        "response_token": {
+          "price": 0.0000072
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000359
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen3-32b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000459
+        }
+      }
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000259
+        },
+        "response_token": {
+          "price": 0.0001036
+        }
+      }
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000459
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000029
+        },
+        "response_token": {
+          "price": 0.0000115
+        }
+      }
+    }
+  },
+  "qwen2.5-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000022
+        },
+        "response_token": {
+          "price": 0.0000072
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000459
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000029
+        },
+        "response_token": {
+          "price": 0.0000115
+        }
+      }
+    }
+  },
+  "qwen2.5-math-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000259
+        },
+        "response_token": {
+          "price": 0.0001036
+        }
+      }
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000029
+        },
+        "response_token": {
+          "price": 0.0000115
+        }
+      }
+    }
+  },
+  "deepseek-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000259
+        },
+        "response_token": {
+          "price": 0.0001147
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-llama-70b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000459
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000459
+        }
+      }
+    }
+  },
+  "text-embedding-v4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-async-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-async-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "multimodal-embedding-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000143
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-omni-mini": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000014
+        },
+        "response_token": {
+          "price": 0.0000058
+        }
+      }
+    }
+  },
+  "moonshot-v1-8k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001434
+        },
+        "response_token": {
+          "price": 0.0004301
+        }
+      }
+    }
+  },
+  "moonshot-v1-32k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.0002294
+        },
+        "response_token": {
+          "price": 0.0006882
+        }
+      }
+    }
+  },
+  "moonshot-v1-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0004588
+        },
+        "response_token": {
+          "price": 0.0013764
+        }
+      }
+    }
+  },
+  "glm-4-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000861
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
+  "glm-4-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000072
+        }
+      }
+    }
+  },
+  "glm-4v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000861
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
+  "minimax-text-01": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0001147
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.1-i2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-tts": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "cosyvoice-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "paraformer-realtime-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-asr": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000029
+        },
+        "response_token": {
+          "price": 0.0000115
+        }
+      }
+    }
+  },
+  "llama3.3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000259
+        },
+        "response_token": {
+          "price": 0.0001036
+        }
+      }
+    }
+  },
+  "llama3.1-405b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001147
+        },
+        "response_token": {
+          "price": 0.0003441
+        }
+      }
+    }
+  },
+  "llama3.1-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000259
+        },
+        "response_token": {
+          "price": 0.0001036
+        }
+      }
+    }
+  },
+  "llama3.1-8b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "wan2.6-t2i": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.8671
+        },
+        "response_token": {
+          "price": 2.8671
+        }
+      }
+    }
+  },
+  "wan2.6-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.8671
+        },
+        "response_token": {
+          "price": 2.8671
+        }
+      }
+    }
+  },
+  "wanx-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.8671
+        },
+        "response_token": {
+          "price": 2.8671
+        }
+      }
+    }
+  },
+  "wanx2.1-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.8671
+        },
+        "response_token": {
+          "price": 2.8671
+        }
+      }
+    }
+  },
+  "wanx2.1-t2i-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.4336
+        },
+        "response_token": {
+          "price": 1.4336
+        }
+      }
+    }
+  },
+  "z-imagery-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.8671
+        },
+        "response_token": {
+          "price": 2.8671
         }
       }
     }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -83,10 +83,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000022
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.0000216
+          "price": 0.00004
         },
         "cache_read_input_token": {
           "price": 0.000001
@@ -110,10 +110,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000345
+          "price": 0.00016
         },
         "response_token": {
-          "price": 0.0001377
+          "price": 0.00064
         },
         "cache_read_input_token": {
           "price": 0.000032
@@ -125,10 +125,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000259
+          "price": 0.000246
         },
         "response_token": {
-          "price": 0.0000775
+          "price": 0.000737
         }
       }
     }
@@ -159,6 +159,12 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
+        },
+        "response_image_token": {
+          "price": 0.000063
         }
       }
     }
@@ -177,6 +183,12 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000084
+        },
+        "response_image_token": {
+          "price": 0.000252
         }
       }
     }
@@ -185,10 +197,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000115
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0000287
+          "price": 0.00012
         },
         "reasoning_token": {
           "price": 0.0004
@@ -347,10 +359,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000043
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000072
+          "price": 0.000016
         }
       }
     }
@@ -458,10 +470,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000144
+          "price": 0.000035
         },
         "response_token": {
-          "price": 0.0000574
+          "price": 0.00014
         },
         "reasoning_token": {
           "price": 0.00042
@@ -473,10 +485,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.0001147
+          "price": 0.00028
         },
         "reasoning_token": {
           "price": 0.00084
@@ -503,10 +515,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000072
+          "price": 0.000018
         },
         "response_token": {
-          "price": 0.0000287
+          "price": 0.00007
         },
         "reasoning_token": {
           "price": 0.00021
@@ -530,10 +542,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000216
+          "price": 0.000045
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.000225
         }
       }
     }
@@ -542,10 +554,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000861
+          "price": 0.00015
         },
         "response_token": {
-          "price": 0.0003441
+          "price": 0.00075
         }
       }
     }
@@ -554,10 +566,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000144
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.0000574
+          "price": 0.00015
         }
       }
     }
@@ -578,10 +590,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000574
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0002294
+          "price": 0.0005
         }
       }
     }
@@ -612,6 +624,9 @@
         },
         "response_audio_token": {
           "price": 0.0038
+        },
+        "request_image_token": {
+          "price": 0.00013
         }
       }
     }
@@ -620,10 +635,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000359
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.0001434
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.000024
@@ -635,10 +650,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000861
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.0003441
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.000024
@@ -650,10 +665,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000144
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0000574
+          "price": 0.00012
         }
       }
     }
@@ -662,10 +677,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000144
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0001434
+          "price": 0.00012
         }
       }
     }
@@ -684,6 +699,12 @@
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
+        },
+        "response_image_token": {
+          "price": 0.000306
         }
       }
     }
@@ -702,6 +723,12 @@
         },
         "response_audio_token": {
           "price": 0.001813
+        },
+        "request_image_token": {
+          "price": 0.000094
+        },
+        "response_image_token": {
+          "price": 0.000367
         }
       }
     }
@@ -740,10 +767,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000143
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.0001434
+          "price": 0.00016
         },
         "reasoning_token": {
           "price": 0.00048
@@ -767,10 +794,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000115
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0000688
+          "price": 0.00024
         }
       }
     }
@@ -839,10 +866,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.000058
+          "price": 0.0000861
         }
       }
     }
@@ -851,10 +878,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.0000861
         }
       }
     }
@@ -959,10 +986,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000108
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.0000431
+          "price": 0.00008
         },
         "reasoning_token": {
           "price": 0.00084
@@ -974,10 +1001,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000029
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.0000287
+          "price": 0.00004
         }
       }
     }
@@ -1022,10 +1049,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000861
+          "price": 0.00012
         },
         "response_token": {
-          "price": 0.0003441
+          "price": 0.0006
         }
       }
     }
@@ -1049,10 +1076,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000022
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.0000215
+          "price": 0.00004
         }
       }
     }
@@ -1319,10 +1346,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000043
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000072
+          "price": 0.000016
         }
       }
     }
@@ -1331,10 +1358,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0002867
+          "price": 0.0004
         }
       }
     }
@@ -1343,10 +1370,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0001147
+          "price": 0.00016
         }
       }
     }
@@ -1391,10 +1418,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000108
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.0000431
+          "price": 0.00008
         }
       }
     }
@@ -1403,10 +1430,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000072
+          "price": 0.000018
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.00021
         }
       }
     }
@@ -1451,10 +1478,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002294
+          "price": 0.00028
         },
         "response_token": {
-          "price": 0.0006881
+          "price": 0.00084
         }
       }
     }
@@ -1473,6 +1500,12 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
+        },
+        "response_image_token": {
+          "price": 0.000063
         }
       }
     }
@@ -1491,6 +1524,12 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
+        },
+        "response_image_token": {
+          "price": 0.000063
         }
       }
     }
@@ -1499,16 +1538,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000058
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000023
+          "price": 0.000027
         },
         "request_audio_token": {
-          "price": 0.0003584
+          "price": 0.000444
         },
         "response_audio_token": {
-          "price": 0.0007168
+          "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
+        },
+        "response_image_token": {
+          "price": 0.000063
         }
       }
     }
@@ -1527,6 +1572,12 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000084
+        },
+        "response_image_token": {
+          "price": 0.000252
         }
       }
     }
@@ -1545,6 +1596,12 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000084
+        },
+        "response_image_token": {
+          "price": 0.000252
         }
       }
     }
@@ -1563,6 +1620,12 @@
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
+        },
+        "response_image_token": {
+          "price": 0.000306
         }
       }
     }
@@ -1581,6 +1644,12 @@
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
+        },
+        "response_image_token": {
+          "price": 0.000306
         }
       }
     }
@@ -1599,6 +1668,12 @@
         },
         "response_audio_token": {
           "price": 0.001813
+        },
+        "request_image_token": {
+          "price": 0.000094
+        },
+        "response_image_token": {
+          "price": 0.000367
         }
       }
     }
@@ -1856,10 +1931,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000101
+          "price": 0.000016
         },
         "response_token": {
-          "price": 0.000028
+          "price": 0.000049
         }
       }
     }
@@ -1868,10 +1943,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000086
+          "price": 0.000012
         },
         "response_token": {
-          "price": 0.0000229
+          "price": 0.000036
         }
       }
     }
@@ -1888,14 +1963,242 @@
       }
     }
   },
-  "qwen-long": {
+  "qwen-plus-us": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000072
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0000287
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen-plus-2025-12-01-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "qwen-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-flash-2025-07-28-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-omni-flash-2025-09-15-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000052
+        },
+        "response_token": {
+          "price": 0.000199
+        },
+        "request_audio_token": {
+          "price": 0.000457
+        },
+        "response_audio_token": {
+          "price": 0.001813
+        },
+        "request_image_token": {
+          "price": 0.000094
+        },
+        "response_image_token": {
+          "price": 0.000367
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2026-01-22-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2025-10-15-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-vl-ocr-2025-08-28": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000016
+        }
+      }
+    }
+  },
+  "qwen-doc-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000087
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "qwen-deep-research": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0007742
+        },
+        "response_token": {
+          "price": 0.0023367
+        }
+      }
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00036
+        }
+      }
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00032
+        }
+      }
+    }
+  },
+  "qwen3.5-27b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0002
         }
       }
     }
@@ -1908,6 +2211,102 @@
         },
         "response_token": {
           "price": 0.00023
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.000092
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-thinking-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00008
+        }
+      }
+    }
+  },
+  "qwen3-4b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-1.7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-0.6b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000805
+        },
+        "response_token": {
+          "price": 0.000322
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000368
+        },
+        "response_token": {
+          "price": 0.000147
         }
       }
     }
@@ -1960,6 +2359,1584 @@
       }
     }
   },
+  "qvq-72b-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001721
+        },
+        "response_token": {
+          "price": 0.0005161
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00028
+        },
+        "response_token": {
+          "price": 0.00084
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00042
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.000105
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000021
+        },
+        "response_token": {
+          "price": 0.000063
+        }
+      }
+    }
+  },
+  "qwen2-vl-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.000105
+        }
+      }
+    }
+  },
+  "qwen2-vl-2b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000021
+        },
+        "response_token": {
+          "price": 0.000063
+        }
+      }
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00004
+        },
+        "request_audio_token": {
+          "price": 0.000676
+        },
+        "response_audio_token": {
+          "price": 0.001351
+        },
+        "request_image_token": {
+          "price": 0.000028
+        },
+        "response_image_token": {
+          "price": 0.000084
+        }
+      }
+    }
+  },
+  "qwen2.5-math-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "deepseek-v3.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "deepseek-r1-0528": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0002294
+        }
+      }
+    }
+  },
+  "deepseek-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0001147
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-14b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000431
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-2.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-max-2025-12-30": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-plus-2026-01-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max-2026-01-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus-2025-12-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus-2025-10-30": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4.5
+        },
+        "response_token": {
+          "price": 4.5
+        }
+      }
+    }
+  },
+  "z-image-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 1.5
+        }
+      }
+    }
+  },
+  "wan2.6-t2i": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.5-t2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.6-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.5-i2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "aitryon-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.1677
+        },
+        "response_token": {
+          "price": 7.1677
+        }
+      }
+    }
+  },
+  "aitryon-parsing-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "wan2.6-t2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-t2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.6
+        },
+        "response_token": {
+          "price": 3.6
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.6-i2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 1.5
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "wan2.2-kf2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 1.5
+        }
+      }
+    }
+  },
+  "wan2.1-kf2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-r2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan.6-r2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.1-vace-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.2-s2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.1677
+        },
+        "response_token": {
+          "price": 7.1677
+        }
+      }
+    }
+  },
+  "wan2.2-s2v-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "wan2.2-animate-move": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 12
+        },
+        "response_token": {
+          "price": 12
+        }
+      }
+    }
+  },
+  "wan2.2-animate-mix": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 18
+        },
+        "response_token": {
+          "price": 18
+        }
+      }
+    }
+  },
+  "animate-anyone-detect-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "animate-anyone-template-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "animate-anyone-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "emo-detect-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "emo-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "liveportrait-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "liveportrait": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.2868
+        },
+        "response_token": {
+          "price": 0.2868
+        }
+      }
+    }
+  },
+  "emoji-detect-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "emoji-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "videoretalk": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "video-style-transform": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.8671
+        },
+        "response_token": {
+          "price": 2.8671
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-09-18": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143
+        },
+        "response_token": {
+          "price": 0.00143
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143
+        },
+        "response_token": {
+          "price": 0.00143
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-realtime-2026-01-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143353
+        },
+        "response_token": {
+          "price": 0.00143353
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-realtime-2025-12-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143353
+        },
+        "response_token": {
+          "price": 0.00143353
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime-2026-01-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime-2025-09-18": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00286706
+        },
+        "response_token": {
+          "price": 0.00286706
+        }
+      }
+    }
+  },
+  "cosyvoice-v3-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0014335
+        },
+        "response_token": {
+          "price": 0.0014335
+        }
+      }
+    }
+  },
+  "cosyvoice-v3.5-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0022
+        },
+        "response_token": {
+          "price": 0.0022
+        }
+      }
+    }
+  },
+  "cosyvoice-v3.5-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00116
+        },
+        "response_token": {
+          "price": 0.00116
+        }
+      }
+    }
+  },
+  "cosyvoice-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00286706
+        },
+        "response_token": {
+          "price": 0.00286706
+        }
+      }
+    }
+  },
+  "qwen-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-2025-05-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-2025-04-10": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000345
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000345
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime-2025-07-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000345
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen-voice-enrollment": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 100
+        },
+        "response_token": {
+          "price": 100
+        }
+      }
+    }
+  },
+  "qwen-voice-design": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2000
+        },
+        "response_token": {
+          "price": 2000
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans-2025-11-17": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime-2026-02-10": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime-2025-10-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "fun-asr": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-2025-08-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-mtl": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-mtl-2025-08-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "fun-asr-realtime-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "fun-asr-flash-8k-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "paraformer-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "paraformer-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "paraformer-realtime-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "request_audio_token": {
+          "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.0038
+        },
+        "request_image_token": {
+          "price": 0.00013
+        }
+      }
+    }
+  },
+  "qwen3-livetranslate-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001577
+        },
+        "response_token": {
+          "price": 0.0001577
+        },
+        "request_audio_token": {
+          "price": 0.0001577
+        },
+        "response_audio_token": {
+          "price": 0.0006308
+        },
+        "request_image_token": {
+          "price": 0.0000631
+        }
+      }
+    }
+  },
   "text-embedding-v4": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -1984,6 +3961,42 @@
       }
     }
   },
+  "tongyi-embedding-vision-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000009
+        },
+        "response_token": {
+          "price": 0.000009
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000009
+        }
+      }
+    }
+  },
+  "qwen3-vl-embedding": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000258
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "qwen3-rerank": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -1996,38 +4009,50 @@
       }
     }
   },
-  "qwen3-tts-flash": {
+  "gte-rerank-v2": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.0000115
         }
       }
     }
   },
-  "qwen3-tts-instruct-flash": {
+  "qwen3-vl-rerank": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00115
+          "price": 0.0000258
         },
         "response_token": {
-          "price": 0.00115
+          "price": 0.00001
         }
       }
     }
   },
-  "qwen3-asr-flash-realtime": {
+  "tongyi-intent-detect-v3": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.009
+          "price": 0.0000058
         },
         "response_token": {
-          "price": 0.009
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "deepseek-v3.2-exp": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000431
         }
       }
     }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -110,10 +110,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00024
+          "price": 0.00016
         },
         "response_token": {
-          "price": 0.00096
+          "price": 0.00064
         },
         "cache_read_input_token": {
           "price": 0.000032
@@ -815,10 +815,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00024
+          "price": 0.00016
         },
         "response_token": {
-          "price": 0.00096
+          "price": 0.00064
         }
       }
     }
@@ -827,10 +827,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00024
+          "price": 0.00016
         },
         "response_token": {
-          "price": 0.00096
+          "price": 0.00064
         }
       }
     }
@@ -863,10 +863,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 0.000023
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0000574
         }
       }
     }
@@ -875,10 +875,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 0.000023
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0000574
         }
       }
     }
@@ -1319,10 +1319,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.0000043
         },
         "response_token": {
-          "price": 0.000016
+          "price": 0.0000072
         }
       }
     }
@@ -1637,10 +1637,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00035
+          "price": 0.0000502
         },
         "response_token": {
-          "price": 0.0007
+          "price": 0.0001004
         }
       }
     }
@@ -1649,10 +1649,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00035
+          "price": 0.0000502
         },
         "response_token": {
-          "price": 0.0007
+          "price": 0.0001004
         }
       }
     }
@@ -1661,10 +1661,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00035
+          "price": 0.0000502
         },
         "response_token": {
-          "price": 0.0007
+          "price": 0.0001004
         }
       }
     }
@@ -1673,10 +1673,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0000861
         }
       }
     }
@@ -1685,10 +1685,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0000861
         }
       }
     }
@@ -1697,10 +1697,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0000861
         }
       }
     }
@@ -1841,10 +1841,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000057
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.000171
+          "price": 0.0000431
         },
         "cache_read_input_token": {
           "price": 0.0000114
@@ -1912,18 +1912,6 @@
       }
     }
   },
-  "qwen-flash-latest": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.00004
-        }
-      }
-    }
-  },
   "qwen-flash-us": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -1941,390 +1929,6 @@
       "pay_as_you_go": {
         "request_token": {
           "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.00004
-        }
-      }
-    }
-  },
-  "qvq-72b-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0001721
-        },
-        "response_token": {
-          "price": 0.0005161
-        }
-      }
-    }
-  },
-  "qwen-deep-research": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0007742
-        },
-        "response_token": {
-          "price": 0.0023367
-        }
-      }
-    }
-  },
-  "qwen-doc-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000087
-        },
-        "response_token": {
-          "price": 0.0000144
-        }
-      }
-    }
-  },
-  "qwen2.5-math-72b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000574
-        },
-        "response_token": {
-          "price": 0.0001721
-        }
-      }
-    }
-  },
-  "qwen2.5-math-7b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000144
-        },
-        "response_token": {
-          "price": 0.0000287
-        }
-      }
-    }
-  },
-  "qwen3-4b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000011
-        },
-        "response_token": {
-          "price": 0.000042
-        }
-      }
-    }
-  },
-  "qwen3-1.7b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000011
-        },
-        "response_token": {
-          "price": 0.000042
-        }
-      }
-    }
-  },
-  "qwen3-0.6b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000011
-        },
-        "response_token": {
-          "price": 0.000042
-        }
-      }
-    }
-  },
-  "qwen3-235b-a22b-thinking-2507": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000023
-        },
-        "response_token": {
-          "price": 0.00023
-        }
-      }
-    }
-  },
-  "qwen3-235b-a22b-instruct-2507": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000023
-        },
-        "response_token": {
-          "price": 0.000092
-        }
-      }
-    }
-  },
-  "qwen3-30b-a3b-thinking-2507": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00024
-        }
-      }
-    }
-  },
-  "qwen3-30b-a3b-instruct-2507": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00008
-        }
-      }
-    }
-  },
-  "qwen3.5-397b-a17b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00036
-        }
-      }
-    }
-  },
-  "qwen3.5-122b-a10b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00004
-        },
-        "response_token": {
-          "price": 0.00032
-        }
-      }
-    }
-  },
-  "qwen3.5-27b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00024
-        }
-      }
-    }
-  },
-  "qwen3.5-35b-a3b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.0002
-        }
-      }
-    }
-  },
-  "qwen2.5-72b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00056
-        }
-      }
-    }
-  },
-  "qwen2.5-32b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00007
-        },
-        "response_token": {
-          "price": 0.00028
-        }
-      }
-    }
-  },
-  "qwen2.5-14b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000035
-        },
-        "response_token": {
-          "price": 0.00014
-        }
-      }
-    }
-  },
-  "qwen2.5-7b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000175
-        },
-        "response_token": {
-          "price": 0.00007
-        }
-      }
-    }
-  },
-  "qwen2.5-14b-instruct-1m": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000805
-        },
-        "response_token": {
-          "price": 0.000322
-        }
-      }
-    }
-  },
-  "qwen2.5-7b-instruct-1m": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000368
-        },
-        "response_token": {
-          "price": 0.000147
-        }
-      }
-    }
-  },
-  "qwen2.5-3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000044
-        },
-        "response_token": {
-          "price": 0.000013
-        }
-      }
-    }
-  },
-  "qwen2.5-vl-72b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00028
-        },
-        "response_token": {
-          "price": 0.00084
-        }
-      }
-    }
-  },
-  "qwen2.5-vl-32b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00014
-        },
-        "response_token": {
-          "price": 0.00042
-        }
-      }
-    }
-  },
-  "qwen2.5-vl-7b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000035
-        },
-        "response_token": {
-          "price": 0.000105
-        }
-      }
-    }
-  },
-  "qwen2.5-vl-3b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000021
-        },
-        "response_token": {
-          "price": 0.000063
-        }
-      }
-    }
-  },
-  "qwen3-vl-flash-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.00004
-        }
-      }
-    }
-  },
-  "qwen3-vl-flash-2026-01-22-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.00004
-        }
-      }
-    }
-  },
-  "qwen3-vl-flash-2025-10-15-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.00004
-        }
-      }
-    }
-  },
-  "qwen-vl-ocr-2025-08-28": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000007
-        },
-        "response_token": {
-          "price": 0.000016
-        }
-      }
-    }
-  },
-  "qwen2.5-omni-7b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
         },
         "response_token": {
           "price": 0.00004
@@ -2380,14 +1984,518 @@
       }
     }
   },
-  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+  "qwen3.5-omni-plus-realtime": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus-realtime-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash-realtime-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-omni-flash-2025-09-15-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000052
+        },
+        "response_token": {
+          "price": 0.000199
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2026-01-22-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2025-10-15-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-vl-ocr-2025-08-28": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000717
+        },
+        "response_token": {
+          "price": 0.0000717
+        }
+      }
+    }
+  },
+  "qwen-vl-ocr-2025-04-13": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000717
+        },
+        "response_token": {
+          "price": 0.0000717
+        }
+      }
+    }
+  },
+  "qwen-vl-ocr-2024-10-28": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000717
+        },
+        "response_token": {
+          "price": 0.0000717
+        }
+      }
+    }
+  },
+  "qwen-doc-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000087
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "qwen-deep-research": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.7742
+        },
+        "response_token": {
+          "price": 2.3367
+        }
+      }
+    }
+  },
+  "qwen3.5-397b-a17b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00036
+        }
+      }
+    }
+  },
+  "qwen3.5-122b-a10b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00032
+        }
+      }
+    }
+  },
+  "qwen3.5-27b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3.5-35b-a3b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-thinking-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.00023
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.000092
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-thinking-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00008
+        }
+      }
+    }
+  },
+  "qwen3-4b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-1.7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-0.6b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000805
+        },
+        "response_token": {
+          "price": 0.000322
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000368
+        },
+        "response_token": {
+          "price": 0.000147
+        }
+      }
+    }
+  },
+  "qwen2.5-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00056
+        }
+      }
+    }
+  },
+  "qwen2.5-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00007
+        },
+        "response_token": {
+          "price": 0.00028
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.00014
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000175
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      }
+    }
+  },
+  "qwen2.5-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000044
+        },
+        "response_token": {
+          "price": 0.000013
+        }
+      }
+    }
+  },
+  "qvq-72b-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001721
+        },
+        "response_token": {
+          "price": 0.0005161
+        }
+      }
+    }
+  },
+  "qwen2.5-omni-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00028
+        },
+        "response_token": {
+          "price": 0.00084
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00042
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.000105
+        }
+      }
+    }
+  },
+  "qwen2.5-vl-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000021
+        },
+        "response_token": {
+          "price": 0.000063
+        }
+      }
+    }
+  },
+  "qwen2.5-math-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "deepseek-v3.2-exp": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000431
         }
       }
     }
@@ -2488,42 +2596,6 @@
       }
     }
   },
-  "qwen3-rerank": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "gte-rerank-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000115
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "tongyi-intent-detect-v3": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000058
-        },
-        "response_token": {
-          "price": 0.0000144
-        }
-      }
-    }
-  },
   "tongyi-embedding-vision-plus": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2548,6 +2620,30 @@
       }
     }
   },
+  "qwen3-rerank": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gte-rerank-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
   "qwen3-vl-embedding": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2556,6 +2652,102 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000058
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "qwen-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-2025-05-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-2025-04-10": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.0001434
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000345
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000345
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen-tts-realtime-2025-07-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000345
+        },
+        "response_token": {
+          "price": 0.0001721
         }
       }
     }
@@ -2748,90 +2940,6 @@
         },
         "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "qwen-tts-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000023
-        },
-        "response_token": {
-          "price": 0.0001434
-        }
-      }
-    }
-  },
-  "qwen-tts-latest": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000023
-        },
-        "response_token": {
-          "price": 0.0001434
-        }
-      }
-    }
-  },
-  "qwen-tts-2025-05-22": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000023
-        },
-        "response_token": {
-          "price": 0.0001434
-        }
-      }
-    }
-  },
-  "qwen-tts-2025-04-10": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000023
-        },
-        "response_token": {
-          "price": 0.0001434
-        }
-      }
-    }
-  },
-  "qwen-tts-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000345
-        },
-        "response_token": {
-          "price": 0.0001721
-        }
-      }
-    }
-  },
-  "qwen-tts-realtime-latest": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000345
-        },
-        "response_token": {
-          "price": 0.0001721
-        }
-      }
-    }
-  },
-  "qwen-tts-realtime-2025-07-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000345
-        },
-        "response_token": {
-          "price": 0.0001721
         }
       }
     }
@@ -3124,14 +3232,26 @@
       }
     }
   },
+  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
   "qwen-image-2.0-pro": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 7.5
         }
       }
     }
@@ -3140,10 +3260,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 7.5
         }
       }
     }
@@ -3152,10 +3272,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3.5
         }
       }
     }
@@ -3164,10 +3284,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3.5
         }
       }
     }
@@ -3176,10 +3296,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 7.5
         }
       }
     }
@@ -3188,10 +3308,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 7.5
         }
       }
     }
@@ -3200,10 +3320,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3
         }
       }
     }
@@ -3212,10 +3332,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3
         }
       }
     }
@@ -3224,10 +3344,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3.5
         }
       }
     }
@@ -3236,10 +3356,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 7.5
         }
       }
     }
@@ -3248,10 +3368,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 7.5
         }
       }
     }
@@ -3260,10 +3380,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3
         }
       }
     }
@@ -3272,10 +3392,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3
         }
       }
     }
@@ -3284,10 +3404,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3
         }
       }
     }
@@ -3296,10 +3416,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 4.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 4.5
         }
       }
     }
@@ -3308,10 +3428,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 1.5
         }
       }
     }
@@ -3320,10 +3440,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3
         }
       }
     }
@@ -3332,10 +3452,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3
         }
       }
     }
@@ -3344,10 +3464,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 5
         }
       }
     }
@@ -3356,10 +3476,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 2.5
         }
       }
     }
@@ -3368,10 +3488,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 5
         }
       }
     }
@@ -3380,10 +3500,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 2.5
         }
       }
     }
@@ -3392,10 +3512,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3
         }
       }
     }
@@ -3404,10 +3524,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3
         }
       }
     }
@@ -3416,22 +3536,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 10
+          "price": 0
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.6-t2v-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
           "price": 10
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3440,10 +3548,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 10
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 10
         }
       }
     }
@@ -3452,10 +3560,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 10
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 2
         }
       }
     }
@@ -3464,10 +3572,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3.6
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3.6
         }
       }
     }
@@ -3476,34 +3584,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 10
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 10
         }
       }
     }
   },
-  "wan2.6-i2v": {
+  "wan2.6-t2v-us": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 10
+          "price": 0
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.6-i2v-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
           "price": 10
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3512,10 +3608,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5
+          "price": 0
         },
         "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.6-i2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0
+        },
+        "response_token": {
+          "price": 10
         }
       }
     }
@@ -3524,10 +3632,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 10
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 10
         }
       }
     }
@@ -3536,10 +3644,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3.6
         }
       }
     }
@@ -3548,10 +3656,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 10
+          "price": 0
         },
         "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0
+        },
+        "response_token": {
+          "price": 10
         }
       }
     }
@@ -3560,10 +3680,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.5
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 3.6
         }
       }
     }
@@ -3572,22 +3692,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 10
+          "price": 0
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.6-r2v": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
           "price": 10
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3596,10 +3704,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.5
+          "price": 0
         },
         "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.6-r2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0
+        },
+        "response_token": {
+          "price": 10
         }
       }
     }
@@ -3608,10 +3728,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 10
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 10
         }
       }
     }
@@ -3620,22 +3740,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.1677
+          "price": 0
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.2-s2v-detect": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0
+          "price": 12.9018
         }
       }
     }
@@ -3644,10 +3752,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 12
+          "price": 0
         },
         "response_token": {
-          "price": 0
+          "price": 12
         }
       }
     }
@@ -3656,166 +3764,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
+          "price": 0
+        },
+        "response_token": {
           "price": 18
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "animate-anyone-detect-gen2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "animate-anyone-template-gen2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "animate-anyone-gen2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "emo-detect-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "emo-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "liveportrait-detect": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "liveportrait": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.2868
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "emoji-detect-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "emoji-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "videoretalk": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "video-style-transform": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.8671
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-voice-enrollment": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-voice-design": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 20
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -152,13 +152,16 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0.000027
+          "price": 0.000107
         },
         "request_audio_token": {
           "price": 0.000444
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
         }
       }
     }
@@ -177,6 +180,9 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000084
         }
       }
     }
@@ -521,7 +527,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0
+          "price": 0.0035
         }
       }
     }
@@ -602,7 +608,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.00013
         },
         "response_token": {
           "price": 0.001
@@ -650,10 +656,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.0002
         }
       }
     }
@@ -662,10 +668,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.0006
         }
       }
     }
@@ -684,6 +690,9 @@
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
         }
       }
     }
@@ -702,6 +711,9 @@
         },
         "response_audio_token": {
           "price": 0.001813
+        },
+        "request_image_token": {
+          "price": 0.000094
         }
       }
     }
@@ -851,10 +863,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.00006
         }
       }
     }
@@ -1163,10 +1175,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.00024
         }
       }
     }
@@ -1175,10 +1187,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.00024
         }
       }
     }
@@ -1187,10 +1199,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.00024
         }
       }
     }
@@ -1319,10 +1331,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000043
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000072
+          "price": 0.000016
         }
       }
     }
@@ -1451,10 +1463,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002294
+          "price": 0.00028
         },
         "response_token": {
-          "price": 0.0006881
+          "price": 0.00084
         }
       }
     }
@@ -1466,13 +1478,16 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0.000027
+          "price": 0.000107
         },
         "request_audio_token": {
           "price": 0.000444
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
         }
       }
     }
@@ -1484,13 +1499,16 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0.000027
+          "price": 0.000107
         },
         "request_audio_token": {
           "price": 0.000444
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
         }
       }
     }
@@ -1502,13 +1520,16 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0.000027
+          "price": 0.000107
         },
         "request_audio_token": {
           "price": 0.000444
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
         }
       }
     }
@@ -1527,6 +1548,9 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000084
         }
       }
     }
@@ -1545,6 +1569,9 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000084
         }
       }
     }
@@ -1563,6 +1590,9 @@
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
         }
       }
     }
@@ -1581,6 +1611,9 @@
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
         }
       }
     }
@@ -1912,6 +1945,18 @@
       }
     }
   },
+  "qwen-flash-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
   "qwen-flash-us": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -1936,140 +1981,38 @@
       }
     }
   },
-  "qwen3.5-omni-plus": {
+  "qwen3-4b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000011
         },
         "response_token": {
-          "price": 0
+          "price": 0.000042
         }
       }
     }
   },
-  "qwen3.5-omni-plus-2026-03-15": {
+  "qwen3-1.7b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000011
         },
         "response_token": {
-          "price": 0
+          "price": 0.000042
         }
       }
     }
   },
-  "qwen3.5-omni-flash": {
+  "qwen3-0.6b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.000011
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3.5-omni-flash-2026-03-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-omni-flash-2025-09-15-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000052
-        },
-        "response_token": {
-          "price": 0.000199
-        },
-        "request_audio_token": {
-          "price": 0.000457
-        },
-        "response_audio_token": {
-          "price": 0.001813
-        }
-      }
-    }
-  },
-  "qwen3-vl-flash-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.00004
-        }
-      }
-    }
-  },
-  "qwen3-vl-flash-2026-01-22-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.00004
-        }
-      }
-    }
-  },
-  "qwen3-vl-flash-2025-10-15-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000005
-        },
-        "response_token": {
-          "price": 0.00004
-        }
-      }
-    }
-  },
-  "qwen-doc-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000087
-        },
-        "response_token": {
-          "price": 0.0000144
-        }
-      }
-    }
-  },
-  "qwen-deep-research": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0007742
-        },
-        "response_token": {
-          "price": 0.0023367
-        }
-      }
-    }
-  },
-  "tongyi-intent-detect-v3": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000058
-        },
-        "response_token": {
-          "price": 0.0000144
+          "price": 0.000042
         }
       }
     }
@@ -2122,114 +2065,6 @@
       }
     }
   },
-  "qwen3-235b-a22b-thinking-2507": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000023
-        },
-        "response_token": {
-          "price": 0.00023
-        }
-      }
-    }
-  },
-  "qwen3-235b-a22b-instruct-2507": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000023
-        },
-        "response_token": {
-          "price": 0.000092
-        }
-      }
-    }
-  },
-  "qwen3-30b-a3b-thinking-2507": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00024
-        }
-      }
-    }
-  },
-  "qwen3-30b-a3b-instruct-2507": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00002
-        },
-        "response_token": {
-          "price": 0.00008
-        }
-      }
-    }
-  },
-  "qwen3-4b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000011
-        },
-        "response_token": {
-          "price": 0.000042
-        }
-      }
-    }
-  },
-  "qwen3-1.7b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000011
-        },
-        "response_token": {
-          "price": 0.000042
-        }
-      }
-    }
-  },
-  "qwen3-0.6b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000011
-        },
-        "response_token": {
-          "price": 0.000042
-        }
-      }
-    }
-  },
-  "qwen2.5-14b-instruct-1m": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000805
-        },
-        "response_token": {
-          "price": 0.000322
-        }
-      }
-    }
-  },
-  "qwen2.5-7b-instruct-1m": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000368
-        },
-        "response_token": {
-          "price": 0.000147
-        }
-      }
-    }
-  },
   "qwen2.5-72b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2267,6 +2102,66 @@
     }
   },
   "qwen2.5-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000175
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      }
+    }
+  },
+  "qwen2.5-14b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000805
+        },
+        "response_token": {
+          "price": 0.000322
+        }
+      }
+    }
+  },
+  "qwen2.5-7b-instruct-1m": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000368
+        },
+        "response_token": {
+          "price": 0.000147
+        }
+      }
+    }
+  },
+  "qwen2.5-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000175
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      }
+    }
+  },
+  "qwen2.5-1.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000175
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      }
+    }
+  },
+  "qwen2.5-0.5b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -2326,20 +2221,26 @@
       }
     }
   },
-  "qwen2.5-omni-7b": {
+  "qwen2-vl-7b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000035
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000105
+        }
+      }
+    }
+  },
+  "qwen2-vl-2b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000021
         },
-        "request_audio_token": {
-          "price": 0.000676
-        },
-        "response_audio_token": {
-          "price": 0.001351
+        "response_token": {
+          "price": 0.000063
         }
       }
     }
@@ -2368,31 +2269,7 @@
       }
     }
   },
-  "qwen2.5-coder-32b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000287
-        },
-        "response_token": {
-          "price": 0.0000861
-        }
-      }
-    }
-  },
-  "qwen2.5-coder-14b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000287
-        },
-        "response_token": {
-          "price": 0.0000861
-        }
-      }
-    }
-  },
-  "qwen2.5-coder-7b-instruct": {
+  "qwen2.5-math-1.5b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -2404,74 +2281,284 @@
       }
     }
   },
-  "text-embedding-v4": {
+  "qwen3-vl-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2026-01-22-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen3-vl-flash-2025-10-15-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-vl-ocr-2025-08-28": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
           "price": 0.000007
         },
         "response_token": {
-          "price": 0
+          "price": 0.000016
         }
       }
     }
   },
-  "text-embedding-v3": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000007
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "tongyi-embedding-vision-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000009
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "tongyi-embedding-vision-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-rerank": {
+  "qwen2.5-omni-7b": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
           "price": 0.00001
         },
         "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "qwen-doc-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000087
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "qwen-deep-research": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0007742
+        },
+        "response_token": {
+          "price": 0.0023367
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
           "price": 0
         }
       }
     }
   },
-  "gte-rerank-v2": {
+  "qwen3.5-omni-plus-2026-03-15": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000115
+          "price": 0
         },
         "response_token": {
           "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00013
+        },
+        "response_token": {
+          "price": 0.001
+        },
+        "request_audio_token": {
+          "price": 0.001
+        },
+        "response_audio_token": {
+          "price": 0.0038
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00115
+        },
+        "response_token": {
+          "price": 0.00115
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-2025-09-18": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.001
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143
+        },
+        "response_token": {
+          "price": 0.00143
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143353
+        },
+        "response_token": {
+          "price": 0.00143353
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0.0013
         }
       }
     }
@@ -2560,1110 +2647,6 @@
       }
     }
   },
-  "qwen3-livetranslate-flash-realtime-2025-09-22": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.001
-        },
-        "response_token": {
-          "price": 0.001
-        },
-        "request_audio_token": {
-          "price": 0.001
-        },
-        "response_audio_token": {
-          "price": 0.0038
-        }
-      }
-    }
-  },
-  "qwen3-livetranslate-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0001577
-        },
-        "response_token": {
-          "price": 0.0001577
-        },
-        "request_audio_token": {
-          "price": 0.0001577
-        },
-        "response_audio_token": {
-          "price": 0.0006308
-        }
-      }
-    }
-  },
-  "qwen-image-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-2.0-pro-2026-03-03": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-2.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-2.0-2026-03-03": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-max": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-max-2025-12-30": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-plus-2026-01-09": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-edit-max": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-edit-max-2026-01-16": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-edit-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-edit-plus-2025-12-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-edit-plus-2025-10-30": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen-image-edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 4.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "z-image-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.6-t2i": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.5-t2i-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.2-t2i-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.2-t2i-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.1-t2i-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.1-t2i-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.6-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.5-i2i-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "aitryon-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.1677
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.6-t2v": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.5-t2v-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.2-t2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.1-t2v-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3.6
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.1-t2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.6-t2v-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.6-i2v-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.6-i2v": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.5-i2v-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.2-i2v-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.2-i2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.1-i2v-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 3.6
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.1-i2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.6-i2v-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.2-kf2v-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.1-kf2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.6-r2v": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan.6-r2v-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.5
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.1-vace-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 10
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.2-s2v": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 7.1677
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.2-animate-move": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 12
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "wan2.2-animate-mix": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 18
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "animate-anyone-template-gen2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "animate-anyone-gen2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "emo-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "liveportrait": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.2868
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "emoji-v1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "videoretalk": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1.1469
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "video-style-transform": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.8671
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-filetrans": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-filetrans-2025-11-17": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-2025-09-08": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-2025-09-08-us": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-realtime-2026-02-10": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-realtime-2025-10-27": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "fun-asr": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "fun-asr-2025-11-07": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "fun-asr-2025-08-25": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "fun-asr-mtl": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "fun-asr-mtl-2025-08-25": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "fun-asr-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "fun-asr-realtime-2025-11-07": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "paraformer-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0012
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "paraformer-8k-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0012
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "paraformer-realtime-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "paraformer-realtime-8k-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-instruct-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00115
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-instruct-flash-2026-01-26": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00115
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-vd-2026-01-26": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00115
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-vc-2026-01-22": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00115
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-2025-11-27": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-2025-09-18": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.001
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-instruct-flash-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00143
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-instruct-flash-realtime-2026-01-22": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00143
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-vd-realtime-2026-01-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00143353
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-vd-realtime-2025-12-16": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00143353
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-vc-realtime-2026-01-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-vc-realtime-2025-11-27": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-realtime-2025-11-27": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-realtime-2025-09-18": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
   "cosyvoice-v3-plus": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -3671,7 +2654,7 @@
           "price": 0.0026
         },
         "response_token": {
-          "price": 0
+          "price": 0.0026
         }
       }
     }
@@ -3683,7 +2666,7 @@
           "price": 0.0013
         },
         "response_token": {
-          "price": 0
+          "price": 0.0013
         }
       }
     }
@@ -3692,10 +2675,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0022
+          "price": 0.0026
         },
         "response_token": {
-          "price": 0
+          "price": 0.0026
         }
       }
     }
@@ -3704,10 +2687,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00116
+          "price": 0.0013
         },
         "response_token": {
-          "price": 0
+          "price": 0.0013
         }
       }
     }
@@ -3716,10 +2699,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00286706
+          "price": 0.0013
         },
         "response_token": {
-          "price": 0
+          "price": 0.0013
         }
       }
     }
@@ -3731,7 +2714,7 @@
           "price": 1
         },
         "response_token": {
-          "price": 0
+          "price": 1
         }
       }
     }
@@ -3743,7 +2726,1087 @@
           "price": 20
         },
         "response_token": {
-          "price": 0
+          "price": 20
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans-2025-11-17": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-2025-09-08-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "fun-asr": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-2025-08-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-mtl": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "fun-asr-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "fun-asr-realtime-2025-11-07": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
+        }
+      }
+    }
+  },
+  "fun-asr-flash-8k-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0032
+        },
+        "response_token": {
+          "price": 0.0032
+        }
+      }
+    }
+  },
+  "paraformer-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "paraformer-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0012
+        },
+        "response_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "paraformer-realtime-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "paraformer-realtime-8k-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "text-embedding-v4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000007
+        }
+      }
+    }
+  },
+  "text-embedding-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000007
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000009
+        },
+        "response_token": {
+          "price": 0.000009
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.000009
+        }
+      }
+    }
+  },
+  "qwen3-vl-embedding": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.0000258
+        }
+      }
+    }
+  },
+  "qwen3-rerank": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "gte-rerank-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000115
+        }
+      }
+    }
+  },
+  "qwen3-vl-rerank": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.0000258
+        }
+      }
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000058
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "deepseek-v3.2-exp": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000431
+        }
+      }
+    }
+  },
+  "deepseek-v3.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "deepseek-r1-0528": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0002294
+        }
+      }
+    }
+  },
+  "deepseek-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0001147
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-14b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000431
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-2.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-max-2025-12-30": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-plus-2026-01-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max-2026-01-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.5
+        },
+        "response_token": {
+          "price": 7.5
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "qwen-image-edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4.5
+        },
+        "response_token": {
+          "price": 4.5
+        }
+      }
+    }
+  },
+  "z-image-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.5
+        },
+        "response_token": {
+          "price": 1.5
+        }
+      }
+    }
+  },
+  "wan2.6-t2i": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.5-t2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 2.5
+        }
+      }
+    }
+  },
+  "wan2.6-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.5-i2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 3
+        }
+      }
+    }
+  },
+  "wan2.6-t2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-t2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.5-t2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.6
+        },
+        "response_token": {
+          "price": 3.6
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-i2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-us": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.6
+        },
+        "response_token": {
+          "price": 3.6
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.2-kf2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.6
+        },
+        "response_token": {
+          "price": 3.6
+        }
+      }
+    }
+  },
+  "wan2.1-kf2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.6-r2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan.6-r2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.1-vace-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 10
+        },
+        "response_token": {
+          "price": 10
+        }
+      }
+    }
+  },
+  "wan2.2-animate-move": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 12
+        },
+        "response_token": {
+          "price": 12
+        }
+      }
+    }
+  },
+  "wan2.2-animate-mix": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 18
+        },
+        "response_token": {
+          "price": 18
+        }
+      }
+    }
+  },
+  "wan2.2-s2v": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.1677
+        },
+        "response_token": {
+          "price": 7.1677
+        }
+      }
+    }
+  },
+  "wan2.2-s2v-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "videoretalk": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "video-style-transform": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.8671
+        },
+        "response_token": {
+          "price": 2.8671
+        }
+      }
+    }
+  },
+  "liveportrait": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.2868
+        },
+        "response_token": {
+          "price": 0.2868
+        }
+      }
+    }
+  },
+  "liveportrait-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "animate-anyone-detect-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "animate-anyone-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "emo-detect-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "emo-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "emoji-detect-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "emoji-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 1.1469
+        }
+      }
+    }
+  },
+  "aitryon-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7.1677
+        },
+        "response_token": {
+          "price": 7.1677
+        }
+      }
+    }
+  },
+  "aitryon-parsing-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0.0574
+        }
+      }
+    }
+  },
+  "qwen-mt-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0431
+        },
+        "response_token": {
+          "price": 0.0431
+        }
+      }
+    }
+  },
+  "wanx2.1-imageedit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.007
+        },
+        "response_token": {
+          "price": 2.007
         }
       }
     }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -110,10 +110,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00016
+          "price": 0.00024
         },
         "response_token": {
-          "price": 0.00064
+          "price": 0.00096
         },
         "cache_read_input_token": {
           "price": 0.000032
@@ -152,16 +152,13 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.000444
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000021
         }
       }
     }
@@ -180,9 +177,6 @@
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000084
         }
       }
     }
@@ -527,7 +521,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
+          "price": 0
         }
       }
     }
@@ -608,7 +602,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00013
+          "price": 0.001
         },
         "response_token": {
           "price": 0.001
@@ -656,10 +650,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00012
         }
       }
     }
@@ -668,10 +662,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00012
         }
       }
     }
@@ -690,9 +684,6 @@
         },
         "response_audio_token": {
           "price": 0.001511
-        },
-        "request_image_token": {
-          "price": 0.000078
         }
       }
     }
@@ -711,9 +702,6 @@
         },
         "response_audio_token": {
           "price": 0.001813
-        },
-        "request_image_token": {
-          "price": 0.000094
         }
       }
     }
@@ -827,10 +815,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00016
+          "price": 0.00024
         },
         "response_token": {
-          "price": 0.00064
+          "price": 0.00096
         }
       }
     }
@@ -839,10 +827,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00016
+          "price": 0.00024
         },
         "response_token": {
-          "price": 0.00064
+          "price": 0.00096
         }
       }
     }
@@ -863,10 +851,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.0000861
         }
       }
     }
@@ -1175,10 +1163,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0000717
         }
       }
     }
@@ -1187,10 +1175,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0000717
         }
       }
     }
@@ -1199,10 +1187,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.0000717
         }
       }
     }
@@ -1463,10 +1451,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00028
+          "price": 0.0002294
         },
         "response_token": {
-          "price": 0.00084
+          "price": 0.0006881
         }
       }
     }
@@ -1478,16 +1466,13 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.000444
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000021
         }
       }
     }
@@ -1499,16 +1484,13 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.000444
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000021
         }
       }
     }
@@ -1520,16 +1502,13 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.000027
         },
         "request_audio_token": {
-          "price": 0.000444
+          "price": 0.0003584
         },
         "response_audio_token": {
-          "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000021
+          "price": 0.0007168
         }
       }
     }
@@ -1548,9 +1527,6 @@
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000084
         }
       }
     }
@@ -1569,9 +1545,6 @@
         },
         "response_audio_token": {
           "price": 0.000889
-        },
-        "request_image_token": {
-          "price": 0.000084
         }
       }
     }
@@ -1590,9 +1563,6 @@
         },
         "response_audio_token": {
           "price": 0.001511
-        },
-        "request_image_token": {
-          "price": 0.000078
         }
       }
     }
@@ -1611,9 +1581,6 @@
         },
         "response_audio_token": {
           "price": 0.001511
-        },
-        "request_image_token": {
-          "price": 0.000078
         }
       }
     }
@@ -1670,10 +1637,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000502
+          "price": 0.00035
         },
         "response_token": {
-          "price": 0.0001004
+          "price": 0.0007
         }
       }
     }
@@ -1682,10 +1649,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000502
+          "price": 0.00035
         },
         "response_token": {
-          "price": 0.0001004
+          "price": 0.0007
         }
       }
     }
@@ -1694,10 +1661,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000502
+          "price": 0.00035
         },
         "response_token": {
-          "price": 0.0001004
+          "price": 0.0007
         }
       }
     }
@@ -1706,10 +1673,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.00015
         }
       }
     }
@@ -1718,10 +1685,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.00015
         }
       }
     }
@@ -1730,10 +1697,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.00015
         }
       }
     }
@@ -1981,6 +1948,66 @@
       }
     }
   },
+  "qvq-72b-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001721
+        },
+        "response_token": {
+          "price": 0.0005161
+        }
+      }
+    }
+  },
+  "qwen-deep-research": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0007742
+        },
+        "response_token": {
+          "price": 0.0023367
+        }
+      }
+    }
+  },
+  "qwen-doc-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000087
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "qwen2.5-math-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
   "qwen3-4b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2013,6 +2040,54 @@
         },
         "response_token": {
           "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-thinking-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.00023
+        }
+      }
+    }
+  },
+  "qwen3-235b-a22b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000023
+        },
+        "response_token": {
+          "price": 0.000092
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-thinking-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-instruct-2507": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00008
         }
       }
     }
@@ -2141,34 +2216,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000175
+          "price": 0.0000044
         },
         "response_token": {
-          "price": 0.00007
-        }
-      }
-    }
-  },
-  "qwen2.5-1.5b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000175
-        },
-        "response_token": {
-          "price": 0.00007
-        }
-      }
-    }
-  },
-  "qwen2.5-0.5b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000175
-        },
-        "response_token": {
-          "price": 0.00007
+          "price": 0.000013
         }
       }
     }
@@ -2217,66 +2268,6 @@
         },
         "response_token": {
           "price": 0.000063
-        }
-      }
-    }
-  },
-  "qwen2-vl-7b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000035
-        },
-        "response_token": {
-          "price": 0.000105
-        }
-      }
-    }
-  },
-  "qwen2-vl-2b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000021
-        },
-        "response_token": {
-          "price": 0.000063
-        }
-      }
-    }
-  },
-  "qwen2.5-math-72b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000574
-        },
-        "response_token": {
-          "price": 0.0001721
-        }
-      }
-    }
-  },
-  "qwen2.5-math-7b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000144
-        },
-        "response_token": {
-          "price": 0.0000287
-        }
-      }
-    }
-  },
-  "qwen2.5-math-1.5b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000144
-        },
-        "response_token": {
-          "price": 0.0000287
         }
       }
     }
@@ -2341,30 +2332,6 @@
       }
     }
   },
-  "qwen-doc-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000087
-        },
-        "response_token": {
-          "price": 0.0000144
-        }
-      }
-    }
-  },
-  "qwen-deep-research": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0007742
-        },
-        "response_token": {
-          "price": 0.0023367
-        }
-      }
-    }
-  },
   "qwen3.5-omni-plus": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2417,16 +2384,178 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00013
+          "price": 0.001
         },
         "response_token": {
           "price": 0.001
+        }
+      }
+    }
+  },
+  "deepseek-v3.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
         },
-        "request_audio_token": {
-          "price": 0.001
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "deepseek-r1-0528": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
         },
-        "response_audio_token": {
-          "price": 0.0038
+        "response_token": {
+          "price": 0.0002294
+        }
+      }
+    }
+  },
+  "deepseek-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0001147
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-14b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000144
+        },
+        "response_token": {
+          "price": 0.0000431
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
+  "text-embedding-v4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "text-embedding-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-rerank": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "gte-rerank-v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-intent-detect-v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000058
+        },
+        "response_token": {
+          "price": 0.0000144
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tongyi-embedding-vision-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-vl-embedding": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2438,7 +2567,7 @@
           "price": 0.00115
         },
         "response_token": {
-          "price": 0.00115
+          "price": 0
         }
       }
     }
@@ -2450,7 +2579,7 @@
           "price": 0.00115
         },
         "response_token": {
-          "price": 0.00115
+          "price": 0
         }
       }
     }
@@ -2462,7 +2591,7 @@
           "price": 0.00115
         },
         "response_token": {
-          "price": 0.00115
+          "price": 0
         }
       }
     }
@@ -2474,7 +2603,7 @@
           "price": 0.00115
         },
         "response_token": {
-          "price": 0.00115
+          "price": 0
         }
       }
     }
@@ -2486,7 +2615,7 @@
           "price": 0.001
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         }
       }
     }
@@ -2498,7 +2627,7 @@
           "price": 0.001
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         }
       }
     }
@@ -2510,7 +2639,7 @@
           "price": 0.001
         },
         "response_token": {
-          "price": 0.001
+          "price": 0
         }
       }
     }
@@ -2522,31 +2651,67 @@
           "price": 0.00143
         },
         "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-realtime-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.00143
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
   },
-  "qwen3-tts-vd-realtime": {
+  "qwen3-tts-vd-realtime-2026-01-15": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
           "price": 0.00143353
         },
         "response_token": {
-          "price": 0.00143353
+          "price": 0
         }
       }
     }
   },
-  "qwen3-tts-vc-realtime": {
+  "qwen3-tts-vd-realtime-2025-12-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00143353
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime-2026-01-15": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
           "price": 0.0013
         },
         "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2558,12 +2723,36 @@
           "price": 0.0013
         },
         "response_token": {
-          "price": 0.0013
+          "price": 0
         }
       }
     }
   },
-  "qwen-tts": {
+  "qwen3-tts-flash-realtime-2025-11-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime-2025-09-18": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0013
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-tts-flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -2654,7 +2843,7 @@
           "price": 0.0026
         },
         "response_token": {
-          "price": 0.0026
+          "price": 0
         }
       }
     }
@@ -2666,7 +2855,7 @@
           "price": 0.0013
         },
         "response_token": {
-          "price": 0.0013
+          "price": 0
         }
       }
     }
@@ -2675,10 +2864,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0026
+          "price": 0.0022
         },
         "response_token": {
-          "price": 0.0026
+          "price": 0
         }
       }
     }
@@ -2687,10 +2876,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0013
+          "price": 0.00116
         },
         "response_token": {
-          "price": 0.0013
+          "price": 0
         }
       }
     }
@@ -2699,34 +2888,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0013
+          "price": 0.00286706
         },
         "response_token": {
-          "price": 0.0013
-        }
-      }
-    }
-  },
-  "qwen-voice-enrollment": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 1
-        },
-        "response_token": {
-          "price": 1
-        }
-      }
-    }
-  },
-  "qwen-voice-design": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 20
-        },
-        "response_token": {
-          "price": 20
+          "price": 0
         }
       }
     }
@@ -2738,7 +2903,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
+          "price": 0
         }
       }
     }
@@ -2750,7 +2915,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
+          "price": 0
         }
       }
     }
@@ -2762,7 +2927,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
+          "price": 0
         }
       }
     }
@@ -2774,7 +2939,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
+          "price": 0
         }
       }
     }
@@ -2786,7 +2951,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
+          "price": 0
         }
       }
     }
@@ -2798,7 +2963,31 @@
           "price": 0.009
         },
         "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime-2026-02-10": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.009
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime-2025-10-27": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2810,7 +2999,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
+          "price": 0
         }
       }
     }
@@ -2822,7 +3011,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
+          "price": 0
         }
       }
     }
@@ -2834,7 +3023,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
+          "price": 0
         }
       }
     }
@@ -2846,7 +3035,19 @@
           "price": 0.0035
         },
         "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "fun-asr-mtl-2025-08-25": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 0.0035
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -2858,7 +3059,7 @@
           "price": 0.009
         },
         "response_token": {
-          "price": 0.009
+          "price": 0
         }
       }
     }
@@ -2870,19 +3071,7 @@
           "price": 0.009
         },
         "response_token": {
-          "price": 0.009
-        }
-      }
-    }
-  },
-  "fun-asr-flash-8k-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0032
-        },
-        "response_token": {
-          "price": 0.0032
+          "price": 0
         }
       }
     }
@@ -2894,7 +3083,7 @@
           "price": 0.0012
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0
         }
       }
     }
@@ -2906,7 +3095,7 @@
           "price": 0.0012
         },
         "response_token": {
-          "price": 0.0012
+          "price": 0
         }
       }
     }
@@ -2918,7 +3107,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
+          "price": 0
         }
       }
     }
@@ -2930,199 +3119,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0.0035
-        }
-      }
-    }
-  },
-  "text-embedding-v4": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000007
-        },
-        "response_token": {
-          "price": 0.000007
-        }
-      }
-    }
-  },
-  "text-embedding-v3": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000007
-        },
-        "response_token": {
-          "price": 0.000007
-        }
-      }
-    }
-  },
-  "tongyi-embedding-vision-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000009
-        },
-        "response_token": {
-          "price": 0.000009
-        }
-      }
-    }
-  },
-  "tongyi-embedding-vision-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000003
-        },
-        "response_token": {
-          "price": 0.000009
-        }
-      }
-    }
-  },
-  "qwen3-vl-embedding": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.0000258
-        }
-      }
-    }
-  },
-  "qwen3-rerank": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00001
-        }
-      }
-    }
-  },
-  "gte-rerank-v2": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000115
-        },
-        "response_token": {
-          "price": 0.0000115
-        }
-      }
-    }
-  },
-  "qwen3-vl-rerank": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.0000258
-        }
-      }
-    }
-  },
-  "tongyi-intent-detect-v3": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000058
-        },
-        "response_token": {
-          "price": 0.0000144
-        }
-      }
-    }
-  },
-  "deepseek-v3.2-exp": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000287
-        },
-        "response_token": {
-          "price": 0.0000431
-        }
-      }
-    }
-  },
-  "deepseek-v3.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000574
-        },
-        "response_token": {
-          "price": 0.0001721
-        }
-      }
-    }
-  },
-  "deepseek-r1-0528": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000574
-        },
-        "response_token": {
-          "price": 0.0002294
-        }
-      }
-    }
-  },
-  "deepseek-v3": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000287
-        },
-        "response_token": {
-          "price": 0.0001147
-        }
-      }
-    }
-  },
-  "deepseek-r1-distill-qwen-7b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000072
-        },
-        "response_token": {
-          "price": 0.0000144
-        }
-      }
-    }
-  },
-  "deepseek-r1-distill-qwen-14b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000144
-        },
-        "response_token": {
-          "price": 0.0000431
-        }
-      }
-    }
-  },
-  "deepseek-r1-distill-qwen-32b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000287
-        },
-        "response_token": {
-          "price": 0.0000861
+          "price": 0
         }
       }
     }
@@ -3134,7 +3131,7 @@
           "price": 7.5
         },
         "response_token": {
-          "price": 7.5
+          "price": 0
         }
       }
     }
@@ -3146,7 +3143,7 @@
           "price": 7.5
         },
         "response_token": {
-          "price": 7.5
+          "price": 0
         }
       }
     }
@@ -3158,7 +3155,7 @@
           "price": 3.5
         },
         "response_token": {
-          "price": 3.5
+          "price": 0
         }
       }
     }
@@ -3170,7 +3167,7 @@
           "price": 3.5
         },
         "response_token": {
-          "price": 3.5
+          "price": 0
         }
       }
     }
@@ -3182,7 +3179,7 @@
           "price": 7.5
         },
         "response_token": {
-          "price": 7.5
+          "price": 0
         }
       }
     }
@@ -3194,7 +3191,7 @@
           "price": 7.5
         },
         "response_token": {
-          "price": 7.5
+          "price": 0
         }
       }
     }
@@ -3206,7 +3203,7 @@
           "price": 3
         },
         "response_token": {
-          "price": 3
+          "price": 0
         }
       }
     }
@@ -3218,7 +3215,7 @@
           "price": 3
         },
         "response_token": {
-          "price": 3
+          "price": 0
         }
       }
     }
@@ -3230,7 +3227,7 @@
           "price": 3.5
         },
         "response_token": {
-          "price": 3.5
+          "price": 0
         }
       }
     }
@@ -3242,7 +3239,7 @@
           "price": 7.5
         },
         "response_token": {
-          "price": 7.5
+          "price": 0
         }
       }
     }
@@ -3254,7 +3251,7 @@
           "price": 7.5
         },
         "response_token": {
-          "price": 7.5
+          "price": 0
         }
       }
     }
@@ -3266,7 +3263,31 @@
           "price": 3
         },
         "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus-2025-12-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus-2025-10-30": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3278,7 +3299,7 @@
           "price": 4.5
         },
         "response_token": {
-          "price": 4.5
+          "price": 0
         }
       }
     }
@@ -3290,7 +3311,7 @@
           "price": 1.5
         },
         "response_token": {
-          "price": 1.5
+          "price": 0
         }
       }
     }
@@ -3302,7 +3323,7 @@
           "price": 3
         },
         "response_token": {
-          "price": 3
+          "price": 0
         }
       }
     }
@@ -3314,7 +3335,7 @@
           "price": 3
         },
         "response_token": {
-          "price": 3
+          "price": 0
         }
       }
     }
@@ -3326,7 +3347,7 @@
           "price": 5
         },
         "response_token": {
-          "price": 5
+          "price": 0
         }
       }
     }
@@ -3338,7 +3359,7 @@
           "price": 2.5
         },
         "response_token": {
-          "price": 2.5
+          "price": 0
         }
       }
     }
@@ -3350,7 +3371,7 @@
           "price": 5
         },
         "response_token": {
-          "price": 5
+          "price": 0
         }
       }
     }
@@ -3362,7 +3383,7 @@
           "price": 2.5
         },
         "response_token": {
-          "price": 2.5
+          "price": 0
         }
       }
     }
@@ -3374,7 +3395,7 @@
           "price": 3
         },
         "response_token": {
-          "price": 3
+          "price": 0
         }
       }
     }
@@ -3386,7 +3407,7 @@
           "price": 3
         },
         "response_token": {
-          "price": 3
+          "price": 0
         }
       }
     }
@@ -3398,7 +3419,7 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
+          "price": 0
         }
       }
     }
@@ -3410,7 +3431,7 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
+          "price": 0
         }
       }
     }
@@ -3422,7 +3443,7 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
+          "price": 0
         }
       }
     }
@@ -3434,7 +3455,7 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
+          "price": 0
         }
       }
     }
@@ -3446,7 +3467,7 @@
           "price": 3.6
         },
         "response_token": {
-          "price": 3.6
+          "price": 0
         }
       }
     }
@@ -3458,7 +3479,7 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
+          "price": 0
         }
       }
     }
@@ -3470,19 +3491,7 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.6-i2v-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 5
-        },
-        "response_token": {
-          "price": 5
+          "price": 0
         }
       }
     }
@@ -3494,7 +3503,19 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
+          "price": 0
+        }
+      }
+    }
+  },
+  "wan2.6-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2.5
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3506,7 +3527,7 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
+          "price": 0
         }
       }
     }
@@ -3515,10 +3536,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3.6
+          "price": 1.5
         },
         "response_token": {
-          "price": 3.6
+          "price": 0
         }
       }
     }
@@ -3530,7 +3551,7 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
+          "price": 0
         }
       }
     }
@@ -3539,10 +3560,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3.6
+          "price": 1.5
         },
         "response_token": {
-          "price": 3.6
+          "price": 0
         }
       }
     }
@@ -3554,7 +3575,7 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
+          "price": 0
         }
       }
     }
@@ -3566,7 +3587,7 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
+          "price": 0
         }
       }
     }
@@ -3575,10 +3596,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5
+          "price": 2.5
         },
         "response_token": {
-          "price": 5
+          "price": 0
         }
       }
     }
@@ -3590,31 +3611,7 @@
           "price": 10
         },
         "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.2-animate-move": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 12
-        },
-        "response_token": {
-          "price": 12
-        }
-      }
-    }
-  },
-  "wan2.2-animate-mix": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 18
-        },
-        "response_token": {
-          "price": 18
+          "price": 0
         }
       }
     }
@@ -3626,7 +3623,7 @@
           "price": 7.1677
         },
         "response_token": {
-          "price": 7.1677
+          "price": 0
         }
       }
     }
@@ -3638,55 +3635,31 @@
           "price": 0.0574
         },
         "response_token": {
-          "price": 0.0574
+          "price": 0
         }
       }
     }
   },
-  "videoretalk": {
+  "wan2.2-animate-move": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.1469
+          "price": 12
         },
         "response_token": {
-          "price": 1.1469
+          "price": 0
         }
       }
     }
   },
-  "video-style-transform": {
+  "wan2.2-animate-mix": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2.8671
+          "price": 18
         },
         "response_token": {
-          "price": 2.8671
-        }
-      }
-    }
-  },
-  "liveportrait": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.2868
-        },
-        "response_token": {
-          "price": 0.2868
-        }
-      }
-    }
-  },
-  "liveportrait-detect": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0574
-        },
-        "response_token": {
-          "price": 0.0574
+          "price": 0
         }
       }
     }
@@ -3698,7 +3671,19 @@
           "price": 0.0574
         },
         "response_token": {
-          "price": 0.0574
+          "price": 0
+        }
+      }
+    }
+  },
+  "animate-anyone-template-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.1469
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3710,7 +3695,7 @@
           "price": 1.1469
         },
         "response_token": {
-          "price": 1.1469
+          "price": 0
         }
       }
     }
@@ -3722,7 +3707,7 @@
           "price": 0.0574
         },
         "response_token": {
-          "price": 0.0574
+          "price": 0
         }
       }
     }
@@ -3734,7 +3719,31 @@
           "price": 1.1469
         },
         "response_token": {
-          "price": 1.1469
+          "price": 0
+        }
+      }
+    }
+  },
+  "liveportrait-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0574
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "liveportrait": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.2868
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
@@ -3746,7 +3755,7 @@
           "price": 0.0574
         },
         "response_token": {
-          "price": 0.0574
+          "price": 0
         }
       }
     }
@@ -3758,55 +3767,55 @@
           "price": 1.1469
         },
         "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "videoretalk": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
           "price": 1.1469
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }
   },
-  "aitryon-plus": {
+  "video-style-transform": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 7.1677
+          "price": 2.8671
         },
         "response_token": {
-          "price": 7.1677
+          "price": 0
         }
       }
     }
   },
-  "aitryon-parsing-v1": {
+  "qwen-voice-enrollment": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0574
+          "price": 1
         },
         "response_token": {
-          "price": 0.0574
+          "price": 0
         }
       }
     }
   },
-  "qwen-mt-image": {
+  "qwen-voice-design": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0431
+          "price": 20
         },
         "response_token": {
-          "price": 0.0431
-        }
-      }
-    }
-  },
-  "wanx2.1-imageedit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 2.007
-        },
-        "response_token": {
-          "price": 2.007
+          "price": 0
         }
       }
     }

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -159,6 +159,9 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
         }
       }
     }
@@ -167,10 +170,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.000444
@@ -260,10 +263,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.00014
+          "price": 0.00012
         }
       }
     }
@@ -521,7 +524,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0
+          "price": 0.0035
         }
       }
     }
@@ -530,10 +533,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000045
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.000225
+          "price": 0.00015
         }
       }
     }
@@ -542,10 +545,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00015
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.0005
         }
       }
     }
@@ -602,10 +605,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.000381
         },
         "response_token": {
-          "price": 0.001
+          "price": 0.000166
         },
         "request_audio_token": {
           "price": 0.001
@@ -650,10 +653,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.00008
         }
       }
     }
@@ -662,10 +665,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.0006
         }
       }
     }
@@ -684,6 +687,9 @@
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
         }
       }
     }
@@ -692,16 +698,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000052
+          "price": 0.000043
         },
         "response_token": {
-          "price": 0.000199
+          "price": 0.000166
         },
         "request_audio_token": {
-          "price": 0.000457
+          "price": 0.000381
         },
         "response_audio_token": {
-          "price": 0.001813
+          "price": 0.001511
         }
       }
     }
@@ -782,7 +788,7 @@
           "price": 0.0000574
         },
         "response_token": {
-          "price": 0.0003011
+          "price": 0.0002294
         }
       }
     }
@@ -839,10 +845,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.000016
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.000064
         }
       }
     }
@@ -851,10 +857,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.000016
         },
         "response_token": {
-          "price": 0.0000861
+          "price": 0.000064
         }
       }
     }
@@ -863,10 +869,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000023
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0000574
+          "price": 0.00024
         }
       }
     }
@@ -875,10 +881,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000023
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0000574
+          "price": 0.00024
         }
       }
     }
@@ -923,10 +929,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000431
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.0002007
+          "price": 0.0001004
         }
       }
     }
@@ -947,10 +953,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.0005
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.002
         }
       }
     }
@@ -959,10 +965,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.00008
+          "price": 0.00028
         },
         "reasoning_token": {
           "price": 0.00084
@@ -1022,10 +1028,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00012
+          "price": 0.0000861
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.0003441
         }
       }
     }
@@ -1163,10 +1169,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.00012
         }
       }
     }
@@ -1175,10 +1181,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.00012
         }
       }
     }
@@ -1187,10 +1193,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000287
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.00012
         }
       }
     }
@@ -1235,10 +1241,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000431
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.0001291
+          "price": 0.00032
         }
       }
     }
@@ -1319,10 +1325,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000043
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000072
+          "price": 0.000016
         }
       }
     }
@@ -1331,10 +1337,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.0004
+          "price": 0.00028
         }
       }
     }
@@ -1343,10 +1349,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.00016
+          "price": 0.00028
         }
       }
     }
@@ -1382,7 +1388,7 @@
           "price": 0.00002
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.00008
         }
       }
     }
@@ -1406,7 +1412,7 @@
           "price": 0.000018
         },
         "response_token": {
-          "price": 0.00021
+          "price": 0.00007
         }
       }
     }
@@ -1451,10 +1457,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002294
+          "price": 0.00028
         },
         "response_token": {
-          "price": 0.0006881
+          "price": 0.00084
         }
       }
     }
@@ -1473,6 +1479,9 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
         }
       }
     }
@@ -1491,6 +1500,9 @@
         },
         "response_audio_token": {
           "price": 0.000889
+        },
+        "request_image_token": {
+          "price": 0.000021
         }
       }
     }
@@ -1505,10 +1517,13 @@
           "price": 0.000027
         },
         "request_audio_token": {
-          "price": 0.0003584
+          "price": 0.000444
         },
         "response_audio_token": {
           "price": 0.0007168
+        },
+        "request_image_token": {
+          "price": 0.000021
         }
       }
     }
@@ -1517,10 +1532,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.000444
@@ -1535,10 +1550,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000027
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.000107
+          "price": 0.000027
         },
         "request_audio_token": {
           "price": 0.000444
@@ -1563,6 +1578,9 @@
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
         }
       }
     }
@@ -1581,6 +1599,9 @@
         },
         "response_audio_token": {
           "price": 0.001511
+        },
+        "request_image_token": {
+          "price": 0.000078
         }
       }
     }
@@ -1589,16 +1610,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000052
+          "price": 0.000043
         },
         "response_token": {
-          "price": 0.000199
+          "price": 0.000166
         },
         "request_audio_token": {
-          "price": 0.000457
+          "price": 0.000381
         },
         "response_audio_token": {
-          "price": 0.001813
+          "price": 0.001511
         }
       }
     }
@@ -1625,10 +1646,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000381
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.000306
+          "price": 0.00008
         }
       }
     }
@@ -1793,10 +1814,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.00014
+          "price": 0.00012
         }
       }
     }
@@ -1912,6 +1933,18 @@
       }
     }
   },
+  "qwen-flash-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
   "qwen-flash-us": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -1936,110 +1969,14 @@
       }
     }
   },
-  "qwen3.5-omni-plus": {
+  "qwen-deep-research": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.0007742
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3.5-omni-plus-2026-03-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3.5-omni-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3.5-omni-flash-2026-03-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3.5-omni-plus-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3.5-omni-plus-realtime-2026-03-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3.5-omni-flash-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3.5-omni-flash-realtime-2026-03-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-omni-flash-2025-09-15-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000052
-        },
-        "response_token": {
-          "price": 0.000199
+          "price": 0.0023367
         }
       }
     }
@@ -2080,122 +2017,74 @@
       }
     }
   },
+  "qwen2.5-math-72b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0001721
+        }
+      }
+    }
+  },
+  "qwen2.5-math-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
+  "qwen2.5-math-1.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000861
+        }
+      }
+    }
+  },
   "qwen-vl-ocr-2025-08-28": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000717
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.000016
         }
       }
     }
   },
-  "qwen-vl-ocr-2025-04-13": {
+  "qwen3-235b-a22b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000717
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.0000717
+          "price": 0.00028
         }
       }
     }
   },
-  "qwen-vl-ocr-2024-10-28": {
+  "qwen3-235b-a22b-thinking": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000717
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.0000717
-        }
-      }
-    }
-  },
-  "qwen-doc-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000087
-        },
-        "response_token": {
-          "price": 0.0000144
-        }
-      }
-    }
-  },
-  "qwen-deep-research": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.7742
-        },
-        "response_token": {
-          "price": 2.3367
-        }
-      }
-    }
-  },
-  "qwen3.5-397b-a17b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00036
-        }
-      }
-    }
-  },
-  "qwen3.5-122b-a10b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00004
-        },
-        "response_token": {
-          "price": 0.00032
-        }
-      }
-    }
-  },
-  "qwen3.5-27b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00024
-        }
-      }
-    }
-  },
-  "qwen3.5-35b-a3b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000025
-        },
-        "response_token": {
-          "price": 0.0002
-        }
-      }
-    }
-  },
-  "qwen3-235b-a22b-thinking-2507": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000023
-        },
-        "response_token": {
-          "price": 0.00023
+          "price": 0.00028
         }
       }
     }
@@ -2204,27 +2093,39 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000023
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.000092
+          "price": 0.00028
         }
       }
     }
   },
-  "qwen3-30b-a3b-thinking-2507": {
+  "qwen3-235b-a22b-thinking-2507": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.00028
         }
       }
     }
   },
-  "qwen3-30b-a3b-instruct-2507": {
+  "qwen3-32b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000016
+        },
+        "response_token": {
+          "price": 0.000064
+        }
+      }
+    }
+  },
+  "qwen3-30b-a3b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -2236,7 +2137,67 @@
       }
     }
   },
+  "qwen3-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00008
+        }
+      }
+    }
+  },
+  "qwen3-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.00014
+        }
+      }
+    }
+  },
+  "qwen3-8b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000018
+        },
+        "response_token": {
+          "price": 0.00007
+        }
+      }
+    }
+  },
+  "qwen3-4b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
   "qwen3-4b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
+  "qwen3-1.7b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -2260,6 +2221,18 @@
       }
     }
   },
+  "qwen3-0.6b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000042
+        }
+      }
+    }
+  },
   "qwen3-0.6b": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2272,26 +2245,50 @@
       }
     }
   },
-  "qwen2.5-14b-instruct-1m": {
+  "qwen3.5-397b-a17b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000805
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.000322
+          "price": 0.00036
         }
       }
     }
   },
-  "qwen2.5-7b-instruct-1m": {
+  "qwen3.5-122b-a10b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000368
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.000147
+          "price": 0.00032
+        }
+      }
+    }
+  },
+  "qwen3.5-27b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen3.5-35b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0002
         }
       }
     }
@@ -2348,10 +2345,34 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000044
+          "price": 0.0000087
         },
         "response_token": {
-          "price": 0.000013
+          "price": 0.000035
+        }
+      }
+    }
+  },
+  "qwen2.5-1.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000087
+        },
+        "response_token": {
+          "price": 0.000035
+        }
+      }
+    }
+  },
+  "qwen2.5-0.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000087
+        },
+        "response_token": {
+          "price": 0.000035
         }
       }
     }
@@ -2360,22 +2381,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001721
+          "price": 0.0000574
         },
         "response_token": {
-          "price": 0.0005161
-        }
-      }
-    }
-  },
-  "qwen2.5-omni-7b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0.00004
+          "price": 0.0002294
         }
       }
     }
@@ -2396,10 +2405,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00014
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.00042
+          "price": 0.00028
         }
       }
     }
@@ -2408,10 +2417,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000035
+          "price": 0.0000175
         },
         "response_token": {
-          "price": 0.000105
+          "price": 0.00007
         }
       }
     }
@@ -2420,39 +2429,111 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000021
+          "price": 0.0000087
         },
         "response_token": {
-          "price": 0.000063
+          "price": 0.000035
         }
       }
     }
   },
-  "qwen2.5-math-72b-instruct": {
+  "qwen2-vl-7b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000574
+          "price": 0.0000175
         },
         "response_token": {
-          "price": 0.0001721
+          "price": 0.00007
         }
       }
     }
   },
-  "qwen2.5-math-7b-instruct": {
+  "qwen2-vl-2b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000144
+          "price": 0.0000087
         },
         "response_token": {
-          "price": 0.0000287
+          "price": 0.000035
         }
       }
     }
   },
-  "qwen2.5-coder-32b-instruct": {
+  "qwen2.5-omni-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000035
+        },
+        "response_token": {
+          "price": 0.00014
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-plus-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3.5-omni-flash-2026-03-15": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen3-livetranslate-flash-realtime-2025-09-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000381
+        },
+        "response_token": {
+          "price": 0.000166
+        }
+      }
+    }
+  },
+  "deepseek-v3": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
@@ -2460,54 +2541,6 @@
         },
         "response_token": {
           "price": 0.0000861
-        }
-      }
-    }
-  },
-  "qwen2.5-coder-14b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000287
-        },
-        "response_token": {
-          "price": 0.0000861
-        }
-      }
-    }
-  },
-  "qwen2.5-coder-7b-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000144
-        },
-        "response_token": {
-          "price": 0.0000287
-        }
-      }
-    }
-  },
-  "deepseek-v3.2-exp": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000287
-        },
-        "response_token": {
-          "price": 0.0000431
-        }
-      }
-    }
-  },
-  "deepseek-v3.1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000574
-        },
-        "response_token": {
-          "price": 0.0001721
         }
       }
     }
@@ -2524,54 +2557,6 @@
       }
     }
   },
-  "deepseek-v3": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000287
-        },
-        "response_token": {
-          "price": 0.0001147
-        }
-      }
-    }
-  },
-  "deepseek-r1-distill-qwen-7b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000072
-        },
-        "response_token": {
-          "price": 0.0000144
-        }
-      }
-    }
-  },
-  "deepseek-r1-distill-qwen-14b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000144
-        },
-        "response_token": {
-          "price": 0.0000431
-        }
-      }
-    }
-  },
-  "deepseek-r1-distill-qwen-32b": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0000287
-        },
-        "response_token": {
-          "price": 0.0000861
-        }
-      }
-    }
-  },
   "text-embedding-v4": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2579,7 +2564,7 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0
+          "price": 0.000007
         }
       }
     }
@@ -2591,7 +2576,7 @@
           "price": 0.000007
         },
         "response_token": {
-          "price": 0
+          "price": 0.000007
         }
       }
     }
@@ -2600,10 +2585,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000009
+          "price": 0.0000007
         },
         "response_token": {
-          "price": 0
+          "price": 0.0000007
         }
       }
     }
@@ -2612,10 +2597,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.0000003
         },
         "response_token": {
-          "price": 0
+          "price": 0.0000003
         }
       }
     }
@@ -2627,7 +2612,7 @@
           "price": 0.00001
         },
         "response_token": {
-          "price": 0
+          "price": 0.00001
         }
       }
     }
@@ -2636,22 +2621,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000115
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-vl-embedding": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00001
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.000007
         }
       }
     }
@@ -2660,10 +2633,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000058
+          "price": 0.0000072
         },
         "response_token": {
-          "price": 0.0000144
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "qwen-doc-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000287
         }
       }
     }
@@ -2720,10 +2705,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000345
+          "price": 0.000023
         },
         "response_token": {
-          "price": 0.0001721
+          "price": 0.0001434
         }
       }
     }
@@ -2732,10 +2717,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000345
+          "price": 0.000023
         },
         "response_token": {
-          "price": 0.0001721
+          "price": 0.0001434
         }
       }
     }
@@ -2744,19 +2729,91 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000345
+          "price": 0.000023
         },
         "response_token": {
-          "price": 0.0001721
+          "price": 0.0001434
         }
       }
     }
   },
-  "qwen3-tts-instruct-flash": {
+  "qwen2.5-coder-32b-instruct": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00115
+          "price": 0.0000574
+        },
+        "response_token": {
+          "price": 0.0002294
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-14b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0001147
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-7b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000143
+        },
+        "response_token": {
+          "price": 0.0000574
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000143
+        },
+        "response_token": {
+          "price": 0.0000574
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-1.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000143
+        },
+        "response_token": {
+          "price": 0.0000574
+        }
+      }
+    }
+  },
+  "qwen2.5-coder-0.5b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000143
+        },
+        "response_token": {
+          "price": 0.0000574
+        }
+      }
+    }
+  },
+  "qven-voice-enrollment": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
         },
         "response_token": {
           "price": 0
@@ -2764,35 +2821,11 @@
       }
     }
   },
-  "qwen3-tts-instruct-flash-2026-01-26": {
+  "qwen-voice-design": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00115
-        },
-        "response_token": {
           "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-vd-2026-01-26": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00115
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-vc-2026-01-22": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00115
         },
         "response_token": {
           "price": 0
@@ -2804,10 +2837,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0
+          "price": 0.00001
         }
       }
     }
@@ -2816,10 +2849,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0
+          "price": 0.00001
         }
       }
     }
@@ -2828,10 +2861,34 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000115
+        }
+      }
+    }
+  },
+  "qwen3-tts-instruct-flash-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000115
         }
       }
     }
@@ -2840,106 +2897,34 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00143
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0
+          "price": 0.0000115
         }
       }
     }
   },
-  "qwen3-tts-instruct-flash-realtime-2026-01-22": {
+  "qwen3-tts-vd-2026-01-26": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00143
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0
+          "price": 0.0000115
         }
       }
     }
   },
-  "qwen3-tts-vd-realtime-2026-01-15": {
+  "qwen3-tts-vc-2026-01-22": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00143353
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-vd-realtime-2025-12-16": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00143353
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-vc-realtime-2026-01-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-vc-realtime-2025-11-27": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-realtime": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-realtime-2025-11-27": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-tts-flash-realtime-2025-09-18": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0013
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0000115
         }
       }
     }
@@ -2948,10 +2933,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0026
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0
+          "price": 0.0000115
         }
       }
     }
@@ -2960,10 +2945,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0013
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0
+          "price": 0.00001
         }
       }
     }
@@ -2972,10 +2957,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0022
+          "price": 0.0000115
         },
         "response_token": {
-          "price": 0
+          "price": 0.0000115
         }
       }
     }
@@ -2984,10 +2969,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00116
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0
+          "price": 0.00001
         }
       }
     }
@@ -2996,34 +2981,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00286706
+          "price": 0.000007
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-filetrans": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-filetrans-2025-11-17": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.000007
         }
       }
     }
@@ -3035,7 +2996,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0
+          "price": 0.0035
         }
       }
     }
@@ -3047,7 +3008,7 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0
+          "price": 0.0035
         }
       }
     }
@@ -3059,7 +3020,31 @@
           "price": 0.0035
         },
         "response_token": {
-          "price": 0
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-filetrans-2025-11-17": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0035
+        },
+        "response_token": {
+          "price": 0.0035
         }
       }
     }
@@ -3071,31 +3056,7 @@
           "price": 0.009
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-realtime-2026-02-10": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
           "price": 0.009
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-asr-flash-realtime-2025-10-27": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.009
-        },
-        "response_token": {
-          "price": 0
         }
       }
     }
@@ -3104,10 +3065,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0035
+          "price": 0.0014
         },
         "response_token": {
-          "price": 0
+          "price": 0.0014
         }
       }
     }
@@ -3116,10 +3077,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0035
+          "price": 0.0014
         },
         "response_token": {
-          "price": 0
+          "price": 0.0014
         }
       }
     }
@@ -3128,10 +3089,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0035
+          "price": 0.0014
         },
         "response_token": {
-          "price": 0
+          "price": 0.0014
         }
       }
     }
@@ -3140,22 +3101,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0035
+          "price": 0.0014
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "fun-asr-mtl-2025-08-25": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.0035
-        },
-        "response_token": {
-          "price": 0
+          "price": 0.0014
         }
       }
     }
@@ -3164,10 +3113,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.009
+          "price": 0.0028
         },
         "response_token": {
-          "price": 0
+          "price": 0.0028
         }
       }
     }
@@ -3176,10 +3125,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.009
+          "price": 0.0028
         },
         "response_token": {
-          "price": 0
+          "price": 0.0028
+        }
+      }
+    }
+  },
+  "fun-asr-flash-8k-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0028
+        },
+        "response_token": {
+          "price": 0.0028
         }
       }
     }
@@ -3188,10 +3149,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0012
+          "price": 0.0014
         },
         "response_token": {
-          "price": 0
+          "price": 0.0014
         }
       }
     }
@@ -3200,10 +3161,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0012
+          "price": 0.0014
         },
         "response_token": {
-          "price": 0
+          "price": 0.0014
         }
       }
     }
@@ -3212,10 +3173,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0035
+          "price": 0.0028
         },
         "response_token": {
-          "price": 0
+          "price": 0.0028
         }
       }
     }
@@ -3224,310 +3185,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0035
+          "price": 0.0028
         },
         "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "qwen3-livetranslate-flash-realtime-2025-09-22": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.001
-        },
-        "response_token": {
-          "price": 0.001
-        }
-      }
-    }
-  },
-  "qwen-image-2.0-pro": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-2.0-pro-2026-03-03": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-2.0": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3.5
-        }
-      }
-    }
-  },
-  "qwen-image-2.0-2026-03-03": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3.5
-        }
-      }
-    }
-  },
-  "qwen-image-max": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-max-2025-12-30": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "qwen-image-plus-2026-01-09": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "qwen-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3.5
-        }
-      }
-    }
-  },
-  "qwen-image-edit-max": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-edit-max-2026-01-16": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 7.5
-        }
-      }
-    }
-  },
-  "qwen-image-edit-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "qwen-image-edit-plus-2025-12-15": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "qwen-image-edit-plus-2025-10-30": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "qwen-image-edit": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 4.5
-        }
-      }
-    }
-  },
-  "z-image-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 1.5
-        }
-      }
-    }
-  },
-  "wan2.6-t2i": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "wan2.5-t2i-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "wan2.2-t2i-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 5
-        }
-      }
-    }
-  },
-  "wan2.2-t2i-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 2.5
-        }
-      }
-    }
-  },
-  "wan2.1-t2i-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 5
-        }
-      }
-    }
-  },
-  "wan2.1-t2i-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 2.5
-        }
-      }
-    }
-  },
-  "wan2.6-image": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3
-        }
-      }
-    }
-  },
-  "wan2.5-i2i-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3
+          "price": 0.0028
         }
       }
     }
@@ -3536,58 +3197,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 7
         },
         "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.5-t2v-preview": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.2-t2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 2
-        }
-      }
-    }
-  },
-  "wan2.1-t2v-turbo": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3.6
-        }
-      }
-    }
-  },
-  "wan2.1-t2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 10
+          "price": 7
         }
       }
     }
@@ -3596,22 +3209,58 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 7
         },
         "response_token": {
-          "price": 10
+          "price": 7
         }
       }
     }
   },
-  "wan2.6-i2v-flash": {
+  "wan2.5-t2v-preview": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 5
         },
         "response_token": {
-          "price": 2.5
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 7
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "wan2.1-t2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 7
         }
       }
     }
@@ -3620,46 +3269,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 7
         },
         "response_token": {
-          "price": 10
+          "price": 7
         }
       }
     }
   },
-  "wan2.5-i2v-preview": {
+  "wan2.6-i2v-flash": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 3.5
         },
         "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan2.2-i2v-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 3.6
-        }
-      }
-    }
-  },
-  "wan2.2-i2v-plus": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 2
+          "price": 3.5
         }
       }
     }
@@ -3668,10 +3293,46 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 7
         },
         "response_token": {
-          "price": 10
+          "price": 7
+        }
+      }
+    }
+  },
+  "wan2.5-i2v-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5
+        },
+        "response_token": {
+          "price": 5
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 7
+        }
+      }
+    }
+  },
+  "wan2.2-i2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
         }
       }
     }
@@ -3680,10 +3341,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 3.5
         },
         "response_token": {
-          "price": 3.6
+          "price": 3.5
         }
       }
     }
@@ -3692,22 +3353,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 7
         },
         "response_token": {
-          "price": 10
-        }
-      }
-    }
-  },
-  "wan.6-r2v-flash": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 2.5
+          "price": 7
         }
       }
     }
@@ -3716,10 +3365,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 7
         },
         "response_token": {
-          "price": 10
+          "price": 7
+        }
+      }
+    }
+  },
+  "wan.6-r2v-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
         }
       }
     }
@@ -3728,10 +3389,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 7
         },
         "response_token": {
-          "price": 10
+          "price": 7
         }
       }
     }
@@ -3740,10 +3401,22 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 7
         },
         "response_token": {
-          "price": 12.9018
+          "price": 7
+        }
+      }
+    }
+  },
+  "wan2.2-s2v-detect": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.7
+        },
+        "response_token": {
+          "price": 0.7
         }
       }
     }
@@ -3752,10 +3425,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 7
         },
         "response_token": {
-          "price": 12
+          "price": 7
         }
       }
     }
@@ -3764,10 +3437,490 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 7
         },
         "response_token": {
-          "price": 18
+          "price": 7
+        }
+      }
+    }
+  },
+  "liveportrait": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "videoretalk": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "video-style-transform": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 7
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 4
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-pro-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 4
+        }
+      }
+    }
+  },
+  "qwen-image-2.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "qwen-image-2.0-2026-03-03": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "qwen-image-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 4
+        }
+      }
+    }
+  },
+  "qwen-image-max-2025-12-30": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 4
+        }
+      }
+    }
+  },
+  "qwen-image-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "qwen-image-plus-2026-01-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "qwen-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 4
+        }
+      }
+    }
+  },
+  "qwen-image-edit-max-2026-01-16": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 4
+        }
+      }
+    }
+  },
+  "qwen-image-edit-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "qwen-image-edit": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "z-image-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "wan2.6-t2i": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 4
+        }
+      }
+    }
+  },
+  "wan2.5-t2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 4
+        }
+      }
+    }
+  },
+  "wan2.2-t2i-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 4
+        }
+      }
+    }
+  },
+  "wan2.1-t2i-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "wan2.6-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 4
+        },
+        "response_token": {
+          "price": 4
+        }
+      }
+    }
+  },
+  "wan2.5-i2i-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2
+        },
+        "response_token": {
+          "price": 2
+        }
+      }
+    }
+  },
+  "emo-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 7
+        }
+      }
+    }
+  },
+  "emoji-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3.5
+        },
+        "response_token": {
+          "price": 3.5
+        }
+      }
+    }
+  },
+  "animate-anyone-gen2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 7
+        },
+        "response_token": {
+          "price": 7
+        }
+      }
+    }
+  },
+  "qwen3-vl-embedding": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.000007
+        }
+      }
+    }
+  },
+  "deepseek-v3.2-exp": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000431
+        }
+      }
+    }
+  },
+  "deepseek-v3.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000287
+        },
+        "response_token": {
+          "price": 0.0000431
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-32b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000143
+        },
+        "response_token": {
+          "price": 0.0000574
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-14b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000143
+        },
+        "response_token": {
+          "price": 0.0000574
+        }
+      }
+    }
+  },
+  "deepseek-r1-distill-qwen-7b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000072
+        },
+        "response_token": {
+          "price": 0.0000287
+        }
+      }
+    }
+  },
+  "qwen3-tts-flash-realtime": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000115
+        }
+      }
+    }
+  },
+  "qwen3-tts-vd-realtime-2026-01-26": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000115
+        }
+      }
+    }
+  },
+  "qwen3-tts-vc-realtime-2026-01-22": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000115
+        },
+        "response_token": {
+          "price": 0.0000115
+        }
+      }
+    }
+  },
+  "qwen-vl-max-2024-11-19": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00008
+        },
+        "response_token": {
+          "price": 0.00032
+        }
+      }
+    }
+  },
+  "qwen-vl-plus-2024-08-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000021
+        },
+        "response_token": {
+          "price": 0.000063
+        }
+      }
+    }
+  },
+  "qwen3-asr-flash-realtime-2025-09-08": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.009
+        },
+        "response_token": {
+          "price": 0.009
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: dashscope

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 168 |
| 🔄 Models updated (merged) | 37 |

### ➕ New Models
- `qwen-plus-us`
- `qwen-plus-2025-12-01-us`
- `qwen-flash-latest`
- `qwen-flash-us`
- `qwen-flash-2025-07-28-us`
- `qwen-deep-research`
- `qwen3-vl-flash-us`
- `qwen3-vl-flash-2026-01-22-us`
- `qwen3-vl-flash-2025-10-15-us`
- `qwen2.5-math-72b-instruct`
- `qwen2.5-math-7b-instruct`
- `qwen2.5-math-1.5b-instruct`
- `qwen-vl-ocr-2025-08-28`
- `qwen3-235b-a22b-instruct`
- `qwen3-235b-a22b-thinking`
- `qwen3-235b-a22b-instruct-2507`
- `qwen3-235b-a22b-thinking-2507`
- `qwen3-32b-instruct`
- `qwen3-30b-a3b-instruct`
- `qwen3-30b-a3b-thinking`
- ... and 148 more

### 🔄 Updated Models
- `qvq-plus`
- `qvq-plus-latest`
- `qvq-plus-2025-05-15`
- `qwen3-coder-next`
- `qwen-vl-ocr-latest`
- `qwen3-32b`
- `qwen3-next-80b-a3b-instruct`
- `qwq-32b`
- `qwq-32b-preview`
- `qwen3-vl-235b-a22b-instruct`
- `qwen3-vl-235b-a22b-thinking`
- `qwen3-vl-30b-a3b-thinking`
- `qwen3-vl-8b-thinking`
- `qwen2-vl-72b-instruct`
- `qwen3-omni-flash`
- `qwen3-omni-flash-2025-12-01`
- `qwen3-omni-flash-2025-09-15`
- `qwen-omni-turbo`
- `qwen-omni-turbo-latest`
- `qwen-omni-turbo-2025-03-26`
- `qwen-omni-turbo-2025-01-19`
- `qwen3-omni-flash-realtime`
- `qwen-omni-turbo-realtime`
- `qwen-omni-turbo-realtime-latest`
- `qwen-omni-turbo-realtime-2025-05-08`
- `qwen3-omni-30b-a3b-captioner`
- `qwen3-livetranslate-flash-realtime`
- `deepseek-v3.2`
- `glm-4.6`
- `qwen-plus-character`
- ... and 7 more


## Model-to-Pricing-Page Mapping

### Sources
- **Page 1**: https://www.alibabacloud.com/help/en/model-studio/models — Commercial Qwen tiers
- **Page 2**: https://www.alibabacloud.com/help/en/model-studio/model-pricing — All other models (open-source, speech, video, image, embeddings, third-party)

### Regional Priority Applied
International → Global → Chinese Mainland (fallback) per model

### Notable Pricing Rules
- **Tiered pricing**: Lowest tier used as default (e.g. qwen3-max 0–32K: $1.2/$6.0)
- **Non-thinking rates**: Used where both thinking/non-thinking exist for same model ID
- **qwen-deep-research**: `per_thousand_tokens` (not per_million) — $0.007742/$0.023367 per 1K tokens
- **TTS models**: `per_million_characters` (scaled from per 10K chars on page)
- **ASR/Video models**: `per_second`
- **Image models**: `per_image`
- **Mainland-only models**: qwen-long, qvq-plus, qwen-math-*, qwen-coder (old), qwen-deep-research, qwen2.5-math-*, paraformer-*, tongyi-intent-detect-v3, gte-rerank-v2, qwen-doc-turbo, deepseek-*, kimi-*, MiniMax-*, GLM-*

### Model Families Covered (~283 models)
- Flagship: qwen3-max, qwen3.5-plus/flash
- Commercial Qwen: qwen-max/plus/flash/turbo + US variants + dated snapshots
- QwQ/QVQ commercial + open-source
- Open-source Qwen3 (0.6b–235b), Qwen3.5 (27b–397b), Qwen2.5 (0.5b–72b)
- Open-source VL: qwen3-vl-*/qwen2.5-vl-*/qwen2-vl-*
- Omni/multimodal: qwen3-omni-flash, qwen-omni-turbo, qwen3.5-omni-*, realtime variants
- Coder: qwen3-coder-*/qwen2.5-coder-*/qwen-coder-*
- Math: qwen-math-*/qwen2.5-math-*
- Translation: qwen-mt-plus/flash/lite/turbo
- OCR: qwen-vl-ocr
- VL commercial: qwen3-vl-plus/flash, qwen-vl-max/plus
- TTS: qwen3-tts-*, qwen-tts-*, cosyvoice-*
- ASR: qwen3-asr-*, fun-asr-*, paraformer-*
- LiveTranslate: qwen3-livetranslate-flash-realtime
- Embeddings: text-embedding-v3/v4, tongyi-embedding-vision-*, qwen3-vl-embedding
- Rerank: qwen3-rerank, gte-rerank-v2
- Domain: tongyi-intent-detect-v3, qwen-*-character, qwen-doc-turbo
- Image gen: qwen-image-*, wan2.*-t2i-*, z-image-turbo
- Video gen: wan2.*-t2v-*, wan2.*-i2v-*, wan2.*-kf2v-*, wan2.*-r2v-*, wan2.*-vace-*, digital human models
- Third-party: deepseek-*, kimi-*, MiniMax-M2.5, glm-*

---
*Generated by Pricing Agent on 2026-04-27*