### PR TITLE
feat(workers-ai): add GLM-5.2 pricing

### DIFF
--- a/pricing/workers-ai.json
+++ b/pricing/workers-ai.json
@@ -451,6 +451,21 @@
       }
     }
   },
+  "@cf/zai-org/glm-5.2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000014
+        },
+        "cache_read_input_token": {
+          "price": 0.00000026
+        },
+        "response_token": {
+          "price": 0.0000044
+        }
+      }
+    }
+  },
   "@cf/baai/bge-small-en-v1.5": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
Add pricing config for @cf/zai-org/glm-5.2:
- Input: $1.40/M tokens
- Output: $4.40/M tokens
- Cache read: $0.26/M tokens

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- [ ] New model pricing
- [ ] Update existing pricing
- [ ] New model configuration
- [ ] Bug fix

## Source Verification

**Source Link:** [Add link here]

> [!IMPORTANT]
> Please include a link to the official pricing page from the provider. Simple "I heard it from somewhere" or screenshot sources are not accepted.

## Checklist

- [ ] I have validated the JSON using `jq` or an online validator
- [ ] I have verified that prices are in **cents per token** (not dollars)
- [ ] I have included the source link above
- [ ] I have signed the CLA (if first-time contributor)

## Related Issue

Fixes # (issue)
