### PR TITLE
Add OpenAI GPT-5.6 models

### DIFF
--- a/general/openai.json
+++ b/general/openai.json
@@ -2850,6 +2850,22 @@
       "unsupported": ["chat", "messages"]
     }
   },
+  "gpt-5.6": {
+    "disablePlayground": true,
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat", "messages"] }
+  },
+  "gpt-5.6-sol": {
+    "disablePlayground": true,
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat", "messages"] }
+  },
+  "gpt-5.6-terra": {
+    "disablePlayground": true,
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat", "messages"] }
+  },
+  "gpt-5.6-luna": {
+    "disablePlayground": true,
+    "type": { "primary": "responses", "supported": ["tools", "image"], "unsupported": ["chat", "messages"] }
+  },
   "gpt-5.5": {
     "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
     "params": [

--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -12229,6 +12229,110 @@
       }
     }
   },
+  "gpt-5.6": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-sol": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-terra": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.0015
+        },
+        "cache_write_input_token": {
+          "price": 0.0003125
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-luna": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        },
+        "cache_write_input_token": {
+          "price": 0.000125
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      }
+    }
+  },
   "gpt-5.5": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
## Summary
- Add OpenAI GPT-5.6 pricing for `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
- Add matching OpenAI model configs as Responses-primary models with tools and image support.
- Include `gpt-5.6` as the documented alias for `gpt-5.6-sol`.

## Pricing notes
- Portkey prices are cents per token.
- Sol:  input /  output per 1M tokens => `0.0005` input / `0.003` output.
- Terra: .50 input /  output per 1M tokens => `0.00025` input / `0.0015` output.
- Luna:  input /  output per 1M tokens => `0.0001` input / `0.0006` output.
- GPT-5.6+ cache writes are 1.25x uncached input, and cache reads keep the 90% cached-input discount, so cache write/read prices are derived from each model's input price.

## Sources
- OpenAI GPT-5.6 announcement and caching notes: https://openai.com/index/gpt-5-6/
- OpenAI latest model guide / alias and model-slug notes: https://developers.openai.com/api/docs/guides/latest-model.md
- OpenAI API model catalog pricing for GPT-5.6 Sol, Terra, and Luna: https://developers.openai.com/api/docs/models

## Validation
- `npx prettier --write pricing/openai.json general/openai.json`
- `npm run lint -- --quiet`
- `python3 scripts/check_duplicate_keys.py`