### PR TITLE
feat: Bedrock: regional multi-tier custom_pricing for Nova, GPT-OSS, Llama, Mistral, Kimi

### DIFF
--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -98,30 +98,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.00006
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000035
-                  },
-                  "response_token": {
-                    "price": 0.000105
-                  }
-                }
-              }
             }
           }
         },
@@ -171,30 +147,6 @@
                   },
                   "response_token": {
                     "price": 0.00003
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.00006
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000035
-                  },
-                  "response_token": {
-                    "price": 0.000105
                   }
                 }
               }
@@ -266,30 +218,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.00002
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
             }
           }
         },
@@ -339,30 +267,6 @@
                   },
                   "response_token": {
                     "price": 0.00001
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.00002
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.000035
                   }
                 }
               }
@@ -434,30 +338,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
             }
           }
         },
@@ -504,30 +384,6 @@
                 "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000005
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
                   },
                   "response_token": {
                     "price": 0
@@ -734,30 +590,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.1
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.175
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
             }
           }
         },
@@ -804,30 +636,6 @@
                 "pay_as_you_go": {
                   "request_token": {
                     "price": 0.05
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.1
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.175
                   },
                   "response_token": {
                     "price": 0
@@ -962,30 +770,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000075
-                  },
-                  "response_token": {
-                    "price": 0.0001
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00013125
-                  },
-                  "response_token": {
-                    "price": 0.000175
-                  }
-                }
-              }
             }
           }
         },
@@ -1035,30 +819,6 @@
                   },
                   "response_token": {
                     "price": 0.00005
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000075
-                  },
-                  "response_token": {
-                    "price": 0.0001
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00013125
-                  },
-                  "response_token": {
-                    "price": 0.000175
                   }
                 }
               }
@@ -1130,30 +890,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000195
-                  },
-                  "response_token": {
-                    "price": 0.000256
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00034125
-                  },
-                  "response_token": {
-                    "price": 0.000448
-                  }
-                }
-              }
             }
           }
         },
@@ -1203,30 +939,6 @@
                   },
                   "response_token": {
                     "price": 0.000128
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000195
-                  },
-                  "response_token": {
-                    "price": 0.000256
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00034125
-                  },
-                  "response_token": {
-                    "price": 0.000448
                   }
                 }
               }
@@ -1346,30 +1058,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.00002
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
             }
           }
         },
@@ -1419,30 +1107,6 @@
                   },
                   "response_token": {
                     "price": 0.00001
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.00002
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.000035
                   }
                 }
               }
@@ -1498,30 +1162,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000018
-                  },
-                  "response_token": {
-                    "price": 0.000024
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000315
-                  },
-                  "response_token": {
-                    "price": 0.000042
-                  }
-                }
-              }
             }
           }
         },
@@ -1571,30 +1211,6 @@
                   },
                   "response_token": {
                     "price": 0.000013
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.000026
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000035
-                  },
-                  "response_token": {
-                    "price": 0.0000455
                   }
                 }
               }
@@ -1650,30 +1266,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000017
-                  },
-                  "response_token": {
-                    "price": 0.000023
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002975
-                  },
-                  "response_token": {
-                    "price": 0.00004025
-                  }
-                }
-              }
             }
           }
         },
@@ -1726,30 +1318,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000016
-                  },
-                  "response_token": {
-                    "price": 0.000022
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000028
-                  },
-                  "response_token": {
-                    "price": 0.0000385
-                  }
-                }
-              }
             }
           }
         },
@@ -1799,30 +1367,6 @@
                   },
                   "response_token": {
                     "price": 0.000017
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000025
-                  },
-                  "response_token": {
-                    "price": 0.000034
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004375
-                  },
-                  "response_token": {
-                    "price": 0.0000595
                   }
                 }
               }
@@ -1894,30 +1438,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000045
-                  },
-                  "response_token": {
-                    "price": 0.00007
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00007875
-                  },
-                  "response_token": {
-                    "price": 0.0001225
-                  }
-                }
-              }
             }
           }
         },
@@ -1967,30 +1487,6 @@
                   },
                   "response_token": {
                     "price": 0.000035
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000045
-                  },
-                  "response_token": {
-                    "price": 0.00007
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00007875
-                  },
-                  "response_token": {
-                    "price": 0.0001225
                   }
                 }
               }
@@ -2046,30 +1542,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000054
-                  },
-                  "response_token": {
-                    "price": 0.000084
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000945
-                  },
-                  "response_token": {
-                    "price": 0.000147
-                  }
-                }
-              }
             }
           }
         },
@@ -2119,30 +1591,6 @@
                   },
                   "response_token": {
                     "price": 0.0000455
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000059
-                  },
-                  "response_token": {
-                    "price": 0.000091
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00010325
-                  },
-                  "response_token": {
-                    "price": 0.00015925
                   }
                 }
               }
@@ -2198,30 +1646,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000052
-                  },
-                  "response_token": {
-                    "price": 0.000081
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000091
-                  },
-                  "response_token": {
-                    "price": 0.00014175
-                  }
-                }
-              }
             }
           }
         },
@@ -2274,30 +1698,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000049
-                  },
-                  "response_token": {
-                    "price": 0.000076
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00008575
-                  },
-                  "response_token": {
-                    "price": 0.000133
-                  }
-                }
-              }
             }
           }
         },
@@ -2347,30 +1747,6 @@
                   },
                   "response_token": {
                     "price": 0.000059
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000076
-                  },
-                  "response_token": {
-                    "price": 0.000118
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000133
-                  },
-                  "response_token": {
-                    "price": 0.0002065
                   }
                 }
               }
@@ -2442,30 +1818,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001
-                  },
-                  "response_token": {
-                    "price": 0.0003
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000175
-                  },
-                  "response_token": {
-                    "price": 0.000525
-                  }
-                }
-              }
             }
           }
         },
@@ -2515,30 +1867,6 @@
                   },
                   "response_token": {
                     "price": 0.00015
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001
-                  },
-                  "response_token": {
-                    "price": 0.0003
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000175
-                  },
-                  "response_token": {
-                    "price": 0.000525
                   }
                 }
               }
@@ -2610,30 +1938,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002
-                  },
-                  "response_token": {
-                    "price": 0.0006
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00035
-                  },
-                  "response_token": {
-                    "price": 0.00105
-                  }
-                }
-              }
             }
           }
         },
@@ -2683,30 +1987,6 @@
                   },
                   "response_token": {
                     "price": 0.00045
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002
-                  },
-                  "response_token": {
-                    "price": 0.0006
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00035
-                  },
-                  "response_token": {
-                    "price": 0.00105
                   }
                 }
               }
@@ -2778,30 +2058,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0004
-                  },
-                  "response_token": {
-                    "price": 0.0012
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0007
-                  },
-                  "response_token": {
-                    "price": 0.0021
-                  }
-                }
-              }
             }
           }
         },
@@ -2851,30 +2107,6 @@
                   },
                   "response_token": {
                     "price": 0.0006
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0004
-                  },
-                  "response_token": {
-                    "price": 0.0012
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0007
-                  },
-                  "response_token": {
-                    "price": 0.0021
                   }
                 }
               }
@@ -2930,30 +2162,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00048
-                  },
-                  "response_token": {
-                    "price": 0.00144
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00084
-                  },
-                  "response_token": {
-                    "price": 0.00252
-                  }
-                }
-              }
             }
           }
         },
@@ -3003,30 +2211,6 @@
                   },
                   "response_token": {
                     "price": 0.00078
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00052
-                  },
-                  "response_token": {
-                    "price": 0.00156
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00091
-                  },
-                  "response_token": {
-                    "price": 0.00273
                   }
                 }
               }
@@ -3082,30 +2266,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00046
-                  },
-                  "response_token": {
-                    "price": 0.00138
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000805
-                  },
-                  "response_token": {
-                    "price": 0.002415
-                  }
-                }
-              }
             }
           }
         },
@@ -3158,30 +2318,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00043
-                  },
-                  "response_token": {
-                    "price": 0.0013
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0007525
-                  },
-                  "response_token": {
-                    "price": 0.002275
-                  }
-                }
-              }
             }
           }
         },
@@ -3231,30 +2367,6 @@
                   },
                   "response_token": {
                     "price": 0.00101
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00067
-                  },
-                  "response_token": {
-                    "price": 0.00202
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0011725
-                  },
-                  "response_token": {
-                    "price": 0.003535
                   }
                 }
               }
@@ -3326,30 +2438,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004
-                  },
-                  "response_token": {
-                    "price": 0.00006
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00007
-                  },
-                  "response_token": {
-                    "price": 0.000105
-                  }
-                }
-              }
             }
           }
         },
@@ -3399,30 +2487,6 @@
                   },
                   "response_token": {
                     "price": 0.00003
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004
-                  },
-                  "response_token": {
-                    "price": 0.00006
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00007
-                  },
-                  "response_token": {
-                    "price": 0.000105
                   }
                 }
               }
@@ -3494,30 +2558,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000265
-                  },
-                  "response_token": {
-                    "price": 0.00035
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00046375
-                  },
-                  "response_token": {
-                    "price": 0.0006125
-                  }
-                }
-              }
             }
           }
         },
@@ -3567,30 +2607,6 @@
                   },
                   "response_token": {
                     "price": 0.000175
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000265
-                  },
-                  "response_token": {
-                    "price": 0.00035
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00046375
-                  },
-                  "response_token": {
-                    "price": 0.0006125
                   }
                 }
               }
@@ -4157,30 +3173,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000022
-                  },
-                  "response_token": {
-                    "price": 0.000022
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000385
-                  },
-                  "response_token": {
-                    "price": 0.0000385
-                  }
-                }
-              }
             }
           }
         },
@@ -4230,30 +3222,6 @@
                   },
                   "response_token": {
                     "price": 0.000011
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000022
-                  },
-                  "response_token": {
-                    "price": 0.000022
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000385
-                  },
-                  "response_token": {
-                    "price": 0.0000385
                   }
                 }
               }
@@ -4325,30 +3293,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000072
-                  },
-                  "response_token": {
-                    "price": 0.000072
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00009
-                  },
-                  "response_token": {
-                    "price": 0.00009
-                  }
-                }
-              }
             }
           }
         },
@@ -4398,30 +3342,6 @@
                   },
                   "response_token": {
                     "price": 0.000036
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000072
-                  },
-                  "response_token": {
-                    "price": 0.000072
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00009
-                  },
-                  "response_token": {
-                    "price": 0.00009
                   }
                 }
               }
@@ -4493,30 +3413,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00024
-                  },
-                  "response_token": {
-                    "price": 0.00024
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00042
-                  },
-                  "response_token": {
-                    "price": 0.00042
-                  }
-                }
-              }
             }
           }
         },
@@ -4569,30 +3465,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00024
-                  },
-                  "response_token": {
-                    "price": 0.00024
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00042
-                  },
-                  "response_token": {
-                    "price": 0.00042
-                  }
-                }
-              }
             }
           }
         },
@@ -4642,30 +3514,6 @@
                   },
                   "response_token": {
                     "price": 0.00012
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00024
-                  },
-                  "response_token": {
-                    "price": 0.00024
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0003
-                  },
-                  "response_token": {
-                    "price": 0.0003
                   }
                 }
               }
@@ -4737,30 +3585,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0.0000175
-                  }
-                }
-              }
             }
           }
         },
@@ -4810,30 +3634,6 @@
                   },
                   "response_token": {
                     "price": 0.000005
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0.0000175
                   }
                 }
               }
@@ -4889,30 +3689,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000013
-                  },
-                  "response_token": {
-                    "price": 0.000013
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002275
-                  },
-                  "response_token": {
-                    "price": 0.00002275
-                  }
-                }
-              }
             }
           }
         },
@@ -4965,30 +3741,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000011
-                  },
-                  "response_token": {
-                    "price": 0.000011
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001925
-                  },
-                  "response_token": {
-                    "price": 0.00001925
-                  }
-                }
-              }
             }
           }
         },
@@ -5038,30 +3790,6 @@
                   },
                   "response_token": {
                     "price": 0.000005
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000013
-                  },
-                  "response_token": {
-                    "price": 0.000013
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002275
-                  },
-                  "response_token": {
-                    "price": 0.00002275
                   }
                 }
               }
@@ -5133,30 +3861,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.000015
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.00002625
-                  }
-                }
-              }
             }
           }
         },
@@ -5206,30 +3910,6 @@
                   },
                   "response_token": {
                     "price": 0.0000075
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.000015
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.00002625
                   }
                 }
               }
@@ -5285,30 +3965,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000019
-                  },
-                  "response_token": {
-                    "price": 0.000019
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00003325
-                  },
-                  "response_token": {
-                    "price": 0.00003325
-                  }
-                }
-              }
             }
           }
         },
@@ -5361,30 +4017,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000017
-                  },
-                  "response_token": {
-                    "price": 0.000017
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002975
-                  },
-                  "response_token": {
-                    "price": 0.00002975
-                  }
-                }
-              }
             }
           }
         },
@@ -5434,30 +4066,6 @@
                   },
                   "response_token": {
                     "price": 0.0000075
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.00002
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000035
-                  },
-                  "response_token": {
-                    "price": 0.000035
                   }
                 }
               }
@@ -5529,30 +4137,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000016
-                  },
-                  "response_token": {
-                    "price": 0.000016
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000028
-                  },
-                  "response_token": {
-                    "price": 0.000028
-                  }
-                }
-              }
             }
           }
         },
@@ -5602,30 +4186,6 @@
                   },
                   "response_token": {
                     "price": 0.000008
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000016
-                  },
-                  "response_token": {
-                    "price": 0.000016
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000028
-                  },
-                  "response_token": {
-                    "price": 0.000028
                   }
                 }
               }
@@ -5697,30 +4257,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000072
-                  },
-                  "response_token": {
-                    "price": 0.000072
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000126
-                  },
-                  "response_token": {
-                    "price": 0.000126
-                  }
-                }
-              }
             }
           }
         },
@@ -5770,30 +4306,6 @@
                   },
                   "response_token": {
                     "price": 0.000036
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000072
-                  },
-                  "response_token": {
-                    "price": 0.000072
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000126
-                  },
-                  "response_token": {
-                    "price": 0.000126
                   }
                 }
               }
@@ -5920,52 +4432,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00008
-                  },
-                  "response_token": {
-                    "price": 0.00032
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -6058,52 +4524,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00008
-                  },
-                  "response_token": {
-                    "price": 0.00032
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -6204,52 +4624,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000096
-                  },
-                  "response_token": {
-                    "price": 0.000384
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000168
-                  },
-                  "response_token": {
-                    "price": 0.000672
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -6342,52 +4716,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000095
-                  },
-                  "response_token": {
-                    "price": 0.00038
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00016625
-                  },
-                  "response_token": {
-                    "price": 0.000665
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -6488,52 +4816,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000094
-                  },
-                  "response_token": {
-                    "price": 0.000376
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001645
-                  },
-                  "response_token": {
-                    "price": 0.000658
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -6626,52 +4908,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000108
-                  },
-                  "response_token": {
-                    "price": 0.000432
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000189
-                  },
-                  "response_token": {
-                    "price": 0.000756
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -6772,52 +5008,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000084
-                  },
-                  "response_token": {
-                    "price": 0.000336
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000147
-                  },
-                  "response_token": {
-                    "price": 0.000588
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -6910,52 +5100,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000087
-                  },
-                  "response_token": {
-                    "price": 0.000348
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00015225
-                  },
-                  "response_token": {
-                    "price": 0.000609
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -7056,52 +5200,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000105
-                  },
-                  "response_token": {
-                    "price": 0.00042
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00018375
-                  },
-                  "response_token": {
-                    "price": 0.000735
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -7194,52 +5292,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000128
-                  },
-                  "response_token": {
-                    "price": 0.000521
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000224
-                  },
-                  "response_token": {
-                    "price": 0.00091175
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -7340,52 +5392,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000088
-                  },
-                  "response_token": {
-                    "price": 0.000352
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000154
-                  },
-                  "response_token": {
-                    "price": 0.000616
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -7478,52 +5484,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000092
-                  },
-                  "response_token": {
-                    "price": 0.000368
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000161
-                  },
-                  "response_token": {
-                    "price": 0.000644
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -7624,52 +5584,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000113
-                  },
-                  "response_token": {
-                    "price": 0.000452
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00019775
-                  },
-                  "response_token": {
-                    "price": 0.000791
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -7766,52 +5680,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000118
-                  },
-                  "response_token": {
-                    "price": 0.000472
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002065
-                  },
-                  "response_token": {
-                    "price": 0.000826
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -7904,52 +5772,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00008
-                  },
-                  "response_token": {
-                    "price": 0.00032
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -8077,52 +5899,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006
-                  },
-                  "response_token": {
-                    "price": 0.000024
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000105
-                  },
-                  "response_token": {
-                    "price": 0.000042
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -8215,52 +5991,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006
-                  },
-                  "response_token": {
-                    "price": 0.000024
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000105
-                  },
-                  "response_token": {
-                    "price": 0.000042
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
                     }
                   }
                 }
