### PR TITLE
chore: Update openrouter pricing and config

### DIFF
--- a/general/openrouter.json
+++ b/general/openrouter.json
@@ -5371,5 +5371,523 @@
         "maxValue": 65000
       }
     ]
+  },
+  "baidu/cobuddy:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
+  "openai/gpt-chat-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "x-ai/grok-4.3": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
+  },
+  "ibm-granite/granite-4.1-8b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 131072
+      }
+    ]
+  },
+  "mistralai/mistral-medium-3-5": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
+  },
+  "openrouter/owl-alpha": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 262144
+      }
+    ]
+  },
+  "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
+  "poolside/laguna-xs.2:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      }
+    ]
+  },
+  "poolside/laguna-m.1:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      }
+    ]
+  },
+  "~anthropic/claude-haiku-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 64000
+      }
+    ]
+  },
+  "~openai/gpt-mini-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "~google/gemini-pro-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
+  "~moonshotai/kimi-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 16384
+      }
+    ]
+  },
+  "~google/gemini-flash-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
+  "~anthropic/claude-sonnet-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "~openai/gpt-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "qwen/qwen3.5-plus-20260420": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
+  "qwen/qwen3.6-flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
+  "qwen/qwen3.6-35b-a3b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 262144
+      }
+    ]
+  },
+  "qwen/qwen3.6-max-preview": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
+  "qwen/qwen3.6-27b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 81920
+      }
+    ]
+  },
+  "openai/gpt-5.5-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "openai/gpt-5.5": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "deepseek/deepseek-v4-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 384000
+      }
+    ]
+  },
+  "deepseek/deepseek-v4-flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 384000
+      }
+    ]
+  },
+  "inclusionai/ling-2.6-1t:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
+      }
+    ]
+  },
+  "tencent/hy3-preview:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 262144
+      }
+    ]
+  },
+  "xiaomi/mimo-v2.5-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 131072
+      }
+    ]
+  },
+  "xiaomi/mimo-v2.5": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 131072
+      }
+    ]
+  },
+  "openai/gpt-5.4-image-2": {
+    "type": {
+      "primary": "image",
+      "supported": [
+        "image"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ],
+    "disablePlayground": true
+  },
+  "inclusionai/ling-2.6-flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
+      }
+    ]
+  },
+  "~anthropic/claude-opus-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "openrouter/pareto-code": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "baidu/qianfan-ocr-fast:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 28672
+      }
+    ]
+  },
+  "moonshotai/kimi-k2.6": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 16384
+      }
+    ]
+  },
+  "arcee-ai/trinity-large-preview": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "microsoft/phi-4-mini-instruct": {
+    "type": {
+      "primary": "chat"
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "google/gemini-embedding-2-preview": {
+    "type": {
+      "primary": "embedding",
+      "supported": [
+        "image"
+      ]
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -148,10 +148,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.0000287
         },
         "response_token": {
-          "price": 0.00012
+          "price": 0.0000431
         }
       }
     }
@@ -160,10 +160,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000026
+          "price": 0.0000252
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.0000378
         }
       }
     }
@@ -844,10 +844,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000021
+          "price": 0.000027
         },
         "response_token": {
-          "price": 0.000079
+          "price": 0.000095
         }
       }
     }
@@ -1291,7 +1291,7 @@
           "price": 0.0000039
         },
         "response_token": {
-          "price": 0.000019
+          "price": 0.000018
         }
       }
     }
@@ -1459,7 +1459,7 @@
           "price": 0.000022
         },
         "response_token": {
-          "price": 0.0001
+          "price": 0.00018
         }
       }
     }
@@ -2092,10 +2092,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000009
         },
         "response_token": {
-          "price": 0.000028
+          "price": 0.000045
         }
       }
     }
@@ -2788,10 +2788,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.00008
+          "price": 0.000075
         }
       }
     }
@@ -3352,10 +3352,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000012
+          "price": 0.000036
         },
         "response_token": {
-          "price": 0.000039
+          "price": 0.00004
         }
       }
     }
@@ -3571,7 +3571,7 @@
           "price": 0.000002
         },
         "response_token": {
-          "price": 0.000004
+          "price": 0.000003
         }
       }
     }
