### PR TITLE
fix(azure-ai): add cached-input pricing for Kimi and DeepSeek V4

### DIFF
--- a/pricing/azure-ai.json
+++ b/pricing/azure-ai.json
@@ -1888,7 +1888,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0
+          "price": 0.0000028
         }
       }
     }
@@ -1906,7 +1906,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0
+          "price": 0.0000145
         }
       }
     }
@@ -3917,6 +3917,9 @@
       "pay_as_you_go": {
         "request_token": {
           "price": 0.000095
+        },
+        "cache_read_input_token": {
+          "price": 0.000019
         },
         "response_token": {
           "price": 0.0004


### PR DESCRIPTION
## Summary

- Add Azure AI cached-input pricing for `Kimi-K2.7-Code`: $0.19/M.
- Replace the existing zero cached-input prices for `DeepSeek-V4-Flash` ($0.028/M) and `DeepSeek-V4-Pro` ($0.145/M).
- Retain the existing input/output pricing and model configuration.

## Context

Azure AI Foundry responses for Kimi K2.7 Code and DeepSeek V4 Pro expose cached usage through `usage.prompt_tokens_details.cached_tokens`. These catalogue entries allow Portkey to apply the published discounted cached-input rate when that usage is present.

## Source verification

- [Introducing Kimi K2.7 Code in Microsoft Foundry](https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k2-7-code-in-microsoft-foundry/4532286)
- [Introducing DeepSeek V4 Flash and V4 Pro in Microsoft Foundry](https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-deepseek-v4-flash-and-v4-pro-in-microsoft-foundry/4515174)

## Validation

- [x] `npm run lint`
- [x] `jq empty pricing/azure-ai.json`
- [x] Verified prices use cents per token