@@ -8361,52 +6091,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000072
-                  },
-                  "response_token": {
-                    "price": 0.0000288
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000126
-                  },
-                  "response_token": {
-                    "price": 0.0000504
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -8499,52 +6183,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000071
-                  },
-                  "response_token": {
-                    "price": 0.0000284
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000012425
-                  },
-                  "response_token": {
-                    "price": 0.0000497
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
                     }
                   }
                 }
@@ -8645,52 +6283,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000081
-                  },
-                  "response_token": {
-                    "price": 0.0000324
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000014175
-                  },
-                  "response_token": {
-                    "price": 0.0000567
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -8783,52 +6375,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000063
-                  },
-                  "response_token": {
-                    "price": 0.0000252
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000011025
-                  },
-                  "response_token": {
-                    "price": 0.0000441
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
                     }
                   }
                 }
@@ -8929,52 +6475,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000065
-                  },
-                  "response_token": {
-                    "price": 0.000026
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000011375
-                  },
-                  "response_token": {
-                    "price": 0.0000455
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -9067,52 +6567,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000064
-                  },
-                  "response_token": {
-                    "price": 0.0000256
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000112
-                  },
-                  "response_token": {
-                    "price": 0.0000448
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
                     }
                   }
                 }
@@ -9213,52 +6667,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000078
-                  },
-                  "response_token": {
-                    "price": 0.0000312
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001365
-                  },
-                  "response_token": {
-                    "price": 0.0000546
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -9351,52 +6759,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000096
-                  },
-                  "response_token": {
-                    "price": 0.0000384
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000168
-                  },
-                  "response_token": {
-                    "price": 0.0000672
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
                     }
                   }
                 }
@@ -9497,52 +6859,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000066
-                  },
-                  "response_token": {
-                    "price": 0.0000264
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001155
-                  },
-                  "response_token": {
-                    "price": 0.0000462
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -9635,52 +6951,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000069
-                  },
-                  "response_token": {
-                    "price": 0.0000276
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000012075
-                  },
-                  "response_token": {
-                    "price": 0.0000483
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
                     }
                   }
                 }
@@ -9781,52 +7051,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000084
-                  },
-                  "response_token": {
-                    "price": 0.0000336
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000147
-                  },
-                  "response_token": {
-                    "price": 0.0000588
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -9923,52 +7147,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000088
-                  },
-                  "response_token": {
-                    "price": 0.0000352
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000154
-                  },
-                  "response_token": {
-                    "price": 0.0000616
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -10061,52 +7239,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006
-                  },
-                  "response_token": {
-                    "price": 0.000024
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000105
-                  },
-                  "response_token": {
-                    "price": 0.000042
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
                     }
                   }
                 }
@@ -10234,52 +7366,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0.000014
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006125
-                  },
-                  "response_token": {
-                    "price": 0.0000245
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -10372,52 +7458,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0.000014
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006125
-                  },
-                  "response_token": {
-                    "price": 0.0000245
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
                     }
                   }
                 }
@@ -10518,52 +7558,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000042
-                  },
-                  "response_token": {
-                    "price": 0.0000168
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000735
-                  },
-                  "response_token": {
-                    "price": 0.0000294
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -10656,52 +7650,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000041
-                  },
-                  "response_token": {
-                    "price": 0.0000164
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000007175
-                  },
-                  "response_token": {
-                    "price": 0.0000287
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
                     }
                   }
                 }
@@ -10802,52 +7750,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000047
-                  },
-                  "response_token": {
-                    "price": 0.0000188
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000008225
-                  },
-                  "response_token": {
-                    "price": 0.0000329
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -10940,52 +7842,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000037
-                  },
-                  "response_token": {
-                    "price": 0.0000148
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006475
-                  },
-                  "response_token": {
-                    "price": 0.0000259
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
                     }
                   }
                 }
@@ -11086,52 +7942,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000046
-                  },
-                  "response_token": {
-                    "price": 0.0000184
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000805
-                  },
-                  "response_token": {
-                    "price": 0.0000322
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -11224,52 +8034,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000038
-                  },
-                  "response_token": {
-                    "price": 0.0000152
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000665
-                  },
-                  "response_token": {
-                    "price": 0.0000266
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
                     }
                   }
                 }
@@ -11370,52 +8134,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000056
-                  },
-                  "response_token": {
-                    "price": 0.0000224
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000098
-                  },
-                  "response_token": {
-                    "price": 0.0000392
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -11508,52 +8226,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000039
-                  },
-                  "response_token": {
-                    "price": 0.0000156
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006825
-                  },
-                  "response_token": {
-                    "price": 0.0000273
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
                     }
                   }
                 }
@@ -11654,52 +8326,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000004
-                  },
-                  "response_token": {
-                    "price": 0.000016
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000007
-                  },
-                  "response_token": {
-                    "price": 0.000028
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -11792,52 +8418,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000049
-                  },
-                  "response_token": {
-                    "price": 0.0000196
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000008575
-                  },
-                  "response_token": {
-                    "price": 0.0000343
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
                     }
                   }
                 }
@@ -11938,52 +8518,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000052
-                  },
-                  "response_token": {
-                    "price": 0.0000208
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000091
-                  },
-                  "response_token": {
-                    "price": 0.0000364
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -12076,52 +8610,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0.000014
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006125
-                  },
-                  "response_token": {
-                    "price": 0.0000245
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
                     }
                   }
                 }
@@ -12252,30 +8740,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000072
-                  },
-                  "response_token": {
-                    "price": 0.000072
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000126
-                  },
-                  "response_token": {
-                    "price": 0.000126
-                  }
-                }
-              }
             }
           }
         },
@@ -12325,30 +8789,6 @@
                   },
                   "response_token": {
                     "price": 0.000036
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000072
-                  },
-                  "response_token": {
-                    "price": 0.000072
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000126
-                  },
-                  "response_token": {
-                    "price": 0.000126
                   }
                 }
               }
@@ -12420,30 +8860,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000017
-                  },
-                  "response_token": {
-                    "price": 0.000066
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002975
-                  },
-                  "response_token": {
-                    "price": 0.0001155
-                  }
-                }
-              }
             }
           }
         },
@@ -12493,30 +8909,6 @@
                   },
                   "response_token": {
                     "price": 0.000033
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000017
-                  },
-                  "response_token": {
-                    "price": 0.000066
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002975
-                  },
-                  "response_token": {
-                    "price": 0.0001155
                   }
                 }
               }
@@ -12588,30 +8980,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000024
-                  },
-                  "response_token": {
-                    "price": 0.000097
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000042
-                  },
-                  "response_token": {
-                    "price": 0.00016975
-                  }
-                }
-              }
             }
           }
         },
@@ -12661,30 +9029,6 @@
                   },
                   "response_token": {
                     "price": 0.0000485
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000024
-                  },
-                  "response_token": {
-                    "price": 0.000097
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000042
-                  },
-                  "response_token": {
-                    "price": 0.00016975
                   }
                 }
               }
@@ -13103,30 +9447,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000002
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
             }
           }
         },
@@ -13173,30 +9493,6 @@
                 "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000001
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000002
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
                   },
                   "response_token": {
                     "price": 0
@@ -13326,52 +9622,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0005
-                  },
-                  "response_token": {
-                    "price": 0.0025
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000625
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00005
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.001
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000875
-                  },
-                  "response_token": {
-                    "price": 0.004375
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00109375
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000875
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00175
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -13468,52 +9718,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0005
-                  },
-                  "response_token": {
-                    "price": 0.0025
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000625
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00005
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.001
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000875
-                  },
-                  "response_token": {
-                    "price": 0.004375
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00109375
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000875
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00175
-                    }
-                  }
-                }
-              }
             }
           }
         }
@@ -13582,30 +9786,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000007
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001225
-                  },
-                  "response_token": {
-                    "price": 0.0000525
-                  }
-                }
-              }
             }
           }
         },
@@ -13655,30 +9835,6 @@
                   },
                   "response_token": {
                     "price": 0.000015
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000007
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001225
-                  },
-                  "response_token": {
-                    "price": 0.0000525
                   }
                 }
               }
@@ -13734,30 +9890,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000008
-                  },
-                  "response_token": {
-                    "price": 0.000036
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000014
-                  },
-                  "response_token": {
-                    "price": 0.000063
-                  }
-                }
-              }
             }
           }
         },
@@ -13807,30 +9939,6 @@
                   },
                   "response_token": {
                     "price": 0.000018
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000008
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000014
-                  },
-                  "response_token": {
-                    "price": 0.00006125
                   }
                 }
               }
@@ -13886,30 +9994,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000007
-                  },
-                  "response_token": {
-                    "price": 0.000031
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001225
-                  },
-                  "response_token": {
-                    "price": 0.00005425
-                  }
-                }
-              }
             }
           }
         },
@@ -13959,30 +10043,6 @@
                   },
                   "response_token": {
                     "price": 0.00002
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000009
-                  },
-                  "response_token": {
-                    "price": 0.00004
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001575
-                  },
-                  "response_token": {
-                    "price": 0.00007
                   }
                 }
               }
@@ -14038,30 +10098,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000011
-                  },
-                  "response_token": {
-                    "price": 0.000047
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001925
-                  },
-                  "response_token": {
-                    "price": 0.00008225
-                  }
-                }
-              }
             }
           }
         },
@@ -14111,30 +10147,6 @@
                   },
                   "response_token": {
                     "price": 0.000018
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000084
-                  },
-                  "response_token": {
-                    "price": 0.000036
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000147
-                  },
-                  "response_token": {
-                    "price": 0.000063
                   }
                 }
               }
@@ -14206,30 +10218,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.00006
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.000105
-                  }
-                }
-              }
             }
           }
         },
@@ -14279,30 +10267,6 @@
                   },
                   "response_token": {
                     "price": 0.00003
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.00006
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.000105
                   }
                 }
               }
@@ -14358,30 +10322,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000018
-                  },
-                  "response_token": {
-                    "price": 0.000073
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000315
-                  },
-                  "response_token": {
-                    "price": 0.00012775
-                  }
-                }
-              }
             }
           }
         },
@@ -14431,30 +10371,6 @@
                   },
                   "response_token": {
                     "price": 0.000035
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000018
-                  },
-                  "response_token": {
-                    "price": 0.000071
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000315
-                  },
-                  "response_token": {
-                    "price": 0.00012425
                   }
                 }
               }
@@ -14510,30 +10426,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000016
-                  },
-                  "response_token": {
-                    "price": 0.000062
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000028
-                  },
-                  "response_token": {
-                    "price": 0.0001085
-                  }
-                }
-              }
             }
           }
         },
@@ -14583,30 +10475,6 @@
                   },
                   "response_token": {
                     "price": 0.00004
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.000079
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000035
-                  },
-                  "response_token": {
-                    "price": 0.00013825
                   }
                 }
               }
@@ -14662,30 +10530,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000018
-                  },
-                  "response_token": {
-                    "price": 0.00007
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000315
-                  },
-                  "response_token": {
-                    "price": 0.0001225
-                  }
-                }
-              }
             }
           }
         },
@@ -14738,30 +10582,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000023
-                  },
-                  "response_token": {
-                    "price": 0.000093
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004025
-                  },
-                  "response_token": {
-                    "price": 0.00016275
-                  }
-                }
-              }
             }
           }
         },
@@ -14811,30 +10631,6 @@
                   },
                   "response_token": {
                     "price": 0.000036
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000018
-                  },
-                  "response_token": {
-                    "price": 0.000072
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000315
-                  },
-                  "response_token": {
-                    "price": 0.000126
                   }
                 }
               }
@@ -14950,52 +10746,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00008
-                  },
-                  "response_token": {
-                    "price": 0.00032
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -15088,52 +10838,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00008
-                  },
-                  "response_token": {
-                    "price": 0.00032
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -15234,52 +10938,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000096
-                  },
-                  "response_token": {
-                    "price": 0.000384
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000168
-                  },
-                  "response_token": {
-                    "price": 0.000672
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -15372,52 +11030,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000095
-                  },
-                  "response_token": {
-                    "price": 0.00038
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00016625
-                  },
-                  "response_token": {
-                    "price": 0.000665
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -15518,52 +11130,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000094
-                  },
-                  "response_token": {
-                    "price": 0.000376
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001645
-                  },
-                  "response_token": {
-                    "price": 0.000658
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -15656,52 +11222,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000108
-                  },
-                  "response_token": {
-                    "price": 0.000432
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000189
-                  },
-                  "response_token": {
-                    "price": 0.000756
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -15802,52 +11322,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000084
-                  },
-                  "response_token": {
-                    "price": 0.000336
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000147
-                  },
-                  "response_token": {
-                    "price": 0.000588
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -15940,52 +11414,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000087
-                  },
-                  "response_token": {
-                    "price": 0.000348
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00015225
-                  },
-                  "response_token": {
-                    "price": 0.000609
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -16086,52 +11514,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000105
-                  },
-                  "response_token": {
-                    "price": 0.00042
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00018375
-                  },
-                  "response_token": {
-                    "price": 0.000735
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -16224,52 +11606,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000128
-                  },
-                  "response_token": {
-                    "price": 0.000521
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000224
-                  },
-                  "response_token": {
-                    "price": 0.00091175
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -16370,52 +11706,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000088
-                  },
-                  "response_token": {
-                    "price": 0.000352
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000154
-                  },
-                  "response_token": {
-                    "price": 0.000616
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -16508,52 +11798,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000092
-                  },
-                  "response_token": {
-                    "price": 0.000368
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000161
-                  },
-                  "response_token": {
-                    "price": 0.000644
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -16654,52 +11898,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000113
-                  },
-                  "response_token": {
-                    "price": 0.000452
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00019775
-                  },
-                  "response_token": {
-                    "price": 0.000791
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -16796,52 +11994,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000118
-                  },
-                  "response_token": {
-                    "price": 0.000472
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002065
-                  },
-                  "response_token": {
-                    "price": 0.000826
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
             }
           }
         },
@@ -16934,52 +12086,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00008
-                  },
-                  "response_token": {
-                    "price": 0.00032
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
                     }
                   }
                 }
@@ -17104,30 +12210,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000002
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
             }
           }
         },
@@ -17174,30 +12256,6 @@
                 "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000001
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000002
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
                   },
                   "response_token": {
                     "price": 0
@@ -17520,30 +12578,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002
-                  },
-                  "response_token": {
-                    "price": 0.0006
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00035
-                  },
-                  "response_token": {
-                    "price": 0.00105
-                  }
-                }
-              }
             }
           }
         },
@@ -17593,30 +12627,6 @@
                   },
                   "response_token": {
                     "price": 0.0003
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002
-                  },
-                  "response_token": {
-                    "price": 0.0006
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00035
-                  },
-                  "response_token": {
-                    "price": 0.00105
                   }
                 }
               }
@@ -17688,30 +12698,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00005
-                  },
-                  "response_token": {
-                    "price": 0.00015
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000875
-                  },
-                  "response_token": {
-                    "price": 0.0002625
-                  }
-                }
-              }
             }
           }
         },
@@ -17761,30 +12747,6 @@
                   },
                   "response_token": {
                     "price": 0.000075
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00005
-                  },
-                  "response_token": {
-                    "price": 0.00015
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000875
-                  },
-                  "response_token": {
-                    "price": 0.0002625
                   }
                 }
               }
@@ -17840,30 +12802,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000061
-                  },
-                  "response_token": {
-                    "price": 0.000182
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00010675
-                  },
-                  "response_token": {
-                    "price": 0.0003185
-                  }
-                }
-              }
             }
           }
         },
@@ -17913,30 +12851,6 @@
                   },
                   "response_token": {
                     "price": 0.000088
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000059
-                  },
-                  "response_token": {
-                    "price": 0.000176
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00010325
-                  },
-                  "response_token": {
-                    "price": 0.000308
                   }
                 }
               }
@@ -17992,30 +12906,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000515
-                  },
-                  "response_token": {
-                    "price": 0.0001545
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000090125
-                  },
-                  "response_token": {
-                    "price": 0.000270375
-                  }
-                }
-              }
             }
           }
         },
@@ -18065,30 +12955,6 @@
                   },
                   "response_token": {
                     "price": 0.0001165
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000078
-                  },
-                  "response_token": {
-                    "price": 0.000233
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001365
-                  },
-                  "response_token": {
-                    "price": 0.00040775
                   }
                 }
               }
@@ -18160,30 +13026,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0.0000175
-                  }
-                }
-              }
             }
           }
         },
@@ -18233,30 +13075,6 @@
                   },
                   "response_token": {
                     "price": 0.000005
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0.0000175
                   }
                 }
               }
@@ -18312,30 +13130,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000012
-                  },
-                  "response_token": {
-                    "price": 0.000012
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000021
-                  },
-                  "response_token": {
-                    "price": 0.000021
-                  }
-                }
-              }
             }
           }
         },
@@ -18388,30 +13182,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000103
-                  },
-                  "response_token": {
-                    "price": 0.0000103
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000018025
-                  },
-                  "response_token": {
-                    "price": 0.000018025
-                  }
-                }
-              }
             }
           }
         },
@@ -18461,30 +13231,6 @@
                   },
                   "response_token": {
                     "price": 0.000008
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000016
-                  },
-                  "response_token": {
-                    "price": 0.000016
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000028
-                  },
-                  "response_token": {
-                    "price": 0.000028
                   }
                 }
               }
