### PR TITLE
add gpt-5.4 models to azure-ai general and pricing configs

### DIFF
--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -2775,6 +2775,230 @@
     ],
     "type": { "primary": "chat", "supported": ["tools", "image"] }
   },
+  "gpt-5.4": {
+    "removeParams": ["max_tokens"],
+    "params": [
+      { "key": "max_completion_tokens", "defaultValue": 20000, "minValue": 1, "maxValue": 272000 },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          { "value": null, "name": "Text" },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": { "type": { "type": "string", "value": "json_object" } }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
+              }
+            },
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["tools", "image"] }
+  },
+  "gpt-5.4-2026-03-05": {
+    "removeParams": ["max_tokens"],
+    "params": [
+      { "key": "max_completion_tokens", "defaultValue": 20000, "minValue": 1, "maxValue": 272000 },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          { "value": null, "name": "Text" },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": { "type": { "type": "string", "value": "json_object" } }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
+              }
+            },
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["tools", "image"] }
+  },
+  "gpt-5.4-mini": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      { "key": "max_completion_tokens", "defaultValue": 20000, "minValue": 1, "maxValue": 272000 },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          { "value": null, "name": "Text" },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": { "type": { "type": "string", "value": "json_object" } }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
+              }
+            },
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["tools", "image"] }
+  },
+  "gpt-5.4-mini-2026-03-17": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      { "key": "max_completion_tokens", "defaultValue": 20000, "minValue": 1, "maxValue": 272000 },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          { "value": null, "name": "Text" },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": { "type": { "type": "string", "value": "json_object" } }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
+              }
+            },
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["tools", "image"] }
+  },
+  "gpt-5.4-nano": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      { "key": "max_completion_tokens", "defaultValue": 20000, "minValue": 1, "maxValue": 272000 },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          { "value": null, "name": "Text" },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": { "type": { "type": "string", "value": "json_object" } }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
+              }
+            },
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["tools", "image"] }
+  },
+  "gpt-5.4-nano-2026-03-17": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      { "key": "max_completion_tokens", "defaultValue": 20000, "minValue": 1, "maxValue": 272000 },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          { "value": null, "name": "Text" },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": { "type": { "type": "string", "value": "json_object" } }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
+              }
+            },
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["tools", "image"] }
+  },
+  "gpt-5.4-pro": {
+    "disablePlayground": true,
+    "type": {
+      "primary": "responses",
+      "supported": ["tools", "image"],
+      "unsupported": ["chat", "messages"]
+    }
+  },
   "grok-3-mini-high": {
     "type": { "primary": "chat", "supported": [] }
   },

--- a/pricing/azure-ai.json
+++ b/pricing/azure-ai.json
@@ -4022,7 +4022,7 @@
           "price": 0.00045
         },
         "cache_read_input_token": {
-          "price": 0.000008
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -4072,6 +4072,95 @@
         },
         "cache_read_input_token": {
           "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.0015
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.4-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.003
+        },
+        "response_token": {
+          "price": 0.018
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.4-mini": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000075
+        },
+        "response_token": {
+          "price": 0.00045
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.4-nano": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.000125
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
         },
         "additional_units": {
           "web_search": {


### PR DESCRIPTION
## Summary
- Adds general capabilities (params, response_format, type) for **gpt-5.4**, **gpt-5.4-2026-03-05**, **gpt-5.4-mini**, **gpt-5.4-mini-2026-03-17**, **gpt-5.4-nano**, **gpt-5.4-nano-2026-03-17**, and **gpt-5.4-pro** to `general/azure-ai.json`
- Adds pricing entries for **gpt-5.4**, **gpt-5.4-pro**, **gpt-5.4-mini**, and **gpt-5.4-nano** to `pricing/azure-ai.json` (dated variants already existed)
- Fixes `gpt-5.4-mini-2026-03-17` cache_read_input_token price from 0.000008 to 0.0000075 (aligning with azure-openai source)
- Mirrors the existing `azure-openai` configs for these models

**Source Link:** https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/

## Checklist
- [x] JSON is valid
- [x] Prices are in cents per token
- [x] Source pricing link included
- [x] Verified against azure-openai configs

## Context
These models were available in Azure OpenAI but missing from the Azure AI (Foundry) provider, preventing users from seeing them in the Model Provisioning UI.