### PR TITLE
Fix bedrock.json pricing for Moonshot models

### DIFF
--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -2006,10 +2006,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0006
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.0025
+          "price": 0.00025
         }
       }
     }
@@ -2018,10 +2018,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0006
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.003
+          "price": 0.0003
         }
       }
     }


### PR DESCRIPTION
# Description

The pricing details for Moonshot's Kimi models are off by a factor of 10

- [ ] New model pricing
- [x] Update existing pricing
- [ ] New model configuration
- [ ] Bug fix

## Source Verification

**Source Link:** [link](https://aws.amazon.com/bedrock/pricing/)
<img width="1161" height="304" alt="image" src="https://github.com/user-attachments/assets/e0f35017-288e-44ae-8026-c204484454ee" />


## Checklist

- [x] I have validated the JSON using `jq` or an online validator
- [x] I have verified that prices are in **cents per token** (not dollars)
- [x] I have included the source link above
- [x] I have signed the CLA (if first-time contributor)

## Related Issue

Fixes # (issue)