@@ -18556,30 +13302,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.000015
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.00002625
-                  }
-                }
-              }
             }
           }
         },
@@ -18629,30 +13351,6 @@
                   },
                   "response_token": {
                     "price": 0.0000075
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.000015
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.00002625
                   }
                 }
               }
@@ -18708,30 +13406,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000018
-                  },
-                  "response_token": {
-                    "price": 0.000018
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000315
-                  },
-                  "response_token": {
-                    "price": 0.0000315
-                  }
-                }
-              }
             }
           }
         },
@@ -18784,30 +13458,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001545
-                  },
-                  "response_token": {
-                    "price": 0.00001545
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000270375
-                  },
-                  "response_token": {
-                    "price": 0.0000270375
-                  }
-                }
-              }
             }
           }
         },
@@ -18857,30 +13507,6 @@
                   },
                   "response_token": {
                     "price": 0.0000115
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000023
-                  },
-                  "response_token": {
-                    "price": 0.000023
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004025
-                  },
-                  "response_token": {
-                    "price": 0.00004025
                   }
                 }
               }
@@ -18952,30 +13578,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.00002
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000035
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
             }
           }
         },
@@ -19025,30 +13627,6 @@
                   },
                   "response_token": {
                     "price": 0.00001
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.00002
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000035
-                  },
-                  "response_token": {
-                    "price": 0.000035
                   }
                 }
               }
@@ -19104,30 +13682,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000024
-                  },
-                  "response_token": {
-                    "price": 0.000024
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000042
-                  },
-                  "response_token": {
-                    "price": 0.000042
-                  }
-                }
-              }
             }
           }
         },
@@ -19180,30 +13734,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000206
-                  },
-                  "response_token": {
-                    "price": 0.0000206
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00003605
-                  },
-                  "response_token": {
-                    "price": 0.00003605
-                  }
-                }
-              }
             }
           }
         },
@@ -19253,30 +13783,6 @@
                   },
                   "response_token": {
                     "price": 0.0000155
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000031
-                  },
-                  "response_token": {
-                    "price": 0.000031
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00005425
-                  },
-                  "response_token": {
-                    "price": 0.00005425
                   }
                 }
               }
@@ -19348,30 +13854,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00005
-                  },
-                  "response_token": {
-                    "price": 0.00015
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000875
-                  },
-                  "response_token": {
-                    "price": 0.0002625
-                  }
-                }
-              }
             }
           }
         },
@@ -19421,30 +13903,6 @@
                   },
                   "response_token": {
                     "price": 0.000075
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00005
-                  },
-                  "response_token": {
-                    "price": 0.00015
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000875
-                  },
-                  "response_token": {
-                    "price": 0.0002625
                   }
                 }
               }
@@ -19500,30 +13958,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000061
-                  },
-                  "response_token": {
-                    "price": 0.000182
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00010675
-                  },
-                  "response_token": {
-                    "price": 0.0003185
-                  }
-                }
-              }
             }
           }
         },
@@ -19576,30 +14010,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000059
-                  },
-                  "response_token": {
-                    "price": 0.000176
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00010325
-                  },
-                  "response_token": {
-                    "price": 0.000308
-                  }
-                }
-              }
             }
           }
         },
@@ -19649,30 +14059,6 @@
                   },
                   "response_token": {
                     "price": 0.00007725
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000515
-                  },
-                  "response_token": {
-                    "price": 0.0001545
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000090125
-                  },
-                  "response_token": {
-                    "price": 0.000270375
                   }
                 }
               }
@@ -19744,30 +14130,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000004
-                  },
-                  "response_token": {
-                    "price": 0.000004
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000007
-                  },
-                  "response_token": {
-                    "price": 0.000007
-                  }
-                }
-              }
             }
           }
         },
@@ -19817,30 +14179,6 @@
                   },
                   "response_token": {
                     "price": 0.000002
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000004
-                  },
-                  "response_token": {
-                    "price": 0.000004
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000007
-                  },
-                  "response_token": {
-                    "price": 0.000007
                   }
                 }
               }
@@ -19896,30 +14234,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000005
-                  },
-                  "response_token": {
-                    "price": 0.000005
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000875
-                  },
-                  "response_token": {
-                    "price": 0.00000875
-                  }
-                }
-              }
             }
           }
         },
@@ -19972,30 +14286,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000412
-                  },
-                  "response_token": {
-                    "price": 0.00000412
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000721
-                  },
-                  "response_token": {
-                    "price": 0.00000721
-                  }
-                }
-              }
             }
           }
         },
@@ -20045,30 +14335,6 @@
                   },
                   "response_token": {
                     "price": 0.000003
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006
-                  },
-                  "response_token": {
-                    "price": 0.000006
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000105
-                  },
-                  "response_token": {
-                    "price": 0.0000105
                   }
                 }
               }
@@ -20140,30 +14406,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0.0000525
-                  }
-                }
-              }
             }
           }
         },
@@ -20213,30 +14455,6 @@
                   },
                   "response_token": {
                     "price": 0.000015
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0.0000525
                   }
                 }
               }
@@ -20292,30 +14510,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000012
-                  },
-                  "response_token": {
-                    "price": 0.000036
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000021
-                  },
-                  "response_token": {
-                    "price": 0.000063
-                  }
-                }
-              }
             }
           }
         },
@@ -20365,30 +14559,6 @@
                   },
                   "response_token": {
                     "price": 0.0000175
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000012
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000021
-                  },
-                  "response_token": {
-                    "price": 0.00006125
                   }
                 }
               }
@@ -20444,30 +14614,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000103
-                  },
-                  "response_token": {
-                    "price": 0.0000309
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000018025
-                  },
-                  "response_token": {
-                    "price": 0.000054075
-                  }
-                }
-              }
             }
           }
         },
@@ -20517,30 +14663,6 @@
                   },
                   "response_token": {
                     "price": 0.0000235
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000016
-                  },
-                  "response_token": {
-                    "price": 0.000047
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000028
-                  },
-                  "response_token": {
-                    "price": 0.00008225
                   }
                 }
               }
@@ -20612,30 +14734,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00006
-                  },
-                  "response_token": {
-                    "price": 0.00025
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000105
-                  },
-                  "response_token": {
-                    "price": 0.0004375
-                  }
-                }
-              }
             }
           }
         },
@@ -20685,30 +14783,6 @@
                   },
                   "response_token": {
                     "price": 0.000125
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00006
-                  },
-                  "response_token": {
-                    "price": 0.00025
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000105
-                  },
-                  "response_token": {
-                    "price": 0.0004375
                   }
                 }
               }
@@ -20764,30 +14838,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000073
-                  },
-                  "response_token": {
-                    "price": 0.000303
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00012775
-                  },
-                  "response_token": {
-                    "price": 0.00053025
-                  }
-                }
-              }
             }
           }
         },
@@ -20840,30 +14890,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000071
-                  },
-                  "response_token": {
-                    "price": 0.000294
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00012425
-                  },
-                  "response_token": {
-                    "price": 0.0005145
-                  }
-                }
-              }
             }
           }
         },
@@ -20913,30 +14939,6 @@
                   },
                   "response_token": {
                     "price": 0.00012875
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000618
-                  },
-                  "response_token": {
-                    "price": 0.0002575
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00010815
-                  },
-                  "response_token": {
-                    "price": 0.000450625
                   }
                 }
               }
@@ -21008,30 +15010,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00006
-                  },
-                  "response_token": {
-                    "price": 0.0003
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000105
-                  },
-                  "response_token": {
-                    "price": 0.000525
-                  }
-                }
-              }
             }
           }
         },
@@ -21081,30 +15059,6 @@
                   },
                   "response_token": {
                     "price": 0.00015
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00006
-                  },
-                  "response_token": {
-                    "price": 0.0003
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000105
-                  },
-                  "response_token": {
-                    "price": 0.000525
                   }
                 }
               }
@@ -21160,30 +15114,6 @@
                   }
                 }
               }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000072
-                  },
-                  "response_token": {
-                    "price": 0.00036
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000126
-                  },
-                  "response_token": {
-                    "price": 0.00063
-                  }
-                }
-              }
             }
           }
         },
@@ -21233,30 +15163,6 @@
                   },
                   "response_token": {
                     "price": 0.0001545
-                  }
-                }
-              }
-            },
-            "provisioned_throughput": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000618
-                  },
-                  "response_token": {
-                    "price": 0.000309
-                  }
-                }
-              }
-            },
-            "reserved": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00010815
-                  },
-                  "response_token": {
-                    "price": 0.00054075
                   }
                 }
               }

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -749,58 +749,6 @@
             }
           }
         },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.00002
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            }
-          }
-        },
         "ap-south-1": {
           "execution_modes": {
             "standard": {
@@ -1078,58 +1026,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000045
-                  },
-                  "response_token": {
-                    "price": 0.00007
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00007875
-                  },
-                  "response_token": {
-                    "price": 0.0001225
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000225
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000225
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -1594,58 +1490,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0004
-                  },
-                  "response_token": {
-                    "price": 0.0012
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0007
-                  },
-                  "response_token": {
-                    "price": 0.0021
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002
-                  },
-                  "response_token": {
-                    "price": 0.0006
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002
-                  },
-                  "response_token": {
-                    "price": 0.0006
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -2792,58 +2636,6 @@
             }
           }
         },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00024
-                  },
-                  "response_token": {
-                    "price": 0.00024
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00042
-                  },
-                  "response_token": {
-                    "price": 0.00042
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00012
-                  },
-                  "response_token": {
-                    "price": 0.00012
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00012
-                  },
-                  "response_token": {
-                    "price": 0.00012
-                  }
-                }
-              }
-            }
-          }
-        },
         "us-east-2": {
           "execution_modes": {
             "standard": {
@@ -2913,58 +2705,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0.0000175
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000005
-                  },
-                  "response_token": {
-                    "price": 0.000005
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000005
-                  },
-                  "response_token": {
-                    "price": 0.000005
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-2,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -3189,58 +2929,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.000015
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.00002625
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.0000075
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.0000075
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-2,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -4954,102 +4642,6 @@
               }
             }
           }
-        },
-        "us-east-1": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00008
-                  },
-                  "response_token": {
-                    "price": 0.00032
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004
-                  },
-                  "response_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004
-                  },
-                  "response_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -6421,102 +6013,6 @@
               }
             }
           }
-        },
-        "us-east-1": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006
-                  },
-                  "response_token": {
-                    "price": 0.000024
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000105
-                  },
-                  "response_token": {
-                    "price": 0.000042
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000003
-                  },
-                  "response_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
-                    }
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000003
-                  },
-                  "response_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000003
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000012
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000012
-                    }
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -7792,102 +7288,6 @@
               }
             }
           }
-        },
-        "us-east-1": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0.000014
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006125
-                  },
-                  "response_token": {
-                    "price": 0.0000245
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000175
-                  },
-                  "response_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
-                    }
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000175
-                  },
-                  "response_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000175
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000007
-                    }
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -8757,58 +8157,6 @@
             }
           }
         },
-        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000007
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001225
-                  },
-                  "response_token": {
-                    "price": 0.0000525
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0.000015
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0.000015
-                  }
-                }
-              }
-            }
-          }
-        },
         "ap-northeast-1,sa-east-1": {
           "execution_modes": {
             "standard": {
@@ -9138,58 +8486,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.00006
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.000105
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -10964,102 +10260,6 @@
               }
             }
           }
-        },
-        "us-east-1": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00008
-                  },
-                  "response_token": {
-                    "price": 0.00032
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004
-                  },
-                  "response_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004
-                  },
-                  "response_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00004
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00016
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00016
-                    }
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -11565,58 +10765,6 @@
             }
           }
         },
-        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00005
-                  },
-                  "response_token": {
-                    "price": 0.00015
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000875
-                  },
-                  "response_token": {
-                    "price": 0.0002625
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000025
-                  },
-                  "response_token": {
-                    "price": 0.000075
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000025
-                  },
-                  "response_token": {
-                    "price": 0.000075
-                  }
-                }
-              }
-            }
-          }
-        },
         "ap-northeast-1,sa-east-1": {
           "execution_modes": {
             "standard": {
@@ -11893,58 +11041,6 @@
             }
           }
         },
-        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0.0000175
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000005
-                  },
-                  "response_token": {
-                    "price": 0.000005
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000005
-                  },
-                  "response_token": {
-                    "price": 0.000005
-                  }
-                }
-              }
-            }
-          }
-        },
         "ap-northeast-1,ap-south-1,eu-south-1,eu-west-1,sa-east-1": {
           "execution_modes": {
             "standard": {
@@ -12118,58 +11214,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.000015
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.00002625
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.0000075
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.0000075
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -12445,58 +11489,6 @@
             }
           }
         },
-        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.00002
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000035
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            }
-          }
-        },
         "ap-northeast-1,ap-south-1,eu-south-1,eu-west-1,sa-east-1": {
           "execution_modes": {
             "standard": {
@@ -12670,58 +11662,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00005
-                  },
-                  "response_token": {
-                    "price": 0.00015
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000875
-                  },
-                  "response_token": {
-                    "price": 0.0002625
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000025
-                  },
-                  "response_token": {
-                    "price": 0.000075
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000025
-                  },
-                  "response_token": {
-                    "price": 0.000075
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -12997,58 +11937,6 @@
             }
           }
         },
-        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000004
-                  },
-                  "response_token": {
-                    "price": 0.000004
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000007
-                  },
-                  "response_token": {
-                    "price": 0.000007
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000002
-                  },
-                  "response_token": {
-                    "price": 0.000002
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000002
-                  },
-                  "response_token": {
-                    "price": 0.000002
-                  }
-                }
-              }
-            }
-          }
-        },
         "ap-northeast-1,ap-south-1,eu-south-1,eu-west-1,sa-east-1": {
           "execution_modes": {
             "standard": {
@@ -13222,58 +12110,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0.0000525
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000005
-                  },
-                  "response_token": {
-                    "price": 0.000015
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000005
-                  },
-                  "response_token": {
-                    "price": 0.000015
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -13601,58 +12437,6 @@
             }
           }
         },
-        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00006
-                  },
-                  "response_token": {
-                    "price": 0.00025
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000105
-                  },
-                  "response_token": {
-                    "price": 0.0004375
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00003
-                  },
-                  "response_token": {
-                    "price": 0.000125
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00003
-                  },
-                  "response_token": {
-                    "price": 0.000125
-                  }
-                }
-              }
-            }
-          }
-        },
         "ap-northeast-1,sa-east-1": {
           "execution_modes": {
             "standard": {
@@ -13826,58 +12610,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00006
-                  },
-                  "response_token": {
-                    "price": 0.0003
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000105
-                  },
-                  "response_token": {
-                    "price": 0.000525
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00003
-                  },
-                  "response_token": {
-                    "price": 0.00015
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00003
-                  },
-                  "response_token": {
-                    "price": 0.00015
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -4481,10 +4481,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000037
+                    "price": 0.000003605
                   },
                   "response_token": {
-                    "price": 0.0000148
+                    "price": 0.00001442
                   },
                   "cache_write_input_token": {
                     "price": 0.000007
@@ -4504,10 +4504,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00000185
+                    "price": 0.0000018025
                   },
                   "response_token": {
-                    "price": 0.0000074
+                    "price": 0.00000721
                   },
                   "cache_write_input_token": {
                     "price": 0.000007
@@ -5018,6 +5018,30 @@
                   }
                 }
               }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002975
+                  },
+                  "response_token": {
+                    "price": 0.00011550000000000002
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000085
+                  },
+                  "response_token": {
+                    "price": 0.000033
+                  }
+                }
+              }
             }
           }
         }
