### PR TITLE
chore: Update x-ai pricing and config

### DIFF
--- a/general/x-ai.json
+++ b/general/x-ai.json
@@ -329,5 +329,17 @@
         "tools"
       ]
     }
+  },
+  "grok-imagine-image-quality-20260403": {
+    "type": {
+      "primary": "image_generation"
+    },
+    "disablePlayground": true
+  },
+  "grok-imagine-image-quality": {
+    "type": {
+      "primary": "image_generation"
+    },
+    "disablePlayground": true
   }
 }

--- a/general/x-ai.json
+++ b/general/x-ai.json
@@ -322,7 +322,7 @@
       ]
     }
   },
-  "latest": {
+  "grok-latest": {
     "type": {
       "primary": "chat",
       "supported": [

--- a/general/x-ai.json
+++ b/general/x-ai.json
@@ -329,5 +329,23 @@
         "tools"
       ]
     }
+  },
+  "grok-imagine-image-quality": {
+    "type": {
+      "primary": "image_generation"
+    },
+    "disablePlayground": true
+  },
+  "grok-imagine-image-quality-20260403": {
+    "type": {
+      "primary": "image_generation"
+    },
+    "disablePlayground": true
+  },
+  "grok-imagine-image-quality-latest": {
+    "type": {
+      "primary": "image_generation"
+    },
+    "disablePlayground": true
   }
 }

--- a/general/x-ai.json
+++ b/general/x-ai.json
@@ -330,6 +330,38 @@
       ]
     }
   },
+  "grok-3-mini-high": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "grok-3-mini-high-beta": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "grok-3-mini-fast-high": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "grok-3-mini-fast-high-beta": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "grok-imagine-image-quality": {
     "type": {
       "primary": "image_generation"

--- a/general/x-ai.json
+++ b/general/x-ai.json
@@ -362,6 +362,14 @@
       ]
     }
   },
+  "grok-build-0.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
   "grok-imagine-image-quality": {
     "type": {
       "primary": "image_generation"

--- a/general/x-ai.json
+++ b/general/x-ai.json
@@ -329,17 +329,5 @@
         "tools"
       ]
     }
-  },
-  "grok-imagine-image-quality-20260403": {
-    "type": {
-      "primary": "image_generation"
-    },
-    "disablePlayground": true
-  },
-  "grok-imagine-image-quality": {
-    "type": {
-      "primary": "image_generation"
-    },
-    "disablePlayground": true
   }
 }

--- a/general/x-ai.json
+++ b/general/x-ai.json
@@ -321,5 +321,13 @@
         "tools"
       ]
     }
+  },
+  "latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
   }
 }

--- a/general/x-ai.json
+++ b/general/x-ai.json
@@ -305,5 +305,21 @@
         "tools"
       ]
     }
+  },
+  "grok-4.3": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "grok-4.3-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
   }
 }

--- a/general/x-ai.json
+++ b/general/x-ai.json
@@ -285,81 +285,55 @@
   "grok-4.20-reasoning-latest": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "grok-4.20-non-reasoning-gv2": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "grok-4.20-reasoning-gv2": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "grok-4.3": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["image", "video", "tools"]
     }
   },
   "grok-4.3-latest": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["image", "video", "tools"]
     }
   },
-  "grok-latest": {
+  "grok-4.5": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     }
   },
-  "grok-3-mini-high": {
+  "grok-4.5-latest": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     }
   },
-  "grok-3-mini-high-beta": {
+  "grok-build-latest": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     }
   },
-  "grok-3-mini-fast-high": {
+  "grok-4.6": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
-    }
-  },
-  "grok-3-mini-fast-high-beta": {
-    "type": {
-      "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     }
   },
   "grok-build-0.1": {
@@ -369,6 +343,12 @@
         "tools"
       ]
     }
+  },
+  "grok-imagine-image-2.0": {
+    "type": {
+      "primary": "image_generation"
+    },
+    "disablePlayground": true
   },
   "grok-imagine-image-quality": {
     "type": {

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -1183,29 +1183,5 @@
         }
       }
     }
-  },
-  "grok-imagine-image-quality-20260403": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
-  },
-  "grok-imagine-image-quality": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0
-        },
-        "response_token": {
-          "price": 0
-        }
-      }
-    }
   }
 }

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -1183,5 +1183,29 @@
         }
       }
     }
+  },
+  "grok-imagine-image-quality-20260403": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "grok-imagine-image-quality": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
   }
 }

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -306,10 +306,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0002
         }
       }
     }
@@ -516,10 +516,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0002
         },
         "cache_read_input_token": {
           "price": 0.000002
@@ -531,10 +531,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0002
         },
         "cache_read_input_token": {
           "price": 0.000002

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -1169,7 +1169,7 @@
       }
     }
   },
