### PR TITLE
Feat: Openrouter Add z-ai/glm-5.2 pricing and config

### DIFF
--- a/general/openrouter.json
+++ b/general/openrouter.json
@@ -5100,6 +5100,12 @@
       "supported": ["tools"]
     }
   },
+  "z-ai/glm-5.2": {
+    "type": {
+      "primary": "chat",
+      "supported": ["tools"]
+    }
+  },
   "google/gemma-4-26b-a4b-it:free": {
     "type": {
       "primary": "chat",

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5388,6 +5388,18 @@
       }
     }
   },
+  "z-ai/glm-5.2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000094
+        },
+        "response_token": {
+          "price": 0.0003
+        }
+      }
+    }
+  },
   "google/gemma-4-26b-a4b-it:free": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
## Summary

Adds GLM-5.2 from Z.ai via OpenRouter (`z-ai/glm-5.2`).

- **general/openrouter.json**: chat model with tool calling support
- **pricing/openrouter.json**: $0.94/1M input, $3/1M output → cents-per-token (`request_token: 0.000094`, `response_token: 0.0003`)

## Source

https://openrouter.ai/z-ai/glm-5.2

## Notes

- 1M-token context window; reasoning + tool use supported
- Entries mirror the existing `z-ai/glm-5.1` format