### PR TITLE
Add Kimi K2.7 Code models to Moonshot catalog

### DIFF
--- a/general/moonshot.json
+++ b/general/moonshot.json
@@ -142,5 +142,17 @@
       "primary": "chat",
       "supported": ["image"]
     }
+  },
+  "kimi-k2.7-code": {
+    "type": {
+      "primary": "chat",
+      "supported": ["image"]
+    }
+  },
+  "kimi-k2.7-code-highspeed": {
+    "type": {
+      "primary": "chat",
+      "supported": ["image"]
+    }
   }
 }

--- a/pricing/moonshot.json
+++ b/pricing/moonshot.json
@@ -231,5 +231,35 @@
         }
       }
     }
+  },
+  "kimi-k2.7-code": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000095
+        },
+        "response_token": {
+          "price": 0.0004
+        },
+        "cache_read_input_token": {
+          "price": 0.000019
+        }
+      }
+    }
+  },
+  "kimi-k2.7-code-highspeed": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00019
+        },
+        "response_token": {
+          "price": 0.0008
+        },
+        "cache_read_input_token": {
+          "price": 0.000038
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add `kimi-k2.7-code` and `kimi-k2.7-code-highspeed` pricing to `pricing/moonshot.json` using official Moonshot rates (cache hit/miss input + output).
- Add matching general config entries in `general/moonshot.json` so both models appear in Model Catalog provisioning.

Pricing source: https://platform.kimi.ai/docs/pricing/chat-k27-code

| Model | Input (cache miss) | Input (cache hit) | Output |
|-------|-------------------|-------------------|--------|
| `kimi-k2.7-code` | $0.95/M | $0.19/M | $4.00/M |
| `kimi-k2.7-code-highspeed` | $1.90/M | $0.38/M | $8.00/M |

## Test plan
- [x] Validate `pricing/moonshot.json` and `general/moonshot.json` pass repo JSON/schema checks
- [ ] After merge, confirm models sync to Albus/gateway via CI and appear in Moonshot Model Provisioning
- [ ] Spot-check cost attribution for a `kimi-k2.7-code` request against published Moonshot pricing