@@ -3772,7 +3772,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000003
+          "price": 0.000004
         },
         "response_token": {
           "price": 0.000004
@@ -4108,10 +4108,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003827
+          "price": 0.000044
         },
         "response_token": {
-          "price": 0.000172
+          "price": 0.0002
         }
       }
     }
@@ -4300,10 +4300,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000039
+          "price": 0.000038
         },
         "response_token": {
-          "price": 0.000175
+          "price": 0.000174
         }
       }
     }
@@ -4612,10 +4612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000118
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.000099
+          "price": 0.000115
         }
       }
     }
@@ -4624,10 +4624,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000072
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.00023
+          "price": 0.000192
         }
       }
     }
@@ -4672,7 +4672,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000011
         },
         "response_token": {
           "price": 0.00008
@@ -4744,10 +4744,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001625
+          "price": 0.000015
         },
         "response_token": {
-          "price": 0.00013
+          "price": 0.0001
         }
       }
     }
@@ -5284,7 +5284,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.00001
         },
         "response_token": {
           "price": 0.000015
@@ -5320,10 +5320,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000095
+          "price": 0.000105
         },
         "response_token": {
-          "price": 0.000315
+          "price": 0.00035
         }
       }
     }
@@ -5344,10 +5344,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000007
+          "price": 0.000006
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000033
         }
       }
     }
@@ -5428,10 +5428,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         }
       }
     }
@@ -5560,10 +5560,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000009
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.000045
         }
       }
     }