@@ -5052,6 +5076,30 @@
               }
             },
             "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.0000485
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000042
+                  },
+                  "response_token": {
+                    "price": 0.00016975
+                  }
+                }
+              }
+            },
+            "flex": {
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -100,58 +100,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.00006
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000035
-                  },
-                  "response_token": {
-                    "price": 0.000105
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -220,58 +168,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000015
-                  },
-                  "response_token": {
-                    "price": 0.00002
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -290,58 +186,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000005
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000005
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -592,58 +436,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.1
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.175
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.05
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.05
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -772,58 +564,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000075
-                  },
-                  "response_token": {
-                    "price": 0.0001
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00013125
-                  },
-                  "response_token": {
-                    "price": 0.000175
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000375
-                  },
-                  "response_token": {
-                    "price": 0.00005
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000375
-                  },
-                  "response_token": {
-                    "price": 0.00005
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -842,58 +582,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000195
-                  },
-                  "response_token": {
-                    "price": 0.000256
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00034125
-                  },
-                  "response_token": {
-                    "price": 0.000448
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000975
-                  },
-                  "response_token": {
-                    "price": 0.000128
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000975
-                  },
-                  "response_token": {
-                    "price": 0.000128
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -1820,58 +1508,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001
-                  },
-                  "response_token": {
-                    "price": 0.0003
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000175
-                  },
-                  "response_token": {
-                    "price": 0.000525
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00005
-                  },
-                  "response_token": {
-                    "price": 0.00015
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00005
-                  },
-                  "response_token": {
-                    "price": 0.00015
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -1890,58 +1526,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002
-                  },
-                  "response_token": {
-                    "price": 0.0006
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00035
-                  },
-                  "response_token": {
-                    "price": 0.00105
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001
-                  },
-                  "response_token": {
-                    "price": 0.0003
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00015
-                  },
-                  "response_token": {
-                    "price": 0.00045
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -2440,58 +2024,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004
-                  },
-                  "response_token": {
-                    "price": 0.00006
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00007
-                  },
-                  "response_token": {
-                    "price": 0.000105
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -2510,58 +2042,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000265
-                  },
-                  "response_token": {
-                    "price": 0.00035
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00046375
-                  },
-                  "response_token": {
-                    "price": 0.0006125
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001325
-                  },
-                  "response_token": {
-                    "price": 0.000175
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001325
-                  },
-                  "response_token": {
-                    "price": 0.000175
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -3175,58 +2655,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000022
-                  },
-                  "response_token": {
-                    "price": 0.000022
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000385
-                  },
-                  "response_token": {
-                    "price": 0.0000385
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000011
-                  },
-                  "response_token": {
-                    "price": 0.000011
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000011
-                  },
-                  "response_token": {
-                    "price": 0.000011
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -3245,58 +2673,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000072
-                  },
-                  "response_token": {
-                    "price": 0.000072
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00009
-                  },
-                  "response_token": {
-                    "price": 0.00009
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000036
-                  },
-                  "response_token": {
-                    "price": 0.000036
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000036
-                  },
-                  "response_token": {
-                    "price": 0.000036
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -4139,58 +3515,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000016
-                  },
-                  "response_token": {
-                    "price": 0.000016
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000028
-                  },
-                  "response_token": {
-                    "price": 0.000028
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000008
-                  },
-                  "response_token": {
-                    "price": 0.000008
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000008
-                  },
-                  "response_token": {
-                    "price": 0.000008
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -4209,58 +3533,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000072
-                  },
-                  "response_token": {
-                    "price": 0.000072
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000126
-                  },
-                  "response_token": {
-                    "price": 0.000126
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000036
-                  },
-                  "response_token": {
-                    "price": 0.000036
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000036
-                  },
-                  "response_token": {
-                    "price": 0.000036
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -8742,58 +8014,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000072
-                  },
-                  "response_token": {
-                    "price": 0.000072
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000126
-                  },
-                  "response_token": {
-                    "price": 0.000126
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000036
-                  },
-                  "response_token": {
-                    "price": 0.000036
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000036
-                  },
-                  "response_token": {
-                    "price": 0.000036
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -8862,58 +8082,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000017
-                  },
-                  "response_token": {
-                    "price": 0.000066
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002975
-                  },
-                  "response_token": {
-                    "price": 0.0001155
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000085
-                  },
-                  "response_token": {
-                    "price": 0.000033
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000085
-                  },
-                  "response_token": {
-                    "price": 0.000033
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -8932,58 +8100,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000024
-                  },
-                  "response_token": {
-                    "price": 0.000097
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000042
-                  },
-                  "response_token": {
-                    "price": 0.00016975
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000012
-                  },
-                  "response_token": {
-                    "price": 0.0000485
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000012
-                  },
-                  "response_token": {
-                    "price": 0.0000485
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -9449,58 +8565,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000002
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000001
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000001
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -9530,102 +8594,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0005
-                  },
-                  "response_token": {
-                    "price": 0.0025
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000625
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00005
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.001
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000875
-                  },
-                  "response_token": {
-                    "price": 0.004375
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00109375
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000875
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00175
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00025
-                  },
-                  "response_token": {
-                    "price": 0.00125
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0003125
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000025
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0005
-                    }
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00025
-                  },
-                  "response_token": {
-                    "price": 0.00125
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000625
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00005
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.001
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {
@@ -12212,58 +11180,6 @@
               }
             }
           }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000002
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000001
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000001
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            }
-          }
         }
       }
     }
@@ -12530,58 +11446,6 @@
     "custom_pricing": {
       "regions": {
         "default": {
-          "execution_modes": {
-            "standard": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002
-                  },
-                  "response_token": {
-                    "price": 0.0006
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00035
-                  },
-                  "response_token": {
-                    "price": 0.00105
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001
-                  },
-                  "response_token": {
-                    "price": 0.0003
-                  }
-                }
-              }
-            },
-            "batch": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001
-                  },
-                  "response_token": {
-                    "price": 0.0003
-                  }
-                }
-              }
-            }
-          }
-        },
-        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
           "execution_modes": {
             "standard": {
               "pricing_config": {

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -63,30 +63,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000035
-                  },
-                  "response_token": {
-                    "price": 0.000105
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -131,30 +107,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.00001
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -192,30 +144,6 @@
                 "pay_as_you_go": {
                   "request_token": {
                     "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000005
                   },
                   "response_token": {
                     "price": 0
@@ -399,30 +327,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.175
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.05
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -527,30 +431,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00013125
-                  },
-                  "response_token": {
-                    "price": 0.000175
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000375
-                  },
-                  "response_token": {
-                    "price": 0.00005
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -591,30 +471,6 @@
                   },
                   "response_token": {
                     "price": 0.000256
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00034125
-                  },
-                  "response_token": {
-                    "price": 0.000448
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000975
-                  },
-                  "response_token": {
-                    "price": 0.000128
                   }
                 }
               }
@@ -1831,30 +1687,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00007
-                  },
-                  "response_token": {
-                    "price": 0.000105
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002
-                  },
-                  "response_token": {
-                    "price": 0.00003
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -1895,30 +1727,6 @@
                   },
                   "response_token": {
                     "price": 0.00035
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00046375
-                  },
-                  "response_token": {
-                    "price": 0.0006125
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001325
-                  },
-                  "response_token": {
-                    "price": 0.000175
                   }
                 }
               }
@@ -2462,30 +2270,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000385
-                  },
-                  "response_token": {
-                    "price": 0.0000385
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000011
-                  },
-                  "response_token": {
-                    "price": 0.000011
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -2526,30 +2310,6 @@
                   },
                   "response_token": {
                     "price": 0.000072
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00009
-                  },
-                  "response_token": {
-                    "price": 0.00009
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000036
-                  },
-                  "response_token": {
-                    "price": 0.000036
                   }
                 }
               }
@@ -2598,30 +2358,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00042
-                  },
-                  "response_token": {
-                    "price": 0.00042
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00012
-                  },
-                  "response_token": {
-                    "price": 0.00012
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -2646,30 +2382,6 @@
                   },
                   "response_token": {
                     "price": 0.00024
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0003
-                  },
-                  "response_token": {
-                    "price": 0.0003
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00012
-                  },
-                  "response_token": {
-                    "price": 0.00012
                   }
                 }
               }
@@ -2718,30 +2430,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000175
-                  },
-                  "response_token": {
-                    "price": 0.0000175
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000005
-                  },
-                  "response_token": {
-                    "price": 0.000005
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -2766,30 +2454,6 @@
                   },
                   "response_token": {
                     "price": 0.000013
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002275
-                  },
-                  "response_token": {
-                    "price": 0.00002275
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000065
-                  },
-                  "response_token": {
-                    "price": 0.0000065
                   }
                 }
               }
@@ -2822,30 +2486,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001925
-                  },
-                  "response_token": {
-                    "price": 0.00001925
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000055
-                  },
-                  "response_token": {
-                    "price": 0.0000055
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -2870,30 +2510,6 @@
                   },
                   "response_token": {
                     "price": 0.000013
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002275
-                  },
-                  "response_token": {
-                    "price": 0.00002275
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000065
-                  },
-                  "response_token": {
-                    "price": 0.0000065
                   }
                 }
               }
@@ -2942,30 +2558,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002625
-                  },
-                  "response_token": {
-                    "price": 0.00002625
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000075
-                  },
-                  "response_token": {
-                    "price": 0.0000075
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -2990,30 +2582,6 @@
                   },
                   "response_token": {
                     "price": 0.000019
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00003325
-                  },
-                  "response_token": {
-                    "price": 0.00003325
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000095
-                  },
-                  "response_token": {
-                    "price": 0.0000095
                   }
                 }
               }
@@ -3046,30 +2614,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002975
-                  },
-                  "response_token": {
-                    "price": 0.00002975
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000085
-                  },
-                  "response_token": {
-                    "price": 0.0000085
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -3094,30 +2638,6 @@
                   },
                   "response_token": {
                     "price": 0.00002
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000035
-                  },
-                  "response_token": {
-                    "price": 0.000035
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001
-                  },
-                  "response_token": {
-                    "price": 0.00001
                   }
                 }
               }
@@ -3166,30 +2686,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000028
-                  },
-                  "response_token": {
-                    "price": 0.000028
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000008
-                  },
-                  "response_token": {
-                    "price": 0.000008
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -3230,30 +2726,6 @@
                   },
                   "response_token": {
                     "price": 0.000072
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000126
-                  },
-                  "response_token": {
-                    "price": 0.000126
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000036
-                  },
-                  "response_token": {
-                    "price": 0.000036
                   }
                 }
               }
@@ -3324,52 +2796,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004
-                  },
-                  "response_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -3415,52 +2841,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004
-                  },
-                  "response_token": {
-                    "price": 0.00016
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -3516,52 +2896,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000168
-                  },
-                  "response_token": {
-                    "price": 0.000672
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000048
-                  },
-                  "response_token": {
-                    "price": 0.000192
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -3607,52 +2941,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00016625
-                  },
-                  "response_token": {
-                    "price": 0.000665
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000475
-                  },
-                  "response_token": {
-                    "price": 0.00019
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -3708,52 +2996,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001645
-                  },
-                  "response_token": {
-                    "price": 0.000658
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000047
-                  },
-                  "response_token": {
-                    "price": 0.000188
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -3799,52 +3041,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000189
-                  },
-                  "response_token": {
-                    "price": 0.000756
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000054
-                  },
-                  "response_token": {
-                    "price": 0.000216
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -3900,52 +3096,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000147
-                  },
-                  "response_token": {
-                    "price": 0.000588
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000042
-                  },
-                  "response_token": {
-                    "price": 0.000168
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -3991,52 +3141,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00015225
-                  },
-                  "response_token": {
-                    "price": 0.000609
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000435
-                  },
-                  "response_token": {
-                    "price": 0.000174
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -4092,52 +3196,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00018375
-                  },
-                  "response_token": {
-                    "price": 0.000735
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000525
-                  },
-                  "response_token": {
-                    "price": 0.00021
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -4183,52 +3241,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000224
-                  },
-                  "response_token": {
-                    "price": 0.00091175
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000064
-                  },
-                  "response_token": {
-                    "price": 0.0002605
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -4284,52 +3296,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000154
-                  },
-                  "response_token": {
-                    "price": 0.000616
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000044
-                  },
-                  "response_token": {
-                    "price": 0.000176
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -4375,52 +3341,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000161
-                  },
-                  "response_token": {
-                    "price": 0.000644
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000046
-                  },
-                  "response_token": {
-                    "price": 0.000184
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -4476,52 +3396,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00019775
-                  },
-                  "response_token": {
-                    "price": 0.000791
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000565
-                  },
-                  "response_token": {
-                    "price": 0.000226
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -4567,52 +3441,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002065
-                  },
-                  "response_token": {
-                    "price": 0.000826
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000059
-                  },
-                  "response_token": {
-                    "price": 0.000236
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -4695,52 +3523,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000105
-                  },
-                  "response_token": {
-                    "price": 0.000042
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000003
-                  },
-                  "response_token": {
-                    "price": 0.000012
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -4786,52 +3568,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000105
-                  },
-                  "response_token": {
-                    "price": 0.000042
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000003
-                  },
-                  "response_token": {
-                    "price": 0.000012
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
                     }
                   }
                 }
@@ -4887,52 +3623,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000126
-                  },
-                  "response_token": {
-                    "price": 0.0000504
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000036
-                  },
-                  "response_token": {
-                    "price": 0.0000144
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -4978,52 +3668,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000012425
-                  },
-                  "response_token": {
-                    "price": 0.0000497
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000355
-                  },
-                  "response_token": {
-                    "price": 0.0000142
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
                     }
                   }
                 }
@@ -5079,52 +3723,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000014175
-                  },
-                  "response_token": {
-                    "price": 0.0000567
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000405
-                  },
-                  "response_token": {
-                    "price": 0.0000162
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -5170,52 +3768,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000011025
-                  },
-                  "response_token": {
-                    "price": 0.0000441
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000315
-                  },
-                  "response_token": {
-                    "price": 0.0000126
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
                     }
                   }
                 }
@@ -5271,52 +3823,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000011375
-                  },
-                  "response_token": {
-                    "price": 0.0000455
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000325
-                  },
-                  "response_token": {
-                    "price": 0.000013
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -5362,52 +3868,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000112
-                  },
-                  "response_token": {
-                    "price": 0.0000448
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000032
-                  },
-                  "response_token": {
-                    "price": 0.0000128
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
                     }
                   }
                 }
@@ -5463,52 +3923,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001365
-                  },
-                  "response_token": {
-                    "price": 0.0000546
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000039
-                  },
-                  "response_token": {
-                    "price": 0.0000156
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -5554,52 +3968,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000168
-                  },
-                  "response_token": {
-                    "price": 0.0000672
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000048
-                  },
-                  "response_token": {
-                    "price": 0.0000192
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
                     }
                   }
                 }
@@ -5655,52 +4023,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00001155
-                  },
-                  "response_token": {
-                    "price": 0.0000462
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000033
-                  },
-                  "response_token": {
-                    "price": 0.0000132
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -5746,52 +4068,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000012075
-                  },
-                  "response_token": {
-                    "price": 0.0000483
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000345
-                  },
-                  "response_token": {
-                    "price": 0.0000138
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
                     }
                   }
                 }
@@ -5847,52 +4123,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000147
-                  },
-                  "response_token": {
-                    "price": 0.0000588
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000042
-                  },
-                  "response_token": {
-                    "price": 0.0000168
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -5938,52 +4168,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000012
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000154
-                  },
-                  "response_token": {
-                    "price": 0.0000616
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000021
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00000525
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000021
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000044
-                  },
-                  "response_token": {
-                    "price": 0.0000176
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.000006
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000015
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.000006
                     }
                   }
                 }
@@ -6066,52 +4250,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006125
-                  },
-                  "response_token": {
-                    "price": 0.0000245
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000175
-                  },
-                  "response_token": {
-                    "price": 0.000007
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -6157,52 +4295,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006125
-                  },
-                  "response_token": {
-                    "price": 0.0000245
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000175
-                  },
-                  "response_token": {
-                    "price": 0.000007
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
                     }
                   }
                 }
@@ -6258,52 +4350,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000735
-                  },
-                  "response_token": {
-                    "price": 0.0000294
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000021
-                  },
-                  "response_token": {
-                    "price": 0.0000084
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -6349,52 +4395,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000007175
-                  },
-                  "response_token": {
-                    "price": 0.0000287
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000205
-                  },
-                  "response_token": {
-                    "price": 0.0000082
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
                     }
                   }
                 }
@@ -6450,52 +4450,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000008225
-                  },
-                  "response_token": {
-                    "price": 0.0000329
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000235
-                  },
-                  "response_token": {
-                    "price": 0.0000094
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -6541,52 +4495,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006475
-                  },
-                  "response_token": {
-                    "price": 0.0000259
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000185
-                  },
-                  "response_token": {
-                    "price": 0.0000074
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
                     }
                   }
                 }
@@ -6642,52 +4550,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000805
-                  },
-                  "response_token": {
-                    "price": 0.0000322
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000023
-                  },
-                  "response_token": {
-                    "price": 0.0000092
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -6733,52 +4595,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000665
-                  },
-                  "response_token": {
-                    "price": 0.0000266
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000019
-                  },
-                  "response_token": {
-                    "price": 0.0000076
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
                     }
                   }
                 }
@@ -6834,52 +4650,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000098
-                  },
-                  "response_token": {
-                    "price": 0.0000392
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000028
-                  },
-                  "response_token": {
-                    "price": 0.0000112
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -6925,52 +4695,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000006825
-                  },
-                  "response_token": {
-                    "price": 0.0000273
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000195
-                  },
-                  "response_token": {
-                    "price": 0.0000078
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
                     }
                   }
                 }
@@ -7026,52 +4750,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000007
-                  },
-                  "response_token": {
-                    "price": 0.000028
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000002
-                  },
-                  "response_token": {
-                    "price": 0.000008
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -7122,52 +4800,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000008575
-                  },
-                  "response_token": {
-                    "price": 0.0000343
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00000245
-                  },
-                  "response_token": {
-                    "price": 0.0000098
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -7213,52 +4845,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.000007
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000091
-                  },
-                  "response_token": {
-                    "price": 0.0000364
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00001225
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000030625
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00001225
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000026
-                  },
-                  "response_token": {
-                    "price": 0.0000104
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0000035
-                  },
-                  "cache_read_input_token": {
-                    "price": 8.75e-7
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0000035
                     }
                   }
                 }
@@ -7377,30 +4963,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000126
-                  },
-                  "response_token": {
-                    "price": 0.000126
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000036
-                  },
-                  "response_token": {
-                    "price": 0.000036
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -7445,30 +5007,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00002975
-                  },
-                  "response_token": {
-                    "price": 0.0001155
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000085
-                  },
-                  "response_token": {
-                    "price": 0.000033
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -7509,30 +5047,6 @@
                   },
                   "response_token": {
                     "price": 0.000097
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000042
-                  },
-                  "response_token": {
-                    "price": 0.00016975
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000012
-                  },
-                  "response_token": {
-                    "price": 0.0000485
                   }
                 }
               }
