### PR TITLE
add: Gemini 3 Pro Image and 3.1 Flash Image GA models

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1509,6 +1509,10 @@
     "type": { "primary": "chat" },
     "disablePlayground": true
   },
+  "gemini-3-pro-image": {
+    "type": { "primary": "chat" },
+    "disablePlayground": true
+  },
   "embedding-001": {
     "type": {
       "primary": "embedding"
@@ -1759,6 +1763,12 @@
     "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools", "audio"] }
   },
   "gemini-3.1-flash-image-preview": {
+    "type": {
+      "primary": "image"
+    },
+    "disablePlayground": true
+  },
+  "gemini-3.1-flash-image": {
     "type": {
       "primary": "image"
     },

--- a/general/openrouter.json
+++ b/general/openrouter.json
@@ -3502,6 +3502,19 @@
     ],
     "disablePlayground": true
   },
+  "google/gemini-3-pro-image": {
+    "type": {
+      "primary": "image",
+      "supported": ["image"]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
+      }
+    ],
+    "disablePlayground": true
+  },
   "x-ai/grok-4.1-fast": {
     "type": {
       "primary": "chat",
@@ -4715,6 +4728,19 @@
       {
         "key": "max_tokens",
         "maxValue": 65536
+      }
+    ],
+    "disablePlayground": true
+  },
+  "google/gemini-3.1-flash-image": {
+    "type": {
+      "primary": "image",
+      "supported": ["image"]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
       }
     ],
     "disablePlayground": true

--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1112,6 +1112,10 @@
     "type": { "primary": "chat" },
     "disablePlayground": true
   },
+  "gemini-3.1-flash-image": {
+    "type": { "primary": "chat" },
+    "disablePlayground": true
+  },
   "anthropic.claude-sonnet-4-5@20250929": {
     "name": "claude-sonnet-4-5@20250929",
     "params": [
@@ -1298,6 +1302,10 @@
     "removeParams": ["temperature", "top_p"]
   },
   "gemini-3-pro-image-preview": {
+    "type": { "primary": "chat" },
+    "disablePlayground": true
+  },
+  "gemini-3-pro-image": {
     "type": { "primary": "chat" },
     "disablePlayground": true
   },

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -1644,6 +1644,74 @@
       }
     }
   },
+  "gemini-3-pro-image-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "image_token": {
+            "price": 0.012
+          },
+          "input_image": {
+            "price": 0.0011
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "gemini-3-pro-image-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "image_token": {
+            "price": 0.012
+          },
+          "input_image": {
+            "price": 0.0011
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
   "gemini-embedding-001": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -2609,6 +2677,68 @@
     }
   },
   "gemini-3.1-flash-image-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image-gt-128k": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -264,6 +264,18 @@
       }
     }
   },
+  "google/gemini-3-pro-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        }
+      }
+    }
+  },
   "x-ai/grok-4.1-fast": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -4849,6 +4861,18 @@
     }
   },
   "google/gemini-3.1-flash-image-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        }
+      }
+    }
+  },
+  "google/gemini-3.1-flash-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -3065,6 +3065,122 @@
       }
     }
   },
+  "gemini-3-pro-image": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "image_token": {
+            "price": 0.012
+          },
+          "search": {
+            "price": 1.4
+          }
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      },
+      "finetune_config": {
+        "pay_per_token": {
+          "price": 0.0005
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0002
+                  },
+                  "response_token": {
+                    "price": 0.0012
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.012
+                    },
+                    "search": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.006
+                    },
+                    "search": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0001
+                  },
+                  "response_token": {
+                    "price": 0.0006
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "image_token": {
+                      "price": 0.006
+                    },
+                    "search": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "gemini-2.5-pro": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -10128,6 +10244,114 @@
     }
   },
   "gemini-3.1-flash-image-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "additional_units": {
+          "image_token": {
+            "price": 0.006
+          },
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00005
+                  },
+                  "response_token": {
+                    "price": 0.0003
+                  },
+                  "additional_units": {
+                    "image_token": {
+                      "price": 0.006
+                    },
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  },
+                  "additional_units": {
+                    "image_token": {
+                      "price": 0.003
+                    },
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000025
+                  },
+                  "response_token": {
+                    "price": 0.00015
+                  },
+                  "additional_units": {
+                    "image_token": {
+                      "price": 0.003
+                    },
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "gemini-3.1-flash-image": {
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {


### PR DESCRIPTION
## Summary

Adds the GA releases of two Gemini image models across all providers that support them in this repo:

- **Gemini 3 Pro Image** (`gemini-3-pro-image`, Nano Banana Pro)
- **Gemini 3.1 Flash Image** (`gemini-3.1-flash-image`, Nano Banana 2)

Existing `-preview` entries are kept; GA IDs are added alongside them (same pattern as `gemini-2.5-flash-image` / `gemini-2.5-flash-image-preview`).

## Providers / files changed

| Provider | General | Pricing |
|----------|---------|---------|
| Google AI Studio | `general/google.json` | `pricing/google.json` (lte/gt-128k tiers) |
| Vertex AI | `general/vertex-ai.json` | `pricing/vertex-ai.json` (with custom_pricing standard/batch/flex) |
| OpenRouter | `general/openrouter.json` | `pricing/openrouter.json` |

These three are the only providers carrying Gemini image models; no other provider (Azure AI, Bedrock, Together AI, etc.) supports them.

## Pricing (sourced from Google docs)

Verified against [Agent Platform Pricing](https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing) and [Gemini API Pricing](https://ai.google.dev/gemini-api/docs/pricing).

| Model | Input | Text output | Image output | Batch/Flex |
|-------|-------|-------------|--------------|------------|
| gemini-3-pro-image | $2/1M | $12/1M | $120/1M (input image $0.0011) | $1 / $6 per 1M, image $60/1M |
| gemini-3.1-flash-image | $0.50/1M | $3/1M | $60/1M | $0.25 / $1.50 per 1M, image $30/1M |

GA pricing matches the existing preview entries exactly, so GA entries were cloned from preview with only the model IDs changed.

## Test plan

- [x] All 6 modified JSON files pass `python3 -m json.tool` validation
- [x] Verified new keys present with no duplicates against preview entries
- [ ] CI `validate-json` workflow passes