@@ -5633,6 +5633,462 @@
       "pay_as_you_go": {
         "request_token": {
           "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "baidu/cobuddy:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "openai/gpt-chat-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        }
+      }
+    }
+  },
+  "x-ai/grok-4.3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.00025
+        }
+      }
+    }
+  },
+  "ibm-granite/granite-4.1-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "mistralai/mistral-medium-3-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.00075
+        }
+      }
+    }
+  },
+  "openrouter/owl-alpha": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "poolside/laguna-xs.2:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "poolside/laguna-m.1:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "~anthropic/claude-haiku-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0005
+        }
+      }
+    }
+  },
+  "~openai/gpt-mini-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000075
+        },
+        "response_token": {
+          "price": 0.00045
+        }
+      }
+    }
+  },
+  "~google/gemini-pro-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
+  "~moonshotai/kimi-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000075
+        },
+        "response_token": {
+          "price": 0.00035
+        }
+      }
+    }
+  },
+  "~google/gemini-flash-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        }
+      }
+    }
+  },
+  "~anthropic/claude-sonnet-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
+  "~openai/gpt-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        }
+      }
+    }
+  },
+  "qwen/qwen3.5-plus-20260420": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.00024
+        }
+      }
+    }
+  },
+  "qwen/qwen3.6-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "qwen/qwen3.6-35b-a3b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.0001
+        }
+      }
+    }
+  },
+  "qwen/qwen3.6-max-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000104
+        },
+        "response_token": {
+          "price": 0.000624
+        }
+      }
+    }
+  },
+  "qwen/qwen3.6-27b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000032
+        },
+        "response_token": {
+          "price": 0.00032
+        }
+      }
+    }
+  },
+  "openai/gpt-5.5-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.003
+        },
+        "response_token": {
+          "price": 0.018
+        }
+      }
+    }
+  },
+  "openai/gpt-5.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        }
+      }
+    }
+  },
+  "deepseek/deepseek-v4-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000435
+        },
+        "response_token": {
+          "price": 0.000087
+        }
+      }
+    }
+  },
+  "deepseek/deepseek-v4-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000014
+        },
+        "response_token": {
+          "price": 0.000028
+        }
+      }
+    }
+  },
+  "inclusionai/ling-2.6-1t:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "tencent/hy3-preview:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "xiaomi/mimo-v2.5-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0003
+        }
+      }
+    }
+  },
+  "xiaomi/mimo-v2.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00004
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "openai/gpt-5.4-image-2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0008
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
+  "inclusionai/ling-2.6-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000024
+        }
+      }
+    }
+  },
+  "~anthropic/claude-opus-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        }
+      }
+    }
+  },
+  "openrouter/pareto-code": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "baidu/qianfan-ocr-fast:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "moonshotai/kimi-k2.6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000075
+        },
+        "response_token": {
+          "price": 0.00035
+        }
+      }
+    }
+  },
+  "arcee-ai/trinity-large-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    }
+  },
+  "microsoft/phi-4-mini-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000008
+        },
+        "response_token": {
+          "price": 0.000035
+        }
+      }
+    }
+  },
+  "google/gemini-embedding-2-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
         },
         "response_token": {
           "price": 0


### PR DESCRIPTION
## 🔄 Models Update: openrouter

### 📊 Summary

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 38 |
| 🔄 Prices updated | 21 |
| 📋 General configs added | 38 |

### ➕ New Models
- `baidu/cobuddy:free`
- `openai/gpt-chat-latest`
- `x-ai/grok-4.3`
- `ibm-granite/granite-4.1-8b`
- `mistralai/mistral-medium-3-5`
- `openrouter/owl-alpha`
- `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`
- `poolside/laguna-xs.2:free`
- `poolside/laguna-m.1:free`
- `~anthropic/claude-haiku-latest`
- `~openai/gpt-mini-latest`
- `~google/gemini-pro-latest`
- `~moonshotai/kimi-latest`
- `~google/gemini-flash-latest`
- `~anthropic/claude-sonnet-latest`
- `~openai/gpt-latest`
- `qwen/qwen3.5-plus-20260420`
- `qwen/qwen3.6-flash`
- `qwen/qwen3.6-35b-a3b`
- `qwen/qwen3.6-max-preview`
- `qwen/qwen3.6-27b`
- `openai/gpt-5.5-pro`
- `openai/gpt-5.5`
- `deepseek/deepseek-v4-pro`
- `deepseek/deepseek-v4-flash`
- `inclusionai/ling-2.6-1t:free`
- `tencent/hy3-preview:free`
- `xiaomi/mimo-v2.5-pro`
- `xiaomi/mimo-v2.5`
- `openai/gpt-5.4-image-2`
- ... and 8 more

### 🔄 Updated Prices
- `z-ai/glm-5.1`
- `google/gemma-4-26b-a4b-it`
- `x-ai/grok-4.20`
- `nvidia/nemotron-3-super-120b-a12b`
- `qwen/qwen3.5-9b`
- `qwen/qwen3.5-35b-a3b`
- `minimax/minimax-m2.5`
- `z-ai/glm-5`
- `qwen/qwen3-coder-next`
- `moonshotai/kimi-k2.5`
- `z-ai/glm-4.7`
- `deepseek/deepseek-v3.2-speciale`
- `deepseek/deepseek-v3.2`
- `deepseek/deepseek-v3.1-terminus`
- `openai/gpt-oss-120b`
- `qwen/qwen3-coder`
- `qwen/qwen3-30b-a3b`
- `qwen/qwen2.5-vl-72b-instruct`
- `qwen/qwen-2.5-72b-instruct`
- `mistralai/mistral-nemo`
- `meta-llama/llama-3-8b-instruct`

### 📋 New General Configs
- `baidu/cobuddy:free`
- `openai/gpt-chat-latest`
- `x-ai/grok-4.3`
- `ibm-granite/granite-4.1-8b`
- `mistralai/mistral-medium-3-5`
- `openrouter/owl-alpha`
- `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`
- `poolside/laguna-xs.2:free`
- `poolside/laguna-m.1:free`
- `~anthropic/claude-haiku-latest`
- `~openai/gpt-mini-latest`
- `~google/gemini-pro-latest`
- `~moonshotai/kimi-latest`
- `~google/gemini-flash-latest`
- `~anthropic/claude-sonnet-latest`
- `~openai/gpt-latest`
- `qwen/qwen3.5-plus-20260420`
- `qwen/qwen3.6-flash`
- `qwen/qwen3.6-35b-a3b`
- `qwen/qwen3.6-max-preview`
- `qwen/qwen3.6-27b`
- `openai/gpt-5.5-pro`
- `openai/gpt-5.5`
- `deepseek/deepseek-v4-pro`
- `deepseek/deepseek-v4-flash`
- `inclusionai/ling-2.6-1t:free`
- `tencent/hy3-preview:free`
- `xiaomi/mimo-v2.5-pro`
- `xiaomi/mimo-v2.5`
- `openai/gpt-5.4-image-2`
- ... and 8 more


---
*Generated by Direct Converter on 2026-05-07*