@@ -7928,30 +5442,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000001
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -8013,52 +5503,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.001
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000875
-                  },
-                  "response_token": {
-                    "price": 0.004375
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00109375
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.0000875
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00175
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00025
-                  },
-                  "response_token": {
-                    "price": 0.00125
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.0003125
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.000025
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.0005
                     }
                   }
                 }
@@ -8942,52 +6386,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004
-                  },
-                  "response_token": {
-                    "price": 0.00016
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -9033,52 +6431,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00014
-                  },
-                  "response_token": {
-                    "price": 0.00056
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00004
-                  },
-                  "response_token": {
-                    "price": 0.00016
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -9134,52 +6486,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000168
-                  },
-                  "response_token": {
-                    "price": 0.000672
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000048
-                  },
-                  "response_token": {
-                    "price": 0.000192
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -9225,52 +6531,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00016625
-                  },
-                  "response_token": {
-                    "price": 0.000665
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000475
-                  },
-                  "response_token": {
-                    "price": 0.00019
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -9326,52 +6586,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0001645
-                  },
-                  "response_token": {
-                    "price": 0.000658
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000047
-                  },
-                  "response_token": {
-                    "price": 0.000188
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -9417,52 +6631,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000189
-                  },
-                  "response_token": {
-                    "price": 0.000756
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000054
-                  },
-                  "response_token": {
-                    "price": 0.000216
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -9518,52 +6686,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000147
-                  },
-                  "response_token": {
-                    "price": 0.000588
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000042
-                  },
-                  "response_token": {
-                    "price": 0.000168
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -9609,52 +6731,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00015225
-                  },
-                  "response_token": {
-                    "price": 0.000609
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000435
-                  },
-                  "response_token": {
-                    "price": 0.000174
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -9710,52 +6786,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00018375
-                  },
-                  "response_token": {
-                    "price": 0.000735
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000525
-                  },
-                  "response_token": {
-                    "price": 0.00021
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -9801,52 +6831,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000224
-                  },
-                  "response_token": {
-                    "price": 0.00091175
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000064
-                  },
-                  "response_token": {
-                    "price": 0.0002605
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -9902,52 +6886,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000154
-                  },
-                  "response_token": {
-                    "price": 0.000616
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000044
-                  },
-                  "response_token": {
-                    "price": 0.000176
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -9993,52 +6931,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000161
-                  },
-                  "response_token": {
-                    "price": 0.000644
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000046
-                  },
-                  "response_token": {
-                    "price": 0.000184
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -10094,52 +6986,6 @@
                 }
               }
             },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.00019775
-                  },
-                  "response_token": {
-                    "price": 0.000791
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000565
-                  },
-                  "response_token": {
-                    "price": 0.000226
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
-                    }
-                  }
-                }
-              }
-            },
             "batch": {
               "pricing_config": {
                 "pay_as_you_go": {
@@ -10185,52 +7031,6 @@
                   "additional_units": {
                     "cache_write_1h": {
                       "price": 0.00016
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0002065
-                  },
-                  "response_token": {
-                    "price": 0.000826
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00028
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00007
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00028
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000059
-                  },
-                  "response_token": {
-                    "price": 0.000236
-                  },
-                  "cache_write_input_token": {
-                    "price": 0.00008
-                  },
-                  "cache_read_input_token": {
-                    "price": 0.00002
-                  },
-                  "additional_units": {
-                    "cache_write_1h": {
-                      "price": 0.00008
                     }
                   }
                 }
@@ -10336,30 +7136,6 @@
                 "pay_as_you_go": {
                   "request_token": {
                     "price": 0.000002
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "priority": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.0000035
-                  },
-                  "response_token": {
-                    "price": 0
-                  }
-                }
-              }
-            },
-            "flex": {
-              "pricing_config": {
-                "pay_as_you_go": {
-                  "request_token": {
-                    "price": 0.000001
                   },
                   "response_token": {
                     "price": 0

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -2490,10 +2490,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 0.0000055
                   },
                   "response_token": {
-                    "price": 0.000005
+                    "price": 0.0000055
                   }
                 }
               }
@@ -2518,10 +2518,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 0.0000065
                   },
                   "response_token": {
-                    "price": 0.000005
+                    "price": 0.0000065
                   }
                 }
               }
@@ -2618,10 +2618,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000075
+                    "price": 0.0000085
                   },
                   "response_token": {
-                    "price": 0.0000075
+                    "price": 0.0000085
                   }
                 }
               }
@@ -2646,10 +2646,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000075
+                    "price": 0.00001
                   },
                   "response_token": {
-                    "price": 0.0000075
+                    "price": 0.00001
                   }
                 }
               }
