### PR TITLE
feat(pricing): Fireworks AI multidimensional custom_pricing

### DIFF
--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -45,6 +45,46 @@
         "response_token": {
           "price": 0.00005
         }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000025
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00005
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000025
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -56,6 +96,46 @@
         },
         "response_token": {
           "price": 0.00012
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012
+                  },
+                  "response_token": {
+                    "price": 0.00012
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -69,6 +149,46 @@
         "response_token": {
           "price": 0.00012
         }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00012
+                  },
+                  "response_token": {
+                    "price": 0.00012
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -80,6 +200,46 @@
         },
         "response_token": {
           "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0.000005
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0.000005
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -93,6 +253,46 @@
         "response_token": {
           "price": 0.00002
         }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -104,6 +304,46 @@
         },
         "response_token": {
           "price": 0.00009
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00009
+                  },
+                  "response_token": {
+                    "price": 0.00009
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000045
+                  },
+                  "response_token": {
+                    "price": 0.000045
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -117,6 +357,46 @@
         "response_token": {
           "price": 8e-7
         }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 4e-7
+        },
+        "response_token": {
+          "price": 4e-7
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 8e-7
+                  },
+                  "response_token": {
+                    "price": 8e-7
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 4e-7
+                  },
+                  "response_token": {
+                    "price": 4e-7
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -128,6 +408,46 @@
         },
         "response_token": {
           "price": 8e-7
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 4e-7
+        },
+        "response_token": {
+          "price": 4e-7
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 8e-7
+                  },
+                  "response_token": {
+                    "price": 8e-7
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 4e-7
+                  },
+                  "response_token": {
+                    "price": 4e-7
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -141,6 +461,46 @@
         "response_token": {
           "price": 8e-7
         }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 4e-7
+        },
+        "response_token": {
+          "price": 4e-7
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 8e-7
+                  },
+                  "response_token": {
+                    "price": 8e-7
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 4e-7
+                  },
+                  "response_token": {
+                    "price": 4e-7
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -152,6 +512,46 @@
         },
         "response_token": {
           "price": 0.0000016
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 8e-7
+        },
+        "response_token": {
+          "price": 8e-7
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000016
+                  },
+                  "response_token": {
+                    "price": 0.0000016
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 8e-7
+                  },
+                  "response_token": {
+                    "price": 8e-7
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -165,6 +565,46 @@
         "response_token": {
           "price": 0.0000016
         }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 8e-7
+        },
+        "response_token": {
+          "price": 8e-7
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000016
+                  },
+                  "response_token": {
+                    "price": 0.0000016
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 8e-7
+                  },
+                  "response_token": {
+                    "price": 8e-7
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -176,6 +616,46 @@
         },
         "response_token": {
           "price": 0.0003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0003
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -189,6 +669,46 @@
         "response_token": {
           "price": 0.0008
         }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0004
+        },
+        "response_token": {
+          "price": 0.0004
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0008
+                  },
+                  "response_token": {
+                    "price": 0.0008
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0004
+                  },
+                  "response_token": {
+                    "price": 0.0004
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -200,6 +720,1750 @@
         },
         "response_token": {
           "price": 0.000168
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000056
+                  },
+                  "response_token": {
+                    "price": 0.000168
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.000084
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "glm-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00016
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.00032
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00016
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00002
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "minimax-m2p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.00012
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "minimax-m2p5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.00012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "minimax-m2p7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.00012
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000006
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000006
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000045
+                  },
+                  "response_token": {
+                    "price": 0.00018
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000009
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "llama4-scout-instruct-basic": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "llama4-maverick-instruct-basic": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.000088
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000011
+        },
+        "response_token": {
+          "price": 0.000044
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000022
+                  },
+                  "response_token": {
+                    "price": 0.000088
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000011
+                  },
+                  "response_token": {
+                    "price": 0.000044
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "kimi-k2-instruct-0905": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00025
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "kimi-k2-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00025
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "kimi-k2-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00025
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.000125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "kimi-k2p5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "deepseek-v3p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000056
+                  },
+                  "response_token": {
+                    "price": 0.000168
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000028
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.000084
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000028
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "deepseek-v3p2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000056
+        },
+        "response_token": {
+          "price": 0.000168
+        },
+        "cache_read_input_token": {
+          "price": 0.000028
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000028
+        },
+        "response_token": {
+          "price": 0.000084
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000056
+                  },
+                  "response_token": {
+                    "price": 0.000168
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000028
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000028
+                  },
+                  "response_token": {
+                    "price": 0.000084
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000028
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "glm-4p7": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00022
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00011
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00006
+                  },
+                  "response_token": {
+                    "price": 0.00022
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "response_token": {
+                    "price": 0.00011
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "glm-5p1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.000026
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00007
+        },
+        "response_token": {
+          "price": 0.00022
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00044
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000026
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00007
+                  },
+                  "response_token": {
+                    "price": 0.00022
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000026
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00021
+                  },
+                  "response_token": {
+                    "price": 0.00066
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000039
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "kimi-k2p6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000095
+        },
+        "response_token": {
+          "price": 0.0004
+        },
+        "cache_read_input_token": {
+          "price": 0.000016
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000475
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000095
+                  },
+                  "response_token": {
+                    "price": 0.0004
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000016
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000475
+                  },
+                  "response_token": {
+                    "price": 0.0002
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000016
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000022
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "gpt-oss-120b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000018
+                  },
+                  "response_token": {
+                    "price": 0.000072
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000018
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "gpt-oss-20b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000007
+        },
+        "response_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.0000035
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000035
+        },
+        "response_token": {
+          "price": 0.000015
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000007
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000035
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000035
+                  },
+                  "response_token": {
+                    "price": 0.000015
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000035
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "qwen3-vl-30b-a3b-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.00003
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00006
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.00003
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000075
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "llama-v3p3-70b-instruct": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00009
+        },
+        "response_token": {
+          "price": 0.00009
+        },
+        "cache_read_input_token": {
+          "price": 0.000045
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000045
+        },
+        "response_token": {
+          "price": 0.000045
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00009
+                  },
+                  "response_token": {
+                    "price": 0.00009
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000045
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000045
+                  },
+                  "response_token": {
+                    "price": 0.000045
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000045
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "qwen3-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00002
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00002
+                  },
+                  "response_token": {
+                    "price": 0.00002
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0.00001
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00001
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "qwen3p6-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00005
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.000025
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.00005
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000025
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.000025
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000025
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "qwen3-embedding-8b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000005
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00001
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000005
+                  },
+                  "response_token": {
+                    "price": 0
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "flux-1-dev-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.05
+          }
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "additional_units": {
+                    "image_inference_step": {
+                      "price": 0.05
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "additional_units": {
+                    "image_inference_step": {
+                      "price": 0.025
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "flux-1-schnell-fp8": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "additional_units": {
+          "image_inference_step": {
+            "price": 0.035
+          }
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "additional_units": {
+                    "image_inference_step": {
+                      "price": 0.035
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "additional_units": {
+                    "image_inference_step": {
+                      "price": 0.0175
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 4
+            }
+          }
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "image": {
+                    "default": {
+                      "default": {
+                        "price": 4
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "image": {
+                    "default": {
+                      "default": {
+                        "price": 2
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "flux-kontext-max": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "image": {
+          "default": {
+            "default": {
+              "price": 8
+            }
+          }
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "image": {
+                    "default": {
+                      "default": {
+                        "price": 8
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "image": {
+                    "default": {
+                      "default": {
+                        "price": 4
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "kimi-k2p6-turbo": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0008
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0004
+        },
+        "cache_read_input_token": {
+          "price": 0.000015
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0008
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00003
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0004
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000015
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "glm-5p1-fast": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00028
+        },
+        "response_token": {
+          "price": 0.00088
+        },
+        "cache_read_input_token": {
+          "price": 0.000052
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.000026
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00028
+                  },
+                  "response_token": {
+                    "price": 0.00088
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000052
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00014
+                  },
+                  "response_token": {
+                    "price": 0.00044
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000026
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -216,155 +2480,54 @@
         "cache_read_input_token": {
           "price": 0.000014
         }
-      }
-    }
-  },
-  "glm-5": {
-    "pricing_config": {
-      "pay_as_you_go": {
+      },
+      "batch_config": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.000087
         },
         "response_token": {
-          "price": 0.00032
-        }
-      }
-    }
-  },
-  "minimax-m2p1": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        }
-      }
-    }
-  },
-  "minimax-m2p5": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        }
-      }
-    }
-  },
-  "minimax-m2p7": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00003
-        },
-        "response_token": {
-          "price": 0.00012
-        }
-      }
-    }
-  },
-  "llama4-scout-instruct-basic": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000015
-        },
-        "response_token": {
-          "price": 0.00006
-        }
-      }
-    }
-  },
-  "llama4-maverick-instruct-basic": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000022
-        },
-        "response_token": {
-          "price": 0.000088
-        }
-      }
-    }
-  },
-  "kimi-k2-instruct-0905": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00025
-        }
-      }
-    }
-  },
-  "kimi-k2-instruct": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00025
-        }
-      }
-    }
-  },
-  "kimi-k2-thinking": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.00025
-        }
-      }
-    }
-  },
-  "kimi-k2p5": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.00006
-        },
-        "response_token": {
-          "price": 0.0003
-        }
-      }
-    }
-  },
-  "fireworks-ai/kimi-k2p6": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000095
-        },
-        "response_token": {
-          "price": 0.0004
+          "price": 0.000174
         },
         "cache_read_input_token": {
-          "price": 0.000016
+          "price": 0.000007
         }
       }