-  "latest": {
+  "grok-latest": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -93,10 +93,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.00025
         }
       }
     }
@@ -106,10 +106,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.00025
         }
       }
     }
@@ -119,10 +119,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.00025
         }
       }
     }
@@ -306,10 +306,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00025
         }
       }
     }
@@ -396,10 +396,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000005
@@ -411,10 +411,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000005
@@ -426,10 +426,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000005
@@ -471,10 +471,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000005
@@ -486,10 +486,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000005
@@ -501,10 +501,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000005
@@ -516,10 +516,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000002
@@ -531,10 +531,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000002

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -132,10 +132,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.00025
         }
       }
     }
@@ -145,10 +145,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.00025
         }
       }
     }
@@ -158,10 +158,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.00025
         }
       }
     }
@@ -171,10 +171,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         }
       }
     }
@@ -184,10 +184,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         }
       }
     }
@@ -197,10 +197,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         }
       }
     }
@@ -210,10 +210,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000075
@@ -226,10 +226,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000075
@@ -242,10 +242,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000075
@@ -258,10 +258,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.0000075
@@ -274,10 +274,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.0000075
@@ -290,10 +290,10 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.0000075
@@ -1170,6 +1170,66 @@
     }
   },
   "grok-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "grok-3-mini-high": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "grok-3-mini-high-beta": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "grok-3-mini-fast-high": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "grok-3-mini-fast-high-beta": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -1168,5 +1168,20 @@
         }
       }
     }
+  },
+  "latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    }
   }
 }

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -366,10 +366,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000005
@@ -381,10 +381,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000005
@@ -441,10 +441,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000005
@@ -456,10 +456,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.000005

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -1244,6 +1244,21 @@
       }
     }
   },
+  "grok-build-0.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0002
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
   "grok-imagine-image-quality": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -1183,5 +1183,41 @@
         }
       }
     }
+  },
+  "grok-imagine-image-quality": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "grok-imagine-image-quality-20260403": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "grok-imagine-image-quality-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
   }
 }

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -618,10 +618,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -633,10 +633,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -648,10 +648,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -663,10 +663,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -678,10 +678,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -693,10 +693,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -708,10 +708,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -723,10 +723,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -798,10 +798,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -813,10 +813,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -828,10 +828,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -843,10 +843,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -858,10 +858,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -873,10 +873,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -888,10 +888,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -933,10 +933,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -948,10 +948,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -963,10 +963,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -978,10 +978,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -1008,10 +1008,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -1023,10 +1023,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -1038,10 +1038,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -1098,10 +1098,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -1113,10 +1113,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -1128,10 +1128,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -1138,5 +1138,35 @@
         }
       }
     }