@@ -2754,7 +2754,7 @@
           "price": 0.00008
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00032
         },
         "cache_read_input_token": {
           "price": 0.00004

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -46,6 +46,162 @@
           "price": 0.00006
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "amazon.titan-text-lite-v1": {
@@ -58,6 +214,162 @@
           "price": 0.00002
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "amazon.titan-embed-text-v1": {
@@ -68,6 +380,162 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -214,6 +682,162 @@
           "price": 0
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.1
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.175
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.05
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.05
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.1
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.175
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.1
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.175
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.05
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.05
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.1
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.175
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "cohere.command-text-v14": {
@@ -286,6 +910,162 @@
           "price": 0.0001
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000075
+                  },
+                  "response_token": {
+                    "price": 0.0001
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00013125
+                  },
+                  "response_token": {
+                    "price": 0.000175
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000375
+                  },
+                  "response_token": {
+                    "price": 0.00005
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000375
+                  },
+                  "response_token": {
+                    "price": 0.00005
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000075
+                  },
+                  "response_token": {
+                    "price": 0.0001
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00013125
+                  },
+                  "response_token": {
+                    "price": 0.000175
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000075
+                  },
+                  "response_token": {
+                    "price": 0.0001
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00013125
+                  },
+                  "response_token": {
+                    "price": 0.000175
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000375
+                  },
+                  "response_token": {
+                    "price": 0.00005
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000375
+                  },
+                  "response_token": {
+                    "price": 0.00005
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000075
+                  },
+                  "response_token": {
+                    "price": 0.0001
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00013125
+                  },
+                  "response_token": {
+                    "price": 0.000175
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "meta.llama2-70b-chat-v1": {
@@ -296,6 +1076,162 @@
         },
         "response_token": {
           "price": 0.000256
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000195
+                  },
+                  "response_token": {
+                    "price": 0.000256
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00034125
+                  },
+                  "response_token": {
+                    "price": 0.000448
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000975
+                  },
+                  "response_token": {
+                    "price": 0.000128
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000975
+                  },
+                  "response_token": {
+                    "price": 0.000128
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000195
+                  },
+                  "response_token": {
+                    "price": 0.000256
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00034125
+                  },
+                  "response_token": {
+                    "price": 0.000448
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000195
+                  },
+                  "response_token": {
+                    "price": 0.000256
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00034125
+                  },
+                  "response_token": {
+                    "price": 0.000448
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000975
+                  },
+                  "response_token": {
+                    "price": 0.000128
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000975
+                  },
+                  "response_token": {
+                    "price": 0.000128
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000195
+                  },
+                  "response_token": {
+                    "price": 0.000256
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00034125
+                  },
+                  "response_token": {
+                    "price": 0.000448
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -358,6 +1294,542 @@
           "price": 0.00002
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.000024
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.000024
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2,eu-west-2,eu-west-3": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.000026
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.0000455
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.000013
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.000013
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.000026
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.0000455
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ca-central-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000017
+                  },
+                  "response_token": {
+                    "price": 0.000023
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002975
+                  },
+                  "response_token": {
+                    "price": 0.00004025
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000085
+                  },
+                  "response_token": {
+                    "price": 0.0000115
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000085
+                  },
+                  "response_token": {
+                    "price": 0.0000115
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000017
+                  },
+                  "response_token": {
+                    "price": 0.000023
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002975
+                  },
+                  "response_token": {
+                    "price": 0.00004025
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000022
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.0000385
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000011
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000011
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000022
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.0000385
+                  }
+                }
+              }
+            }
+          }
+        },
+        "sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000034
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004375
+                  },
+                  "response_token": {
+                    "price": 0.0000595
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000125
+                  },
+                  "response_token": {
+                    "price": 0.000017
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000125
+                  },
+                  "response_token": {
+                    "price": 0.000017
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000034
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004375
+                  },
+                  "response_token": {
+                    "price": 0.0000595
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "mistral.mixtral-8x7b-instruct-v0:1": {
@@ -368,6 +1840,542 @@
         },
         "response_token": {
           "price": 0.00007
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000045
+                  },
+                  "response_token": {
+                    "price": 0.00007
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00007875
+                  },
+                  "response_token": {
+                    "price": 0.0001225
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000225
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000225
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000045
+                  },
+                  "response_token": {
+                    "price": 0.00007
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00007875
+                  },
+                  "response_token": {
+                    "price": 0.0001225
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000045
+                  },
+                  "response_token": {
+                    "price": 0.00007
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00007875
+                  },
+                  "response_token": {
+                    "price": 0.0001225
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000225
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000225
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000045
+                  },
+                  "response_token": {
+                    "price": 0.00007
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00007875
+                  },
+                  "response_token": {
+                    "price": 0.0001225
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000054
+                  },
+                  "response_token": {
+                    "price": 0.000084
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000945
+                  },
+                  "response_token": {
+                    "price": 0.000147
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000027
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000027
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000054
+                  },
+                  "response_token": {
+                    "price": 0.000084
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000945
+                  },
+                  "response_token": {
+                    "price": 0.000147
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2,eu-west-2,eu-west-3": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000059
+                  },
+                  "response_token": {
+                    "price": 0.000091
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010325
+                  },
+                  "response_token": {
+                    "price": 0.00015925
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000295
+                  },
+                  "response_token": {
+                    "price": 0.0000455
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000295
+                  },
+                  "response_token": {
+                    "price": 0.0000455
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000059
+                  },
+                  "response_token": {
+                    "price": 0.000091
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010325
+                  },
+                  "response_token": {
+                    "price": 0.00015925
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ca-central-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000052
+                  },
+                  "response_token": {
+                    "price": 0.000081
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000091
+                  },
+                  "response_token": {
+                    "price": 0.00014175
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000026
+                  },
+                  "response_token": {
+                    "price": 0.0000405
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000026
+                  },
+                  "response_token": {
+                    "price": 0.0000405
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000052
+                  },
+                  "response_token": {
+                    "price": 0.000081
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000091
+                  },
+                  "response_token": {
+                    "price": 0.00014175
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000049
+                  },
+                  "response_token": {
+                    "price": 0.000076
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008575
+                  },
+                  "response_token": {
+                    "price": 0.000133
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000245
+                  },
+                  "response_token": {
+                    "price": 0.000038
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000245
+                  },
+                  "response_token": {
+                    "price": 0.000038
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000049
+                  },
+                  "response_token": {
+                    "price": 0.000076
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008575
+                  },
+                  "response_token": {
+                    "price": 0.000133
+                  }
+                }
+              }
+            }
+          }
+        },
+        "sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000076
+                  },
+                  "response_token": {
+                    "price": 0.000118
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000133
+                  },
+                  "response_token": {
+                    "price": 0.0002065
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000038
+                  },
+                  "response_token": {
+                    "price": 0.000059
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000038
+                  },
+                  "response_token": {
+                    "price": 0.000059
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000076
+                  },
+                  "response_token": {
+                    "price": 0.000118
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000133
+                  },
+                  "response_token": {
+                    "price": 0.0002065
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -382,6 +2390,162 @@
           "price": 0.0003
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000175
+                  },
+                  "response_token": {
+                    "price": 0.000525
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000175
+                  },
+                  "response_token": {
+                    "price": 0.000525
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000175
+                  },
+                  "response_token": {
+                    "price": 0.000525
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000175
+                  },
+                  "response_token": {
+                    "price": 0.000525
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "mistral.mistral-large-2407-v1:0": {
@@ -392,6 +2556,162 @@
         },
         "response_token": {
           "price": 0.0006
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00035
+                  },
+                  "response_token": {
+                    "price": 0.00105
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.00045
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00035
+                  },
+                  "response_token": {
+                    "price": 0.00105
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00035
+                  },
+                  "response_token": {
+                    "price": 0.00105
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.00045
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00035
+                  },
+                  "response_token": {
+                    "price": 0.00105
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -406,6 +2726,542 @@
           "price": 0.0012
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0004
+                  },
+                  "response_token": {
+                    "price": 0.0012
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0007
+                  },
+                  "response_token": {
+                    "price": 0.0021
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0004
+                  },
+                  "response_token": {
+                    "price": 0.0012
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0007
+                  },
+                  "response_token": {
+                    "price": 0.0021
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0004
+                  },
+                  "response_token": {
+                    "price": 0.0012
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0007
+                  },
+                  "response_token": {
+                    "price": 0.0021
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0004
+                  },
+                  "response_token": {
+                    "price": 0.0012
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0007
+                  },
+                  "response_token": {
+                    "price": 0.0021
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00048
+                  },
+                  "response_token": {
+                    "price": 0.00144
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00084
+                  },
+                  "response_token": {
+                    "price": 0.00252
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00024
+                  },
+                  "response_token": {
+                    "price": 0.00072
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00024
+                  },
+                  "response_token": {
+                    "price": 0.00072
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00048
+                  },
+                  "response_token": {
+                    "price": 0.00144
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00084
+                  },
+                  "response_token": {
+                    "price": 0.00252
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2,eu-west-2,eu-west-3": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00052
+                  },
+                  "response_token": {
+                    "price": 0.00156
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00091
+                  },
+                  "response_token": {
+                    "price": 0.00273
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00026
+                  },
+                  "response_token": {
+                    "price": 0.00078
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00026
+                  },
+                  "response_token": {
+                    "price": 0.00078
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00052
+                  },
+                  "response_token": {
+                    "price": 0.00156
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00091
+                  },
+                  "response_token": {
+                    "price": 0.00273
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ca-central-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00046
+                  },
+                  "response_token": {
+                    "price": 0.00138
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000805
+                  },
+                  "response_token": {
+                    "price": 0.002415
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00023
+                  },
+                  "response_token": {
+                    "price": 0.00069
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00023
+                  },
+                  "response_token": {
+                    "price": 0.00069
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00046
+                  },
+                  "response_token": {
+                    "price": 0.00138
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000805
+                  },
+                  "response_token": {
+                    "price": 0.002415
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00043
+                  },
+                  "response_token": {
+                    "price": 0.0013
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0007525
+                  },
+                  "response_token": {
+                    "price": 0.002275
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000215
+                  },
+                  "response_token": {
+                    "price": 0.00065
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000215
+                  },
+                  "response_token": {
+                    "price": 0.00065
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00043
+                  },
+                  "response_token": {
+                    "price": 0.0013
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0007525
+                  },
+                  "response_token": {
+                    "price": 0.002275
+                  }
+                }
+              }
+            }
+          }
+        },
+        "sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00067
+                  },
+                  "response_token": {
+                    "price": 0.00202
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0011725
+                  },
+                  "response_token": {
+                    "price": 0.003535
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000335
+                  },
+                  "response_token": {
+                    "price": 0.00101
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000335
+                  },
+                  "response_token": {
+                    "price": 0.00101
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00067
+                  },
+                  "response_token": {
+                    "price": 0.00202
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0011725
+                  },
+                  "response_token": {
+                    "price": 0.003535
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "meta.llama3-8b-instruct-v1:0": {
@@ -418,6 +3274,162 @@
           "price": 0.00006
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00007
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00007
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00007
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00007
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "meta.llama3-70b-instruct-v1:0": {
@@ -428,6 +3440,162 @@
         },
         "response_token": {
           "price": 0.00035
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000265
+                  },
+                  "response_token": {
+                    "price": 0.00035
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00046375
+                  },
+                  "response_token": {
+                    "price": 0.0006125
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001325
+                  },
+                  "response_token": {
+                    "price": 0.000175
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001325
+                  },
+                  "response_token": {
+                    "price": 0.000175
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000265
+                  },
+                  "response_token": {
+                    "price": 0.00035
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00046375
+                  },
+                  "response_token": {
+                    "price": 0.0006125
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000265
+                  },
+                  "response_token": {
+                    "price": 0.00035
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00046375
+                  },
+                  "response_token": {
+                    "price": 0.0006125
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001325
+                  },
+                  "response_token": {
+                    "price": 0.000175
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001325
+                  },
+                  "response_token": {
+                    "price": 0.000175
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000265
+                  },
+                  "response_token": {
+                    "price": 0.00035
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00046375
+                  },
+                  "response_token": {
+                    "price": 0.0006125
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -937,6 +4105,162 @@
           "price": 0.000022
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000022
+                  },
+                  "response_token": {
+                    "price": 0.000022
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000385
+                  },
+                  "response_token": {
+                    "price": 0.0000385
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011
+                  },
+                  "response_token": {
+                    "price": 0.000011
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011
+                  },
+                  "response_token": {
+                    "price": 0.000011
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000022
+                  },
+                  "response_token": {
+                    "price": 0.000022
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000385
+                  },
+                  "response_token": {
+                    "price": 0.0000385
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000022
+                  },
+                  "response_token": {
+                    "price": 0.000022
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000385
+                  },
+                  "response_token": {
+                    "price": 0.0000385
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011
+                  },
+                  "response_token": {
+                    "price": 0.000011
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011
+                  },
+                  "response_token": {
+                    "price": 0.000011
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000022
+                  },
+                  "response_token": {
+                    "price": 0.000022
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000385
+                  },
+                  "response_token": {
+                    "price": 0.0000385
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "meta.llama3-1-70b-instruct-v1:0": {
@@ -947,6 +4271,162 @@
         },
         "response_token": {
           "price": 0.000099
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00009
+                  },
+                  "response_token": {
+                    "price": 0.00009
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00009
+                  },
+                  "response_token": {
+                    "price": 0.00009
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00009
+                  },
+                  "response_token": {
+                    "price": 0.00009
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00009
+                  },
+                  "response_token": {
+                    "price": 0.00009
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -961,6 +4441,238 @@
           "price": 0.0016
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00024
+                  },
+                  "response_token": {
+                    "price": 0.00024
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00042
+                  },
+                  "response_token": {
+                    "price": 0.00042
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012
+                  },
+                  "response_token": {
+                    "price": 0.00012
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012
+                  },
+                  "response_token": {
+                    "price": 0.00012
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00024
+                  },
+                  "response_token": {
+                    "price": 0.00024
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00042
+                  },
+                  "response_token": {
+                    "price": 0.00042
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00024
+                  },
+                  "response_token": {
+                    "price": 0.00024
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00042
+                  },
+                  "response_token": {
+                    "price": 0.00042
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012
+                  },
+                  "response_token": {
+                    "price": 0.00012
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012
+                  },
+                  "response_token": {
+                    "price": 0.00012
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00024
+                  },
+                  "response_token": {
+                    "price": 0.00024
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00042
+                  },
+                  "response_token": {
+                    "price": 0.00042
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00024
+                  },
+                  "response_token": {
+                    "price": 0.00024
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0003
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012
+                  },
+                  "response_token": {
+                    "price": 0.00012
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012
+                  },
+                  "response_token": {
+                    "price": 0.00012
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00024
+                  },
+                  "response_token": {
+                    "price": 0.00024
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0003
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "meta.llama3-2-1b-instruct-v1:0": {
@@ -971,6 +4683,390 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000175
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000175
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-2,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000175
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000175
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-central-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000013
+                  },
+                  "response_token": {
+                    "price": 0.000013
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002275
+                  },
+                  "response_token": {
+                    "price": 0.00002275
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000065
+                  },
+                  "response_token": {
+                    "price": 0.0000065
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000065
+                  },
+                  "response_token": {
+                    "price": 0.0000065
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000013
+                  },
+                  "response_token": {
+                    "price": 0.000013
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002275
+                  },
+                  "response_token": {
+                    "price": 0.00002275
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011
+                  },
+                  "response_token": {
+                    "price": 0.000011
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001925
+                  },
+                  "response_token": {
+                    "price": 0.00001925
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000055
+                  },
+                  "response_token": {
+                    "price": 0.0000055
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011
+                  },
+                  "response_token": {
+                    "price": 0.000011
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001925
+                  },
+                  "response_token": {
+                    "price": 0.00001925
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-3": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000013
+                  },
+                  "response_token": {
+                    "price": 0.000013
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002275
+                  },
+                  "response_token": {
+                    "price": 0.00002275
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000065
+                  },
+                  "response_token": {
+                    "price": 0.0000065
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000013
+                  },
+                  "response_token": {
+                    "price": 0.000013
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002275
+                  },
+                  "response_token": {
+                    "price": 0.00002275
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -985,6 +5081,390 @@
           "price": 0.000015
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.00002625
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.00002625
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-2,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.00002625
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.00002625
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-central-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000019
+                  },
+                  "response_token": {
+                    "price": 0.000019
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003325
+                  },
+                  "response_token": {
+                    "price": 0.00003325
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000095
+                  },
+                  "response_token": {
+                    "price": 0.0000095
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000095
+                  },
+                  "response_token": {
+                    "price": 0.0000095
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000019
+                  },
+                  "response_token": {
+                    "price": 0.000019
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003325
+                  },
+                  "response_token": {
+                    "price": 0.00003325
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000017
+                  },
+                  "response_token": {
+                    "price": 0.000017
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002975
+                  },
+                  "response_token": {
+                    "price": 0.00002975
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000085
+                  },
+                  "response_token": {
+                    "price": 0.0000085
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000017
+                  },
+                  "response_token": {
+                    "price": 0.000017
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002975
+                  },
+                  "response_token": {
+                    "price": 0.00002975
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-3": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "meta.llama3-2-11b-instruct-v1:0": {
@@ -997,6 +5477,162 @@
           "price": 0.000035
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000016
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.000028
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000008
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000008
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000016
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.000028
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000016
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.000028
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000008
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000008
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000016
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.000028
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "meta.llama3-2-90b-instruct-v1:0": {
@@ -1007,6 +5643,162 @@
         },
         "response_token": {
           "price": 0.0002
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000126
+                  },
+                  "response_token": {
+                    "price": 0.000126
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000126
+                  },
+                  "response_token": {
+                    "price": 0.000126
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000126
+                  },
+                  "response_token": {
+                    "price": 0.000126
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000126
+                  },
+                  "response_token": {
+                    "price": 0.000126
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1029,6 +5821,2140 @@
         "additional_units": {
           "cache_write_1h": {
             "price": 0.00016
+          }
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-3,ap-south-2,ap-southeast-3,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-2,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-2,us-gov-east-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,us-gov-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000096
+                  },
+                  "response_token": {
+                    "price": 0.000384
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000168
+                  },
+                  "response_token": {
+                    "price": 0.000672
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000048
+                  },
+                  "response_token": {
+                    "price": 0.000192
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000048
+                  },
+                  "response_token": {
+                    "price": 0.000192
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000096
+                  },
+                  "response_token": {
+                    "price": 0.000384
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000168
+                  },
+                  "response_token": {
+                    "price": 0.000672
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000095
+                  },
+                  "response_token": {
+                    "price": 0.00038
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00016625
+                  },
+                  "response_token": {
+                    "price": 0.000665
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000475
+                  },
+                  "response_token": {
+                    "price": 0.00019
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000475
+                  },
+                  "response_token": {
+                    "price": 0.00019
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000095
+                  },
+                  "response_token": {
+                    "price": 0.00038
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00016625
+                  },
+                  "response_token": {
+                    "price": 0.000665
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000094
+                  },
+                  "response_token": {
+                    "price": 0.000376
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001645
+                  },
+                  "response_token": {
+                    "price": 0.000658
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000047
+                  },
+                  "response_token": {
+                    "price": 0.000188
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000047
+                  },
+                  "response_token": {
+                    "price": 0.000188
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000094
+                  },
+                  "response_token": {
+                    "price": 0.000376
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001645
+                  },
+                  "response_token": {
+                    "price": 0.000658
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000108
+                  },
+                  "response_token": {
+                    "price": 0.000432
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000189
+                  },
+                  "response_token": {
+                    "price": 0.000756
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000054
+                  },
+                  "response_token": {
+                    "price": 0.000216
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000054
+                  },
+                  "response_token": {
+                    "price": 0.000216
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000108
+                  },
+                  "response_token": {
+                    "price": 0.000432
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000189
+                  },
+                  "response_token": {
+                    "price": 0.000756
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000084
+                  },
+                  "response_token": {
+                    "price": 0.000336
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000147
+                  },
+                  "response_token": {
+                    "price": 0.000588
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000042
+                  },
+                  "response_token": {
+                    "price": 0.000168
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000042
+                  },
+                  "response_token": {
+                    "price": 0.000168
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000084
+                  },
+                  "response_token": {
+                    "price": 0.000336
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000147
+                  },
+                  "response_token": {
+                    "price": 0.000588
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-4,eu-north-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000087
+                  },
+                  "response_token": {
+                    "price": 0.000348
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015225
+                  },
+                  "response_token": {
+                    "price": 0.000609
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000435
+                  },
+                  "response_token": {
+                    "price": 0.000174
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000435
+                  },
+                  "response_token": {
+                    "price": 0.000174
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000087
+                  },
+                  "response_token": {
+                    "price": 0.000348
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015225
+                  },
+                  "response_token": {
+                    "price": 0.000609
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-central-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.00042
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00018375
+                  },
+                  "response_token": {
+                    "price": 0.000735
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000525
+                  },
+                  "response_token": {
+                    "price": 0.00021
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000525
+                  },
+                  "response_token": {
+                    "price": 0.00021
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.00042
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00018375
+                  },
+                  "response_token": {
+                    "price": 0.000735
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000128
+                  },
+                  "response_token": {
+                    "price": 0.000521
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000224
+                  },
+                  "response_token": {
+                    "price": 0.00091175
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000064
+                  },
+                  "response_token": {
+                    "price": 0.0002605
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000064
+                  },
+                  "response_token": {
+                    "price": 0.0002605
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000128
+                  },
+                  "response_token": {
+                    "price": 0.000521
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000224
+                  },
+                  "response_token": {
+                    "price": 0.00091175
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-south-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000088
+                  },
+                  "response_token": {
+                    "price": 0.000352
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000154
+                  },
+                  "response_token": {
+                    "price": 0.000616
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000044
+                  },
+                  "response_token": {
+                    "price": 0.000176
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000044
+                  },
+                  "response_token": {
+                    "price": 0.000176
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000088
+                  },
+                  "response_token": {
+                    "price": 0.000352
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000154
+                  },
+                  "response_token": {
+                    "price": 0.000616
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000092
+                  },
+                  "response_token": {
+                    "price": 0.000368
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000161
+                  },
+                  "response_token": {
+                    "price": 0.000644
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000046
+                  },
+                  "response_token": {
+                    "price": 0.000184
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000046
+                  },
+                  "response_token": {
+                    "price": 0.000184
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000092
+                  },
+                  "response_token": {
+                    "price": 0.000368
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000161
+                  },
+                  "response_token": {
+                    "price": 0.000644
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000113
+                  },
+                  "response_token": {
+                    "price": 0.000452
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00019775
+                  },
+                  "response_token": {
+                    "price": 0.000791
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000565
+                  },
+                  "response_token": {
+                    "price": 0.000226
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000565
+                  },
+                  "response_token": {
+                    "price": 0.000226
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000113
+                  },
+                  "response_token": {
+                    "price": 0.000452
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00019775
+                  },
+                  "response_token": {
+                    "price": 0.000791
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-3": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000118
+                  },
+                  "response_token": {
+                    "price": 0.000472
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002065
+                  },
+                  "response_token": {
+                    "price": 0.000826
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000059
+                  },
+                  "response_token": {
+                    "price": 0.000236
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000059
+                  },
+                  "response_token": {
+                    "price": 0.000236
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000118
+                  },
+                  "response_token": {
+                    "price": 0.000472
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002065
+                  },
+                  "response_token": {
+                    "price": 0.000826
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1055,6 +7981,2140 @@
           }
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000024
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000105
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000003
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000003
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000024
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000105
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-3,ap-south-2,ap-southeast-3,ap-southeast-6,ca-west-1,eu-central-2,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-2,us-gov-east-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000024
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000105
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000003
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000003
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000024
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000105
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,ap-southeast-5,ap-southeast-7,us-gov-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000072
+                  },
+                  "response_token": {
+                    "price": 0.0000288
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000126
+                  },
+                  "response_token": {
+                    "price": 0.0000504
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000036
+                  },
+                  "response_token": {
+                    "price": 0.0000144
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000036
+                  },
+                  "response_token": {
+                    "price": 0.0000144
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000072
+                  },
+                  "response_token": {
+                    "price": 0.0000288
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000126
+                  },
+                  "response_token": {
+                    "price": 0.0000504
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-2,ap-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000071
+                  },
+                  "response_token": {
+                    "price": 0.0000284
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012425
+                  },
+                  "response_token": {
+                    "price": 0.0000497
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000355
+                  },
+                  "response_token": {
+                    "price": 0.0000142
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000355
+                  },
+                  "response_token": {
+                    "price": 0.0000142
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000071
+                  },
+                  "response_token": {
+                    "price": 0.0000284
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012425
+                  },
+                  "response_token": {
+                    "price": 0.0000497
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000081
+                  },
+                  "response_token": {
+                    "price": 0.0000324
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000014175
+                  },
+                  "response_token": {
+                    "price": 0.0000567
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000405
+                  },
+                  "response_token": {
+                    "price": 0.0000162
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000405
+                  },
+                  "response_token": {
+                    "price": 0.0000162
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000081
+                  },
+                  "response_token": {
+                    "price": 0.0000324
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000014175
+                  },
+                  "response_token": {
+                    "price": 0.0000567
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000063
+                  },
+                  "response_token": {
+                    "price": 0.0000252
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011025
+                  },
+                  "response_token": {
+                    "price": 0.0000441
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000315
+                  },
+                  "response_token": {
+                    "price": 0.0000126
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000315
+                  },
+                  "response_token": {
+                    "price": 0.0000126
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000063
+                  },
+                  "response_token": {
+                    "price": 0.0000252
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011025
+                  },
+                  "response_token": {
+                    "price": 0.0000441
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-4,eu-north-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000065
+                  },
+                  "response_token": {
+                    "price": 0.000026
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011375
+                  },
+                  "response_token": {
+                    "price": 0.0000455
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000325
+                  },
+                  "response_token": {
+                    "price": 0.000013
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000325
+                  },
+                  "response_token": {
+                    "price": 0.000013
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000065
+                  },
+                  "response_token": {
+                    "price": 0.000026
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011375
+                  },
+                  "response_token": {
+                    "price": 0.0000455
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ca-central-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000064
+                  },
+                  "response_token": {
+                    "price": 0.0000256
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000112
+                  },
+                  "response_token": {
+                    "price": 0.0000448
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000032
+                  },
+                  "response_token": {
+                    "price": 0.0000128
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000032
+                  },
+                  "response_token": {
+                    "price": 0.0000128
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000064
+                  },
+                  "response_token": {
+                    "price": 0.0000256
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000112
+                  },
+                  "response_token": {
+                    "price": 0.0000448
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-central-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000078
+                  },
+                  "response_token": {
+                    "price": 0.0000312
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001365
+                  },
+                  "response_token": {
+                    "price": 0.0000546
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000039
+                  },
+                  "response_token": {
+                    "price": 0.0000156
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000039
+                  },
+                  "response_token": {
+                    "price": 0.0000156
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000078
+                  },
+                  "response_token": {
+                    "price": 0.0000312
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001365
+                  },
+                  "response_token": {
+                    "price": 0.0000546
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000096
+                  },
+                  "response_token": {
+                    "price": 0.0000384
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000168
+                  },
+                  "response_token": {
+                    "price": 0.0000672
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000048
+                  },
+                  "response_token": {
+                    "price": 0.0000192
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000048
+                  },
+                  "response_token": {
+                    "price": 0.0000192
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000096
+                  },
+                  "response_token": {
+                    "price": 0.0000384
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000168
+                  },
+                  "response_token": {
+                    "price": 0.0000672
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-south-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000066
+                  },
+                  "response_token": {
+                    "price": 0.0000264
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001155
+                  },
+                  "response_token": {
+                    "price": 0.0000462
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000033
+                  },
+                  "response_token": {
+                    "price": 0.0000132
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000033
+                  },
+                  "response_token": {
+                    "price": 0.0000132
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000066
+                  },
+                  "response_token": {
+                    "price": 0.0000264
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001155
+                  },
+                  "response_token": {
+                    "price": 0.0000462
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000069
+                  },
+                  "response_token": {
+                    "price": 0.0000276
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012075
+                  },
+                  "response_token": {
+                    "price": 0.0000483
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000345
+                  },
+                  "response_token": {
+                    "price": 0.0000138
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000345
+                  },
+                  "response_token": {
+                    "price": 0.0000138
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000069
+                  },
+                  "response_token": {
+                    "price": 0.0000276
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012075
+                  },
+                  "response_token": {
+                    "price": 0.0000483
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000084
+                  },
+                  "response_token": {
+                    "price": 0.0000336
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000147
+                  },
+                  "response_token": {
+                    "price": 0.0000588
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000042
+                  },
+                  "response_token": {
+                    "price": 0.0000168
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000042
+                  },
+                  "response_token": {
+                    "price": 0.0000168
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000084
+                  },
+                  "response_token": {
+                    "price": 0.0000336
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000147
+                  },
+                  "response_token": {
+                    "price": 0.0000588
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-3": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000088
+                  },
+                  "response_token": {
+                    "price": 0.0000352
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000154
+                  },
+                  "response_token": {
+                    "price": 0.0000616
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000044
+                  },
+                  "response_token": {
+                    "price": 0.0000176
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000044
+                  },
+                  "response_token": {
+                    "price": 0.0000176
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000088
+                  },
+                  "response_token": {
+                    "price": 0.0000352
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000154
+                  },
+                  "response_token": {
+                    "price": 0.0000616
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000024
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000105
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000003
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000006
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000006
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000003
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000024
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000012
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000012
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000105
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000525
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000021
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000021
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "amazon.nova-micro-v1:0": {
@@ -1075,6 +10135,1998 @@
         "additional_units": {
           "cache_write_1h": {
             "price": 0.000007
+          }
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.000014
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006125
+                  },
+                  "response_token": {
+                    "price": 0.0000245
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000175
+                  },
+                  "response_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000175
+                  },
+                  "response_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.000014
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006125
+                  },
+                  "response_token": {
+                    "price": 0.0000245
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-3,ap-south-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-2,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-2,us-gov-east-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.000014
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006125
+                  },
+                  "response_token": {
+                    "price": 0.0000245
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000175
+                  },
+                  "response_token": {
+                    "price": 0.000007
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000175
+                  },
+                  "response_token": {
+                    "price": 0.000007
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.000014
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006125
+                  },
+                  "response_token": {
+                    "price": 0.0000245
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,us-gov-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000042
+                  },
+                  "response_token": {
+                    "price": 0.0000168
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000735
+                  },
+                  "response_token": {
+                    "price": 0.0000294
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000021
+                  },
+                  "response_token": {
+                    "price": 0.0000084
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000021
+                  },
+                  "response_token": {
+                    "price": 0.0000084
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000042
+                  },
+                  "response_token": {
+                    "price": 0.0000168
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000735
+                  },
+                  "response_token": {
+                    "price": 0.0000294
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-2,ap-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000041
+                  },
+                  "response_token": {
+                    "price": 0.0000164
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007175
+                  },
+                  "response_token": {
+                    "price": 0.0000287
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000205
+                  },
+                  "response_token": {
+                    "price": 0.0000082
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000205
+                  },
+                  "response_token": {
+                    "price": 0.0000082
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000041
+                  },
+                  "response_token": {
+                    "price": 0.0000164
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007175
+                  },
+                  "response_token": {
+                    "price": 0.0000287
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000047
+                  },
+                  "response_token": {
+                    "price": 0.0000188
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008225
+                  },
+                  "response_token": {
+                    "price": 0.0000329
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000235
+                  },
+                  "response_token": {
+                    "price": 0.0000094
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000235
+                  },
+                  "response_token": {
+                    "price": 0.0000094
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000047
+                  },
+                  "response_token": {
+                    "price": 0.0000188
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008225
+                  },
+                  "response_token": {
+                    "price": 0.0000329
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000037
+                  },
+                  "response_token": {
+                    "price": 0.0000148
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006475
+                  },
+                  "response_token": {
+                    "price": 0.0000259
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000185
+                  },
+                  "response_token": {
+                    "price": 0.0000074
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000185
+                  },
+                  "response_token": {
+                    "price": 0.0000074
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000037
+                  },
+                  "response_token": {
+                    "price": 0.0000148
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006475
+                  },
+                  "response_token": {
+                    "price": 0.0000259
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-central-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000046
+                  },
+                  "response_token": {
+                    "price": 0.0000184
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000805
+                  },
+                  "response_token": {
+                    "price": 0.0000322
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000023
+                  },
+                  "response_token": {
+                    "price": 0.0000092
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000023
+                  },
+                  "response_token": {
+                    "price": 0.0000092
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000046
+                  },
+                  "response_token": {
+                    "price": 0.0000184
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000805
+                  },
+                  "response_token": {
+                    "price": 0.0000322
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-north-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000038
+                  },
+                  "response_token": {
+                    "price": 0.0000152
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000665
+                  },
+                  "response_token": {
+                    "price": 0.0000266
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000019
+                  },
+                  "response_token": {
+                    "price": 0.0000076
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000019
+                  },
+                  "response_token": {
+                    "price": 0.0000076
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000038
+                  },
+                  "response_token": {
+                    "price": 0.0000152
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000665
+                  },
+                  "response_token": {
+                    "price": 0.0000266
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000056
+                  },
+                  "response_token": {
+                    "price": 0.0000224
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000098
+                  },
+                  "response_token": {
+                    "price": 0.0000392
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000028
+                  },
+                  "response_token": {
+                    "price": 0.0000112
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000028
+                  },
+                  "response_token": {
+                    "price": 0.0000112
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000056
+                  },
+                  "response_token": {
+                    "price": 0.0000224
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000098
+                  },
+                  "response_token": {
+                    "price": 0.0000392
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-south-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000039
+                  },
+                  "response_token": {
+                    "price": 0.0000156
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006825
+                  },
+                  "response_token": {
+                    "price": 0.0000273
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000195
+                  },
+                  "response_token": {
+                    "price": 0.0000078
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000195
+                  },
+                  "response_token": {
+                    "price": 0.0000078
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000039
+                  },
+                  "response_token": {
+                    "price": 0.0000156
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006825
+                  },
+                  "response_token": {
+                    "price": 0.0000273
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000004
+                  },
+                  "response_token": {
+                    "price": 0.000016
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.000028
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0.000008
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0.000008
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000004
+                  },
+                  "response_token": {
+                    "price": 0.000016
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.000028
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000049
+                  },
+                  "response_token": {
+                    "price": 0.0000196
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008575
+                  },
+                  "response_token": {
+                    "price": 0.0000343
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000245
+                  },
+                  "response_token": {
+                    "price": 0.0000098
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000245
+                  },
+                  "response_token": {
+                    "price": 0.0000098
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000049
+                  },
+                  "response_token": {
+                    "price": 0.0000196
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008575
+                  },
+                  "response_token": {
+                    "price": 0.0000343
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-3": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000052
+                  },
+                  "response_token": {
+                    "price": 0.0000208
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000091
+                  },
+                  "response_token": {
+                    "price": 0.0000364
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000026
+                  },
+                  "response_token": {
+                    "price": 0.0000104
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000026
+                  },
+                  "response_token": {
+                    "price": 0.0000104
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000052
+                  },
+                  "response_token": {
+                    "price": 0.0000208
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000091
+                  },
+                  "response_token": {
+                    "price": 0.0000364
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.000014
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006125
+                  },
+                  "response_token": {
+                    "price": 0.0000245
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000175
+                  },
+                  "response_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 8.75e-7
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0000035
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0000035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000175
+                  },
+                  "response_token": {
+                    "price": 0.000007
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.000014
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000175
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.000007
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006125
+                  },
+                  "response_token": {
+                    "price": 0.0000245
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000030625
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00001225
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00001225
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1148,6 +12200,162 @@
           "price": 0.000072
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000126
+                  },
+                  "response_token": {
+                    "price": 0.000126
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000126
+                  },
+                  "response_token": {
+                    "price": 0.000126
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000126
+                  },
+                  "response_token": {
+                    "price": 0.000126
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000126
+                  },
+                  "response_token": {
+                    "price": 0.000126
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "meta.llama4-scout-17b-instruct-v1:0": {
@@ -1160,6 +12368,162 @@
           "price": 0.000066
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000017
+                  },
+                  "response_token": {
+                    "price": 0.000066
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002975
+                  },
+                  "response_token": {
+                    "price": 0.0001155
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000085
+                  },
+                  "response_token": {
+                    "price": 0.000033
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000085
+                  },
+                  "response_token": {
+                    "price": 0.000033
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000017
+                  },
+                  "response_token": {
+                    "price": 0.000066
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002975
+                  },
+                  "response_token": {
+                    "price": 0.0001155
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000017
+                  },
+                  "response_token": {
+                    "price": 0.000066
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002975
+                  },
+                  "response_token": {
+                    "price": 0.0001155
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000085
+                  },
+                  "response_token": {
+                    "price": 0.000033
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000085
+                  },
+                  "response_token": {
+                    "price": 0.000033
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000017
+                  },
+                  "response_token": {
+                    "price": 0.000066
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002975
+                  },
+                  "response_token": {
+                    "price": 0.0001155
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "meta.llama4-maverick-17b-instruct-v1:0": {
@@ -1170,6 +12534,162 @@
         },
         "response_token": {
           "price": 0.000097
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000024
+                  },
+                  "response_token": {
+                    "price": 0.000097
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000042
+                  },
+                  "response_token": {
+                    "price": 0.00016975
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.0000485
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.0000485
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000024
+                  },
+                  "response_token": {
+                    "price": 0.000097
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000042
+                  },
+                  "response_token": {
+                    "price": 0.00016975
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000024
+                  },
+                  "response_token": {
+                    "price": 0.000097
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000042
+                  },
+                  "response_token": {
+                    "price": 0.00016975
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.0000485
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.0000485
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000024
+                  },
+                  "response_token": {
+                    "price": 0.000097
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000042
+                  },
+                  "response_token": {
+                    "price": 0.00016975
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1521,7 +13041,6 @@
       }
     }
   },
-
   "amazon.titan-embed-text-v2:0": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -1530,6 +13049,162 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1555,6 +13230,294 @@
           }
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00005
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.001
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000875
+                  },
+                  "response_token": {
+                    "price": 0.004375
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00109375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000875
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00175
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000025
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0005
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00005
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.001
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00005
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.001
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000875
+                  },
+                  "response_token": {
+                    "price": 0.004375
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00109375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000875
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00175
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00005
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.001
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000875
+                  },
+                  "response_token": {
+                    "price": 0.004375
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00109375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000875
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00175
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.0003125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000025
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.0005
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00005
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.001
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00005
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.001
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000875
+                  },
+                  "response_token": {
+                    "price": 0.004375
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00109375
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000875
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00175
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "openai.gpt-oss-20b-1:0": {
@@ -1565,6 +13528,618 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001225
+                  },
+                  "response_token": {
+                    "price": 0.0000525
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001225
+                  },
+                  "response_token": {
+                    "price": 0.0000525
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001225
+                  },
+                  "response_token": {
+                    "price": 0.0000525
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001225
+                  },
+                  "response_token": {
+                    "price": 0.0000525
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000014
+                  },
+                  "response_token": {
+                    "price": 0.000063
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000004
+                  },
+                  "response_token": {
+                    "price": 0.000018
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000004
+                  },
+                  "response_token": {
+                    "price": 0.000018
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000014
+                  },
+                  "response_token": {
+                    "price": 0.000063
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-south-1,eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000014
+                  },
+                  "response_token": {
+                    "price": 0.00006125
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000004
+                  },
+                  "response_token": {
+                    "price": 0.0000175
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000004
+                  },
+                  "response_token": {
+                    "price": 0.000018
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000014
+                  },
+                  "response_token": {
+                    "price": 0.00006125
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-3": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.000031
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001225
+                  },
+                  "response_token": {
+                    "price": 0.00005425
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.0000155
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000004
+                  },
+                  "response_token": {
+                    "price": 0.000016
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.000031
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001225
+                  },
+                  "response_token": {
+                    "price": 0.00005425
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-central-1,eu-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.00004
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001575
+                  },
+                  "response_token": {
+                    "price": 0.00007
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000045
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.00004
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001575
+                  },
+                  "response_token": {
+                    "price": 0.00007
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011
+                  },
+                  "response_token": {
+                    "price": 0.000047
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001925
+                  },
+                  "response_token": {
+                    "price": 0.00008225
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000055
+                  },
+                  "response_token": {
+                    "price": 0.0000235
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000023
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011
+                  },
+                  "response_token": {
+                    "price": 0.000047
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001925
+                  },
+                  "response_token": {
+                    "price": 0.00008225
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-gov-east-1,us-gov-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000084
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000147
+                  },
+                  "response_token": {
+                    "price": 0.000063
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000042
+                  },
+                  "response_token": {
+                    "price": 0.000018
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000042
+                  },
+                  "response_token": {
+                    "price": 0.000018
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000084
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000147
+                  },
+                  "response_token": {
+                    "price": 0.000063
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1579,6 +14154,694 @@
           "price": 0.00006
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.000105
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.000073
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.00012775
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.0000365
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.000073
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.00012775
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.000071
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.00012425
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.0000355
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.000071
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.00012425
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-3": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000062
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.0001085
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000031
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000031
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000062
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.0001085
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-central-1,eu-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.000079
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.00013825
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.0000395
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00004
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.000079
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.00013825
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.00007
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.0001225
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.00007
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.0001225
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000023
+                  },
+                  "response_token": {
+                    "price": 0.000093
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004025
+                  },
+                  "response_token": {
+                    "price": 0.00016275
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000115
+                  },
+                  "response_token": {
+                    "price": 0.0000465
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.000047
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000023
+                  },
+                  "response_token": {
+                    "price": 0.000093
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004025
+                  },
+                  "response_token": {
+                    "price": 0.00016275
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-gov-east-1,us-gov-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.000126
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.000126
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "us.amazon.nova-pro-v1": {
@@ -1591,9 +14854,2142 @@
           "price": 0.00032
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-3,ap-south-2,ap-southeast-3,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-2,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-2,us-gov-east-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,us-gov-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000096
+                  },
+                  "response_token": {
+                    "price": 0.000384
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000168
+                  },
+                  "response_token": {
+                    "price": 0.000672
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000048
+                  },
+                  "response_token": {
+                    "price": 0.000192
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000048
+                  },
+                  "response_token": {
+                    "price": 0.000192
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000096
+                  },
+                  "response_token": {
+                    "price": 0.000384
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000168
+                  },
+                  "response_token": {
+                    "price": 0.000672
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000095
+                  },
+                  "response_token": {
+                    "price": 0.00038
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00016625
+                  },
+                  "response_token": {
+                    "price": 0.000665
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000475
+                  },
+                  "response_token": {
+                    "price": 0.00019
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000475
+                  },
+                  "response_token": {
+                    "price": 0.00019
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000095
+                  },
+                  "response_token": {
+                    "price": 0.00038
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00016625
+                  },
+                  "response_token": {
+                    "price": 0.000665
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000094
+                  },
+                  "response_token": {
+                    "price": 0.000376
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001645
+                  },
+                  "response_token": {
+                    "price": 0.000658
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000047
+                  },
+                  "response_token": {
+                    "price": 0.000188
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000047
+                  },
+                  "response_token": {
+                    "price": 0.000188
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000094
+                  },
+                  "response_token": {
+                    "price": 0.000376
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001645
+                  },
+                  "response_token": {
+                    "price": 0.000658
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000108
+                  },
+                  "response_token": {
+                    "price": 0.000432
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000189
+                  },
+                  "response_token": {
+                    "price": 0.000756
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000054
+                  },
+                  "response_token": {
+                    "price": 0.000216
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000054
+                  },
+                  "response_token": {
+                    "price": 0.000216
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000108
+                  },
+                  "response_token": {
+                    "price": 0.000432
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000189
+                  },
+                  "response_token": {
+                    "price": 0.000756
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000084
+                  },
+                  "response_token": {
+                    "price": 0.000336
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000147
+                  },
+                  "response_token": {
+                    "price": 0.000588
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000042
+                  },
+                  "response_token": {
+                    "price": 0.000168
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000042
+                  },
+                  "response_token": {
+                    "price": 0.000168
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000084
+                  },
+                  "response_token": {
+                    "price": 0.000336
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000147
+                  },
+                  "response_token": {
+                    "price": 0.000588
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-4,eu-north-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000087
+                  },
+                  "response_token": {
+                    "price": 0.000348
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015225
+                  },
+                  "response_token": {
+                    "price": 0.000609
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000435
+                  },
+                  "response_token": {
+                    "price": 0.000174
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000435
+                  },
+                  "response_token": {
+                    "price": 0.000174
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000087
+                  },
+                  "response_token": {
+                    "price": 0.000348
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015225
+                  },
+                  "response_token": {
+                    "price": 0.000609
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-central-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.00042
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00018375
+                  },
+                  "response_token": {
+                    "price": 0.000735
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000525
+                  },
+                  "response_token": {
+                    "price": 0.00021
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000525
+                  },
+                  "response_token": {
+                    "price": 0.00021
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.00042
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00018375
+                  },
+                  "response_token": {
+                    "price": 0.000735
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000128
+                  },
+                  "response_token": {
+                    "price": 0.000521
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000224
+                  },
+                  "response_token": {
+                    "price": 0.00091175
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000064
+                  },
+                  "response_token": {
+                    "price": 0.0002605
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000064
+                  },
+                  "response_token": {
+                    "price": 0.0002605
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000128
+                  },
+                  "response_token": {
+                    "price": 0.000521
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000224
+                  },
+                  "response_token": {
+                    "price": 0.00091175
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-south-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000088
+                  },
+                  "response_token": {
+                    "price": 0.000352
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000154
+                  },
+                  "response_token": {
+                    "price": 0.000616
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000044
+                  },
+                  "response_token": {
+                    "price": 0.000176
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000044
+                  },
+                  "response_token": {
+                    "price": 0.000176
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000088
+                  },
+                  "response_token": {
+                    "price": 0.000352
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000154
+                  },
+                  "response_token": {
+                    "price": 0.000616
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000092
+                  },
+                  "response_token": {
+                    "price": 0.000368
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000161
+                  },
+                  "response_token": {
+                    "price": 0.000644
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000046
+                  },
+                  "response_token": {
+                    "price": 0.000184
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000046
+                  },
+                  "response_token": {
+                    "price": 0.000184
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000092
+                  },
+                  "response_token": {
+                    "price": 0.000368
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000161
+                  },
+                  "response_token": {
+                    "price": 0.000644
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000113
+                  },
+                  "response_token": {
+                    "price": 0.000452
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00019775
+                  },
+                  "response_token": {
+                    "price": 0.000791
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000565
+                  },
+                  "response_token": {
+                    "price": 0.000226
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000565
+                  },
+                  "response_token": {
+                    "price": 0.000226
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000113
+                  },
+                  "response_token": {
+                    "price": 0.000452
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00019775
+                  },
+                  "response_token": {
+                    "price": 0.000791
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-3": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000118
+                  },
+                  "response_token": {
+                    "price": 0.000472
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002065
+                  },
+                  "response_token": {
+                    "price": 0.000826
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000059
+                  },
+                  "response_token": {
+                    "price": 0.000236
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000059
+                  },
+                  "response_token": {
+                    "price": 0.000236
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000118
+                  },
+                  "response_token": {
+                    "price": 0.000472
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002065
+                  },
+                  "response_token": {
+                    "price": 0.000826
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00008
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00008
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00008
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00004
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00016
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00016
+                    }
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00056
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00007
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00028
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.00028
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
-
   "stability.stable-image-core-v1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -1654,6 +17050,162 @@
         },
         "response_token": {
           "price": 0
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1916,6 +17468,162 @@
           "price": 0.0006
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00035
+                  },
+                  "response_token": {
+                    "price": 0.00105
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00035
+                  },
+                  "response_token": {
+                    "price": 0.00105
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00035
+                  },
+                  "response_token": {
+                    "price": 0.00105
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00035
+                  },
+                  "response_token": {
+                    "price": 0.00105
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "mistral.magistral-small-2509": {
@@ -1926,6 +17634,466 @@
         },
         "response_token": {
           "price": 0.00015
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000875
+                  },
+                  "response_token": {
+                    "price": 0.0002625
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000075
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000075
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000875
+                  },
+                  "response_token": {
+                    "price": 0.0002625
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000875
+                  },
+                  "response_token": {
+                    "price": 0.0002625
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000075
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000075
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000875
+                  },
+                  "response_token": {
+                    "price": 0.0002625
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000061
+                  },
+                  "response_token": {
+                    "price": 0.000182
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010675
+                  },
+                  "response_token": {
+                    "price": 0.0003185
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000305
+                  },
+                  "response_token": {
+                    "price": 0.000091
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000305
+                  },
+                  "response_token": {
+                    "price": 0.000091
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000061
+                  },
+                  "response_token": {
+                    "price": 0.000182
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010675
+                  },
+                  "response_token": {
+                    "price": 0.0003185
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-south-1,eu-south-1,eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000059
+                  },
+                  "response_token": {
+                    "price": 0.000176
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010325
+                  },
+                  "response_token": {
+                    "price": 0.000308
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000295
+                  },
+                  "response_token": {
+                    "price": 0.000088
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000295
+                  },
+                  "response_token": {
+                    "price": 0.000088
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000059
+                  },
+                  "response_token": {
+                    "price": 0.000176
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010325
+                  },
+                  "response_token": {
+                    "price": 0.000308
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000515
+                  },
+                  "response_token": {
+                    "price": 0.0001545
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000090125
+                  },
+                  "response_token": {
+                    "price": 0.000270375
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002575
+                  },
+                  "response_token": {
+                    "price": 0.00007725
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002575
+                  },
+                  "response_token": {
+                    "price": 0.00007725
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000515
+                  },
+                  "response_token": {
+                    "price": 0.0001545
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000090125
+                  },
+                  "response_token": {
+                    "price": 0.000270375
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000078
+                  },
+                  "response_token": {
+                    "price": 0.000233
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001365
+                  },
+                  "response_token": {
+                    "price": 0.00040775
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000039
+                  },
+                  "response_token": {
+                    "price": 0.0001165
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000039
+                  },
+                  "response_token": {
+                    "price": 0.0001165
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000078
+                  },
+                  "response_token": {
+                    "price": 0.000233
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001365
+                  },
+                  "response_token": {
+                    "price": 0.00040775
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1940,6 +18108,390 @@
           "price": 0.00001
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000175
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000175
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000175
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000175
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,ap-south-1,eu-south-1,eu-west-1,sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000021
+                  },
+                  "response_token": {
+                    "price": 0.000021
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000006
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000006
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000021
+                  },
+                  "response_token": {
+                    "price": 0.000021
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000103
+                  },
+                  "response_token": {
+                    "price": 0.0000103
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018025
+                  },
+                  "response_token": {
+                    "price": 0.000018025
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000515
+                  },
+                  "response_token": {
+                    "price": 0.00000515
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000515
+                  },
+                  "response_token": {
+                    "price": 0.00000515
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000103
+                  },
+                  "response_token": {
+                    "price": 0.0000103
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018025
+                  },
+                  "response_token": {
+                    "price": 0.000018025
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000016
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.000028
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000008
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.000008
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000016
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.000028
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "mistral.ministral-3-8b-instruct": {
@@ -1950,6 +18502,390 @@
         },
         "response_token": {
           "price": 0.000015
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.00002625
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.00002625
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.00002625
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002625
+                  },
+                  "response_token": {
+                    "price": 0.00002625
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,ap-south-1,eu-south-1,eu-west-1,sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.000018
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.0000315
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.000009
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000009
+                  },
+                  "response_token": {
+                    "price": 0.000009
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.000018
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000315
+                  },
+                  "response_token": {
+                    "price": 0.0000315
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001545
+                  },
+                  "response_token": {
+                    "price": 0.00001545
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000270375
+                  },
+                  "response_token": {
+                    "price": 0.0000270375
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007725
+                  },
+                  "response_token": {
+                    "price": 0.000007725
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007725
+                  },
+                  "response_token": {
+                    "price": 0.000007725
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001545
+                  },
+                  "response_token": {
+                    "price": 0.00001545
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000270375
+                  },
+                  "response_token": {
+                    "price": 0.0000270375
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000023
+                  },
+                  "response_token": {
+                    "price": 0.000023
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004025
+                  },
+                  "response_token": {
+                    "price": 0.00004025
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000115
+                  },
+                  "response_token": {
+                    "price": 0.0000115
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000115
+                  },
+                  "response_token": {
+                    "price": 0.0000115
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000023
+                  },
+                  "response_token": {
+                    "price": 0.000023
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00004025
+                  },
+                  "response_token": {
+                    "price": 0.00004025
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1964,6 +18900,390 @@
           "price": 0.00002
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000035
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,ap-south-1,eu-south-1,eu-west-1,sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000024
+                  },
+                  "response_token": {
+                    "price": 0.000024
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000042
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.000012
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000024
+                  },
+                  "response_token": {
+                    "price": 0.000024
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000042
+                  },
+                  "response_token": {
+                    "price": 0.000042
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000206
+                  },
+                  "response_token": {
+                    "price": 0.0000206
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003605
+                  },
+                  "response_token": {
+                    "price": 0.00003605
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000103
+                  },
+                  "response_token": {
+                    "price": 0.0000103
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000103
+                  },
+                  "response_token": {
+                    "price": 0.0000103
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000206
+                  },
+                  "response_token": {
+                    "price": 0.0000206
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003605
+                  },
+                  "response_token": {
+                    "price": 0.00003605
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000031
+                  },
+                  "response_token": {
+                    "price": 0.000031
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005425
+                  },
+                  "response_token": {
+                    "price": 0.00005425
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000155
+                  },
+                  "response_token": {
+                    "price": 0.0000155
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000155
+                  },
+                  "response_token": {
+                    "price": 0.0000155
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000031
+                  },
+                  "response_token": {
+                    "price": 0.000031
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005425
+                  },
+                  "response_token": {
+                    "price": 0.00005425
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "mistral.mistral-large-3-675b-instruct": {
@@ -1974,6 +19294,390 @@
         },
         "response_token": {
           "price": 0.00015
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000875
+                  },
+                  "response_token": {
+                    "price": 0.0002625
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000075
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000075
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000875
+                  },
+                  "response_token": {
+                    "price": 0.0002625
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000875
+                  },
+                  "response_token": {
+                    "price": 0.0002625
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000075
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000075
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000875
+                  },
+                  "response_token": {
+                    "price": 0.0002625
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000061
+                  },
+                  "response_token": {
+                    "price": 0.000182
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010675
+                  },
+                  "response_token": {
+                    "price": 0.0003185
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000305
+                  },
+                  "response_token": {
+                    "price": 0.000091
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000305
+                  },
+                  "response_token": {
+                    "price": 0.000091
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000061
+                  },
+                  "response_token": {
+                    "price": 0.000182
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010675
+                  },
+                  "response_token": {
+                    "price": 0.0003185
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000059
+                  },
+                  "response_token": {
+                    "price": 0.000176
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010325
+                  },
+                  "response_token": {
+                    "price": 0.000308
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000295
+                  },
+                  "response_token": {
+                    "price": 0.000088
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000295
+                  },
+                  "response_token": {
+                    "price": 0.000088
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000059
+                  },
+                  "response_token": {
+                    "price": 0.000176
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010325
+                  },
+                  "response_token": {
+                    "price": 0.000308
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000515
+                  },
+                  "response_token": {
+                    "price": 0.0001545
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000090125
+                  },
+                  "response_token": {
+                    "price": 0.000270375
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002575
+                  },
+                  "response_token": {
+                    "price": 0.00007725
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002575
+                  },
+                  "response_token": {
+                    "price": 0.00007725
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000515
+                  },
+                  "response_token": {
+                    "price": 0.0001545
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000090125
+                  },
+                  "response_token": {
+                    "price": 0.000270375
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -1988,6 +19692,390 @@
           "price": 0.000004
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000004
+                  },
+                  "response_token": {
+                    "price": 0.000004
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.000007
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0.000002
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0.000002
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000004
+                  },
+                  "response_token": {
+                    "price": 0.000004
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.000007
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000004
+                  },
+                  "response_token": {
+                    "price": 0.000004
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.000007
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0.000002
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000002
+                  },
+                  "response_token": {
+                    "price": 0.000002
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000004
+                  },
+                  "response_token": {
+                    "price": 0.000004
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.000007
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,ap-south-1,eu-south-1,eu-west-1,sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000875
+                  },
+                  "response_token": {
+                    "price": 0.00000875
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000025
+                  },
+                  "response_token": {
+                    "price": 0.0000025
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000025
+                  },
+                  "response_token": {
+                    "price": 0.0000025
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000875
+                  },
+                  "response_token": {
+                    "price": 0.00000875
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000412
+                  },
+                  "response_token": {
+                    "price": 0.00000412
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000721
+                  },
+                  "response_token": {
+                    "price": 0.00000721
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000206
+                  },
+                  "response_token": {
+                    "price": 0.00000206
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000206
+                  },
+                  "response_token": {
+                    "price": 0.00000206
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000412
+                  },
+                  "response_token": {
+                    "price": 0.00000412
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000721
+                  },
+                  "response_token": {
+                    "price": 0.00000721
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000105
+                  },
+                  "response_token": {
+                    "price": 0.0000105
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000003
+                  },
+                  "response_token": {
+                    "price": 0.000003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000003
+                  },
+                  "response_token": {
+                    "price": 0.000003
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000006
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000105
+                  },
+                  "response_token": {
+                    "price": 0.0000105
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "mistral.voxtral-small-24b-2507": {
@@ -1998,6 +20086,466 @@
         },
         "response_token": {
           "price": 0.00003
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000525
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000525
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000525
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000175
+                  },
+                  "response_token": {
+                    "price": 0.0000525
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000021
+                  },
+                  "response_token": {
+                    "price": 0.000063
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000018
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.000018
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.000036
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000021
+                  },
+                  "response_token": {
+                    "price": 0.000063
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-south-1,eu-south-1,eu-west-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000021
+                  },
+                  "response_token": {
+                    "price": 0.00006125
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.0000175
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000006
+                  },
+                  "response_token": {
+                    "price": 0.0000175
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000012
+                  },
+                  "response_token": {
+                    "price": 0.000035
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000021
+                  },
+                  "response_token": {
+                    "price": 0.00006125
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000103
+                  },
+                  "response_token": {
+                    "price": 0.0000309
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018025
+                  },
+                  "response_token": {
+                    "price": 0.000054075
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000515
+                  },
+                  "response_token": {
+                    "price": 0.00001545
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00000515
+                  },
+                  "response_token": {
+                    "price": 0.00001545
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000103
+                  },
+                  "response_token": {
+                    "price": 0.0000309
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018025
+                  },
+                  "response_token": {
+                    "price": 0.000054075
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000047
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.00008225
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.0000235
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000008
+                  },
+                  "response_token": {
+                    "price": 0.0000235
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000016
+                  },
+                  "response_token": {
+                    "price": 0.000047
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.00008225
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2012,6 +20560,390 @@
           "price": 0.0025
         }
       }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.0004375
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.0004375
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-3,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.0004375
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.0004375
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000073
+                  },
+                  "response_token": {
+                    "price": 0.000303
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012775
+                  },
+                  "response_token": {
+                    "price": 0.00053025
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000365
+                  },
+                  "response_token": {
+                    "price": 0.0001515
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000365
+                  },
+                  "response_token": {
+                    "price": 0.0001515
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000073
+                  },
+                  "response_token": {
+                    "price": 0.000303
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012775
+                  },
+                  "response_token": {
+                    "price": 0.00053025
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-south-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000071
+                  },
+                  "response_token": {
+                    "price": 0.000294
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012425
+                  },
+                  "response_token": {
+                    "price": 0.0005145
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000355
+                  },
+                  "response_token": {
+                    "price": 0.000147
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000355
+                  },
+                  "response_token": {
+                    "price": 0.000147
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000071
+                  },
+                  "response_token": {
+                    "price": 0.000294
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012425
+                  },
+                  "response_token": {
+                    "price": 0.0005145
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000618
+                  },
+                  "response_token": {
+                    "price": 0.0002575
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010815
+                  },
+                  "response_token": {
+                    "price": 0.000450625
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000309
+                  },
+                  "response_token": {
+                    "price": 0.00012875
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000309
+                  },
+                  "response_token": {
+                    "price": 0.00012875
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000618
+                  },
+                  "response_token": {
+                    "price": 0.0002575
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010815
+                  },
+                  "response_token": {
+                    "price": 0.000450625
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "moonshotai.kimi-k2.5": {
@@ -2022,6 +20954,314 @@
         },
         "response_token": {
           "price": 0.003
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.000525
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.000525
+                  }
+                }
+              }
+            }
+          }
+        },
+        "af-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-south-2,ap-southeast-1,ap-southeast-4,ap-southeast-5,ap-southeast-6,ap-southeast-7,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,me-central-1,me-south-1,mx-central-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.000525
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000105
+                  },
+                  "response_token": {
+                    "price": 0.000525
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-northeast-1,ap-south-1,ap-southeast-3,eu-north-1,sa-east-1": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.00036
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000126
+                  },
+                  "response_token": {
+                    "price": 0.00063
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.00018
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000036
+                  },
+                  "response_token": {
+                    "price": 0.00018
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000072
+                  },
+                  "response_token": {
+                    "price": 0.00036
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000126
+                  },
+                  "response_token": {
+                    "price": 0.00063
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ap-southeast-2": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000618
+                  },
+                  "response_token": {
+                    "price": 0.000309
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010815
+                  },
+                  "response_token": {
+                    "price": 0.00054075
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000309
+                  },
+                  "response_token": {
+                    "price": 0.0001545
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000309
+                  },
+                  "response_token": {
+                    "price": 0.0001545
+                  }
+                }
+              }
+            },
+            "provisioned_throughput": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000618
+                  },
+                  "response_token": {
+                    "price": 0.000309
+                  }
+                }
+              }
+            },
+            "reserved": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00010815
+                  },
+                  "response_token": {
+                    "price": 0.00054075
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -2291,10 +2291,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000099
+          "price": 0.000072
         },
         "response_token": {
-          "price": 0.000099
+          "price": 0.000072
         }
       }
     },
