### PR TITLE
fix: hide top_k in Playground for Claude Opus 4.7/4.8 and Fable 5

### DIFF
--- a/general/anthropic.json
+++ b/general/anthropic.json
@@ -605,7 +605,7 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["temperature", "top_p"]
+    "removeParams": ["temperature", "top_p", "top_k"]
   },
   "claude-opus-4-8": {
     "params": [
@@ -629,7 +629,7 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["temperature", "top_p"]
+    "removeParams": ["temperature", "top_p", "top_k"]
   },
   "claude-fable-5": {
     "params": [
@@ -653,6 +653,6 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["temperature", "top_p"]
+    "removeParams": ["temperature", "top_p", "top_k"]
   }
 }

--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -2542,7 +2542,7 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "claude-opus-4-8": {
     "params": [
@@ -2566,7 +2566,7 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "claude-fable-5": {
     "params": [
@@ -2590,7 +2590,7 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "claude-sonnet-4-6": {
     "params": [

--- a/general/bedrock-mantle.json
+++ b/general/bedrock-mantle.json
@@ -41,7 +41,7 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
 
   "anthropic.claude-opus-4-8": {
@@ -72,7 +72,7 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
 
   "anthropic.claude-fable-5": {
@@ -103,7 +103,7 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
 
   "nvidia.nemotron-super-3-120b": {

--- a/general/bedrock.json
+++ b/general/bedrock.json
@@ -4225,7 +4225,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "us.anthropic.claude-opus-4-7": {
     "params": [
@@ -4289,7 +4289,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "eu.anthropic.claude-opus-4-7": {
     "params": [
@@ -4353,7 +4353,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "global.anthropic.claude-opus-4-7": {
     "params": [
@@ -4417,7 +4417,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "anthropic.claude-opus-4-8": {
     "params": [
@@ -4481,7 +4481,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "us.anthropic.claude-opus-4-8": {
     "params": [
@@ -4545,7 +4545,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "eu.anthropic.claude-opus-4-8": {
     "params": [
@@ -4609,7 +4609,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "global.anthropic.claude-opus-4-8": {
     "params": [
@@ -4673,7 +4673,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "anthropic.claude-fable-5": {
     "params": [
@@ -4737,7 +4737,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "us.anthropic.claude-fable-5": {
     "params": [
@@ -4801,7 +4801,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "eu.anthropic.claude-fable-5": {
     "params": [
@@ -4865,7 +4865,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   },
   "global.anthropic.claude-fable-5": {
     "params": [
@@ -4929,6 +4929,6 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["top_p", "temperature"]
+    "removeParams": ["top_p", "temperature", "top_k"]
   }
 }

--- a/general/claude-platform-aws.json
+++ b/general/claude-platform-aws.json
@@ -61,7 +61,7 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["temperature", "top_p"]
+    "removeParams": ["temperature", "top_p", "top_k"]
   },
   "claude-opus-4-8": {
     "params": [
@@ -85,7 +85,7 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["temperature", "top_p"]
+    "removeParams": ["temperature", "top_p", "top_k"]
   },
   "claude-fable-5": {
     "params": [
@@ -109,7 +109,7 @@
       }
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
-    "removeParams": ["temperature", "top_p"]
+    "removeParams": ["temperature", "top_p", "top_k"]
   },
   "claude-opus-4-6": {
     "params": [

--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1664,7 +1664,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["temperature", "top_p"]
+    "removeParams": ["temperature", "top_p", "top_k"]
   },
   "anthropic.claude-opus-4-8": {
     "params": [
@@ -1694,7 +1694,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["temperature", "top_p"]
+    "removeParams": ["temperature", "top_p", "top_k"]
   },
   "anthropic.claude-fable-5": {
     "params": [
@@ -1724,7 +1724,7 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     },
-    "removeParams": ["temperature", "top_p"]
+    "removeParams": ["temperature", "top_p", "top_k"]
   },
   "anthropic.claude-sonnet-4-6": {
     "params": [


### PR DESCRIPTION
## Summary
- Adds `top_k` to `removeParams` for `claude-opus-4-7`, `claude-opus-4-8`, and `claude-fable-5` across Anthropic-hosted provider configs.
- Fixes Playground showing/injecting unsupported `top_k` on load for thinking-first models where `withdrawParams` only applied after thinking was explicitly enabled.
- Scope is intentionally limited to the models reported in Pylon [#6646](https://app.usepylon.com/support/issues/views/4305f6d4-1eeb-4039-92aa-1867128acd4f?issueNumber=6646&view=fs) (Snorkel); Sonnet/Haiku and older thinking models are unchanged and still rely on `withdrawParams` when thinking is enabled.

**Providers updated:** `anthropic`, `bedrock` (incl. `us.`/`eu.`/`global.` IDs), `claude-platform-aws`, `vertex-ai`, `azure-ai`, `bedrock-mantle`.

## Context
On Anthropic routes, provider defaults include `top_k`, but Opus 4.7/4.8 and Fable 5 are thinking-first models where `top_k` is incompatible when thinking is active (and always on for Fable). These models already removed `temperature` and `top_p` via `removeParams` and used `withdrawParams` on the `thinking` param, but `top_k` could still appear in Playground DEFAULT view until thinking was toggled.

## Test plan
- [ ] Playground + Anthropic VK: verify `claude-opus-4-7`, `claude-opus-4-8`, `claude-fable-5` no longer show `top_k`, `temperature`, or `top_p` in DEFAULT params
- [ ] Playground + Bedrock VK: verify same for `anthropic.claude-opus-4-7`, `anthropic.claude-opus-4-8`, `anthropic.claude-fable-5` (and one regional ID)
- [ ] Regression: `claude-sonnet-4-6` and `claude-haiku-4-5` still show `top_k` when thinking is off; `top_k` hides when thinking is enabled
- [ ] Send a playground request on Opus 4.7 without manually clearing presets