### PR TITLE
chore(pricing): Update deepseek pricing

### DIFF
--- a/general/deepseek.json
+++ b/general/deepseek.json
@@ -19,5 +19,15 @@
   },
   "deepseek-reasoner": {
     "type": { "primary": "chat" }
+  },
+  "deepseek-v4-flash": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "deepseek-v4-pro": {
+    "type": {
+      "primary": "chat"
+    }
   }
 }

--- a/pricing/deepseek.json
+++ b/pricing/deepseek.json
@@ -40,10 +40,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000028
+          "price": 0.000014
         },
         "response_token": {
-          "price": 0.000042
+          "price": 0.000028
         },
         "cache_write_input_token": {
           "price": 0
@@ -58,10 +58,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000028
+          "price": 0.000014
         },
         "response_token": {
-          "price": 0.000042
+          "price": 0.000028
         },
         "cache_write_input_token": {
           "price": 0

--- a/pricing/deepseek.json
+++ b/pricing/deepseek.json
@@ -40,10 +40,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000014
+          "price": 0.000028
         },
         "response_token": {
-          "price": 0.000028
+          "price": 0.000042
         },
         "cache_write_input_token": {
           "price": 0
@@ -58,16 +58,46 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000014
+          "price": 0.000028
         },
         "response_token": {
-          "price": 0.000028
+          "price": 0.000042
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
           "price": 0.0000028
+        }
+      }
+    }
+  },
+  "deepseek-v4-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000014
+        },
+        "response_token": {
+          "price": 0.000028
+        },
+        "cache_read_input_token": {
+          "price": 0.0000028
+        }
+      }
+    }
+  },
+  "deepseek-v4-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000174
+        },
+        "response_token": {
+          "price": 0.000348
+        },
+        "cache_read_input_token": {
+          "price": 0.0000145
         }
       }
     }

--- a/pricing/deepseek.json
+++ b/pricing/deepseek.json
@@ -91,13 +91,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000174
+          "price": 0.0000435
         },
         "response_token": {
-          "price": 0.000348
+          "price": 0.000087
         },
         "cache_read_input_token": {
-          "price": 0.0000145
+          "price": 0.000003625
         }
       }
     }

--- a/pricing/deepseek.json
+++ b/pricing/deepseek.json
@@ -82,7 +82,7 @@
           "price": 0.000028
         },
         "cache_read_input_token": {
-          "price": 0.0000028
+          "price": 0.00000028
         }
       }
     }
@@ -97,7 +97,7 @@
           "price": 0.000087
         },
         "cache_read_input_token": {
-          "price": 0.000003625
+          "price": 0.0000003625
         }
       }
     }


### PR DESCRIPTION
## 🔄 Pricing Update: deepseek

### 📊 Summary (complete_diff mode)

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 2 |
| 🔄 Models updated (merged) | 0 |

### ➕ New Models
- `deepseek-v4-flash`
- `deepseek-v4-pro`



## Model → Pricing Page Mapping

| Model ID | Pricing Row | Notes |
|----------|-------------|-------|
| `deepseek-v4-flash` | DeepSeek-V4-Flash | Cache miss input $0.14, cache hit $0.0028, output $0.28 per 1M tokens |
| `deepseek-v4-pro` | DeepSeek-V4-Pro | Limited-time 75% off until 2026/05/05: input $0.435 (was $1.74), cache hit $0.003625 (was $0.0145), output $0.87 (was $3.48) per 1M tokens |

> Note: `deepseek-chat` and `deepseek-reasoner` are being deprecated; they map to non-thinking and thinking modes of `deepseek-v4-flash` respectively.

---
*Generated by Pricing Agent on 2026-04-27*