### PR TITLE
fix(pricing): align DeepSeek v4 and alias model prices with official docs

### DIFF
--- a/pricing/deepseek.json
+++ b/pricing/deepseek.json
@@ -40,16 +40,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000028
+          "price": 0.000014
         },
         "response_token": {
-          "price": 0.000042
+          "price": 0.000028
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000028
+          "price": 0.00000028
         }
       }
     }
@@ -58,16 +58,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000028
+          "price": 0.000014
         },
         "response_token": {
-          "price": 0.000042
+          "price": 0.000028
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000028
+          "price": 0.00000028
         }
       }
     }
@@ -94,16 +94,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000174
+          "price": 0.0000435
         },
         "response_token": {
-          "price": 0.000348
+          "price": 0.000087
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00000145
+          "price": 0.0000003625
         }
       }
     }


### PR DESCRIPTION
### Summary
- Updated `pricing/deepseek.json` to match official DeepSeek pricing for:
  - `deepseek-v4-pro`
  - `deepseek-chat` (deepseek-v4-flash non-thinking alias)
  - `deepseek-reasoner` (deepseek-v4-flash thinking alias)
- Corrected request/output token rates and cache-read input token rates where values were outdated.

### Why
- DeepSeek docs indicate `deepseek-chat` and `deepseek-reasoner` are compatibility aliases for `deepseek-v4-flash`, and current pricing values should reflect the latest official rates.
- This prevents stale cost attribution for DeepSeek models.

### Reference
- [DeepSeek Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing)

### Scope
- Only `pricing/deepseek.json` was updated.
- No code-path or schema changes.