### PR TITLE
Add Gemma 4 models to bedrock-mantle

### DIFF
--- a/general/bedrock-mantle.json
+++ b/general/bedrock-mantle.json
@@ -214,6 +214,18 @@
     "params": [{ "key": "max_tokens", "maxValue": 8192 }],
     "type": { "primary": "chat" }
   },
+  "google.gemma-4-31b": {
+    "params": [{ "key": "max_tokens", "maxValue": 32768 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
+  },
+  "google.gemma-4-26b-a4b": {
+    "params": [{ "key": "max_tokens", "maxValue": 32768 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
+  },
+  "google.gemma-4-e2b": {
+    "params": [{ "key": "max_tokens", "maxValue": 32768 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
+  },
 
   "deepseek.v3.1": {
     "params": [{ "key": "max_tokens", "maxValue": 8192 }],

--- a/pricing/bedrock-mantle.json
+++ b/pricing/bedrock-mantle.json
@@ -417,6 +417,42 @@
       }
     }
   },
+  "google.gemma-4-31b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000014
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "google.gemma-4-26b-a4b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000013
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "google.gemma-4-e2b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000004
+        },
+        "response_token": {
+          "price": 0.000008
+        }
+      }
+    }
+  },
   "deepseek.v3.1": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
## Summary

- Add `google.gemma-4-31b`, `google.gemma-4-26b-a4b`, and `google.gemma-4-e2b` to `general/bedrock-mantle.json` and `pricing/bedrock-mantle.json`.
- Pricing uses AWS Bedrock US On-Demand rates (same convention as existing Gemma 3 entries).
- `max_tokens` cap set to `32768`, matching other bedrock-mantle chat models.

**Pylon:** [#6853 — Enabling Gemma 4 on PortKey (AWS Bedrock Mantle)](https://app.usepylon.com/issues?issueNumber=6853)

## Test plan

- [x] `jq empty general/bedrock-mantle.json pricing/bedrock-mantle.json`
- [ ] Verify models appear in catalog after S3 sync
- [ ] Smoke test chat completion via bedrock-mantle provider after deploy