### PR TITLE
fix(pricing): correct stale o4-mini-deep-research-2025-06-26 rates (Fixes #114)

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -5333,13 +5333,13 @@
           "price": 0.0002
         },
         "response_token": {
-          "price": 0.004
+          "price": 0.0008
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00025
+          "price": 0.00005
         },
         "additional_units": {
           "web_search": {


### PR DESCRIPTION
Description

This PR resolves Issue #114 by correcting the stale pricing configuration for the o4-mini-deep-research-2025-06-26 snapshot.

Changes:

    Corrected response_token price from 0.004 (

            
    40/1M)to‘0.0008‘(
    40/1M)to‘0.0008‘(

          

    8/1M) to match the current OpenAI pricing card.

    Bonus Fix: Also corrected the cache_read_input_token price from 0.00025 (

            
    2.50/1M)to‘0.00005‘(
    2.50/1M)to‘0.00005‘(

          

    0.50/1M) in the same block. This ensures internal consistency, as the alias and custom_pricing blocks were already updated to $0.50, but the snapshot was left behind.

All unit conventions (cents per token) have been maintained.