### PR TITLE
Add Fireworks GLM 5.2 and Minimax M3 to catalog

### DIFF
--- a/general/fireworks-ai.json
+++ b/general/fireworks-ai.json
@@ -659,6 +659,11 @@
     "params": [{ "key": "max_tokens", "maxValue": 32768 }],
     "type": { "primary": "chat", "supported": ["tools"] }
   },
+  "accounts/fireworks/models/glm-5p2": {
+    "name": "glm-5p2",
+    "params": [{ "key": "max_tokens", "maxValue": 32768 }],
+    "type": { "primary": "chat", "supported": ["tools"] }
+  },
   "accounts/fireworks/models/minimax-m2p1": {
     "name": "minimax-m2p1",
     "params": [{ "key": "max_tokens", "maxValue": 8192 }],
@@ -673,6 +678,11 @@
     "name": "minimax-m2p7",
     "params": [{ "key": "max_tokens", "maxValue": 8192 }],
     "type": { "primary": "chat", "supported": ["tools"] }
+  },
+  "accounts/fireworks/models/minimax-m3": {
+    "name": "minimax-m3",
+    "params": [{ "key": "max_tokens", "maxValue": 8192 }],
+    "type": { "primary": "chat", "supported": ["tools", "image"] }
   },
   "accounts/fireworks/models/qwen3-coder-480b-a35b-instruct": {
     "name": "qwen3-coder-480b-a35b-instruct",

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -231,6 +231,21 @@
       }
     }
   },
+  "glm-5p2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.000026
+        }
+      }
+    }
+  },
   "minimax-m2p1": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -263,6 +278,21 @@
         },
         "response_token": {
           "price": 0.00012
+        }
+      }
+    }
+  },
+  "minimax-m3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add Fireworks serverless models `glm-5p2` (GLM 5.2) and `minimax-m3` (Minimax M3) to the catalog
- Pricing aligned with Fireworks published rates ($/1M tokens)
- Resolves Faire customer request (Pylon #6799)

## Test plan
- [ ] Verify both models appear under Fireworks in Model Catalog after deploy
- [ ] Confirm chat completion works via `@fireworks-ai/accounts/fireworks/models/glm-5p2`
- [ ] Confirm chat completion works via `@fireworks-ai/accounts/fireworks/models/minimax-m3`
- [ ] Verify usage/cost tracking reflects expected Fireworks pricing

Made with [Cursor](https://cursor.com)