@@ -2335,10 +2335,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000532
+          "price": 0.00024
         },
         "response_token": {
-          "price": 0.0016
+          "price": 0.00024
         }
       }
     },
@@ -2663,10 +2663,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000035
+          "price": 0.000016
         },
         "response_token": {
-          "price": 0.000035
+          "price": 0.000016
         }
       }
     },
@@ -2707,10 +2707,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000072
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.000072
         }
       }
     },


### PR DESCRIPTION
source: https://aws.amazon.com/bedrock/pricing/

# Description

Updates `pricing/bedrock.json` from the official Amazon Bedrock pricing page (on-demand / regional Anthropic + non-Anthropic alignment as in this change).

- [ ] New model pricing
- [x] Update existing pricing
- [ ] New model configuration
- [ ] Bug fix

## Source Verification

**Source Link:** https://aws.amazon.com/bedrock/pricing/

> [!IMPORTANT]
> Please include a link to the official pricing page from the provider. Simple "I heard it from somewhere" or screenshot sources are not accepted.

## Checklist

- [ ] I have validated the JSON using `jq` or an online validator
- [ ] I have verified that prices are in **cents per token** (not dollars)
- [x] I have included the source link above
- [ ] I have signed the CLA (if first-time contributor)

## Related Issue

Fixes # (issue)