-    }
-  },
-  "kimi-k2p6": {
-    "pricing_config": {
-      "pay_as_you_go": {
-        "request_token": {
-          "price": 0.000095
-        },
-        "response_token": {
-          "price": 0.0004
-        },
-        "cache_read_input_token": {
-          "price": 0.000016
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000174
+                  },
+                  "response_token": {
+                    "price": 0.000348
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000014
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000087
+                  },
+                  "response_token": {
+                    "price": 0.000174
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000007
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Adds `custom_pricing.regions.default.execution_modes` for all priced Fireworks AI models in `pricing/fireworks-ai.json` only.
- Covers **standard**, **batch** (50% serverless I/O per docs), and **priority** where published on the [serverless pricing page](https://docs.fireworks.ai/serverless/pricing.md).
- Adds fast-model entries (`kimi-k2p6-turbo`, `glm-5p1-fast`) and backfills top-level `batch_config` where missing.

## Scope
- **Single file:** `pricing/fireworks-ai.json` (44 models with `custom_pricing`)

## Test plan
- [ ] `node -e "JSON.parse(require('fs').readFileSync('pricing/fireworks-ai.json'))"`
- [ ] Spot-check `kimi-k2p6`, `glm-5p1`, `gpt-oss-120b` standard / batch / priority rates vs Fireworks docs
- [ ] Confirm PR diff contains only `pricing/fireworks-ai.json`