+  },
+  "grok-4.3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "grok-4.3-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    }
   }
 }

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -768,10 +768,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -783,10 +783,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -903,10 +903,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -918,10 +918,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -1053,10 +1053,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -1068,10 +1068,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002
@@ -1083,10 +1083,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         },
         "cache_read_input_token": {
           "price": 0.00002

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -7,6 +7,23 @@
         },
         "response_token": {
           "price": 0
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       },
       "calculate": {
@@ -45,6 +62,23 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -58,6 +92,23 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -71,6 +122,23 @@
         },
         "response_token": {
           "price": 0.0015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -84,6 +152,23 @@
         },
         "response_token": {
           "price": 0.0015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -93,10 +178,27 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -106,10 +208,27 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -119,10 +238,27 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -132,10 +268,27 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -145,10 +298,27 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -158,10 +328,27 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -171,10 +358,27 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -184,10 +388,27 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -197,10 +418,27 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -210,13 +448,30 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0015
         },
         "cache_read_input_token": {
           "price": 0.000075
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -226,13 +481,30 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0015
         },
         "cache_read_input_token": {
           "price": 0.000075
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -242,13 +514,30 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0015
         },
         "cache_read_input_token": {
           "price": 0.000075
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -258,13 +547,30 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.0000075
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -274,13 +580,30 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.0000075
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -290,13 +613,30 @@
       "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.0000075
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -309,7 +649,24 @@
           "price": 0.0001
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -322,6 +679,23 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -334,6 +708,23 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -346,6 +737,23 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -358,6 +766,23 @@
         },
         "response_token": {
           "price": 0.001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -366,13 +791,30 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -381,13 +823,30 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -396,13 +855,30 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -411,13 +887,30 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -426,13 +919,30 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -441,13 +951,30 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -456,13 +983,30 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -471,13 +1015,30 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -486,13 +1047,30 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -501,13 +1079,30 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "cache_read_input_token": {
           "price": 0.000005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -519,10 +1114,27 @@
           "price": 0.0001
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00015
         },
         "cache_read_input_token": {
           "price": 0.000002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -534,10 +1146,27 @@
           "price": 0.0001
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00015
         },
         "cache_read_input_token": {
           "price": 0.000002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -621,10 +1250,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -636,10 +1282,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -651,10 +1314,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -666,10 +1346,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -681,10 +1378,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -696,10 +1410,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -711,10 +1442,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -726,10 +1474,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -745,6 +1510,23 @@
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -760,6 +1542,23 @@
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -771,10 +1570,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -786,10 +1602,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -801,10 +1634,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -816,10 +1666,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -831,10 +1698,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -846,10 +1730,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -861,10 +1762,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -876,10 +1794,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -891,10 +1826,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -906,10 +1858,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -921,10 +1890,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -936,10 +1922,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -951,10 +1954,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -966,10 +1986,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -981,10 +2018,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -1000,6 +2054,23 @@
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -1011,10 +2082,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -1026,10 +2114,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -1041,10 +2146,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -1056,10 +2178,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -1071,10 +2210,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -1086,10 +2242,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -1101,10 +2274,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -1116,10 +2306,27 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -1131,16 +2338,34 @@
           "price": 0.000125
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
   },
   "grok-4.3": {
     "pricing_config": {
+      "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
           "price": 0.000125
@@ -1150,12 +2375,30 @@
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
   },
   "grok-4.3-latest": {
     "pricing_config": {
+      "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
           "price": 0.000125
@@ -1165,81 +2408,155 @@
         },
         "cache_read_input_token": {
           "price": 0.00002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
   },
-  "grok-latest": {
+  "grok-4.5": {
     "pricing_config": {
+      "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
   },
-  "grok-3-mini-high": {
+  "grok-4.5-latest": {
     "pricing_config": {
+      "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
   },
-  "grok-3-mini-high-beta": {
+  "grok-build-latest": {
     "pricing_config": {
+      "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 0.00003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
   },
-  "grok-3-mini-fast-high": {
+  "grok-4.6": {
     "pricing_config": {
+      "currency": "USD",
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.00025
+          "price": 0.0006
         },
         "cache_read_input_token": {
-          "price": 0.00002
-        }
-      }
-    }
-  },
-  "grok-3-mini-fast-high-beta": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000125
+          "price": 0.00005
         },
-        "response_token": {
-          "price": 0.00025
-        },
-        "cache_read_input_token": {
-          "price": 0.00002
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
         }
       }
     }
@@ -1255,6 +2572,18 @@
         },
         "cache_read_input_token": {
           "price": 0.00002
+        }
+      }
+    }
+  },
+  "grok-imagine-image-2.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Models Update: x-ai

### 📊 Summary

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 5 |
| 🔄 Prices updated | 35 |
| 📋 General configs added | 5 |

### ➕ New Models
- `grok-build-0.1`
- `grok-imagine-image-2.0`
- `grok-imagine-image-quality`
- `grok-imagine-image-quality-20260403`
- `grok-imagine-image-quality-latest`

### 🔄 Updated Prices
- `grok-4.20-0309-non-reasoning`
- `grok-4.20-non-reasoning`
- `grok-4.20-non-reasoning-latest`
- `grok-4.20-beta-non-reasoning`
- `grok-4.20-beta-latest-non-reasoning`
- `grok-4.20-experimental-beta-0304-non-reasoning`
- `grok-4.20-experimental-beta-non-reasoning-latest`
- `grok-4.20-beta-0309-non-reasoning`
- `grok-4.20-non-reasoning-gv2`
- `grok-4.20-0309-reasoning`
- `grok-4.20-reasoning-latest`
- `grok-4.20`
- `grok-4.20-reasoning`
- `grok-4.20-0309`
- `grok-4.20-beta-0309-reasoning`
- `grok-4.20-beta`
- `grok-4.20-beta-0309`
- `grok-4.20-beta-latest`
- `grok-4.20-beta-latest-reasoning`
- `grok-4.20-beta-reasoning`
- `grok-4.20-experimental-beta-0304-reasoning`
- `grok-4.20-experimental-beta-0304`
- `grok-4.20-experimental-beta-reasoning-latest`
- `grok-4.20-experimental-beta-latest`
- `grok-4.20-reasoning-gv2`
- `grok-4.20-multi-agent-0309`
- `grok-4.20-multi-agent`
- `grok-4.20-multi-agent-latest`
- `grok-4.20-multi-agent-beta-latest`
- `grok-4.20-multi-agent-experimental-beta-0304`
- ... and 5 more

### 📋 New General Configs
- `grok-build-0.1`
- `grok-imagine-image-2.0`
- `grok-imagine-image-quality`
- `grok-imagine-image-quality-20260403`
- `grok-imagine-image-quality-latest`


---
*Generated by Direct Converter on 2026-09-20*