### PR TITLE
chore: Update openrouter pricing and config

### DIFF
--- a/general/openrouter.json
+++ b/general/openrouter.json
@@ -5855,5 +5855,514 @@
     "params": [{ "key": "max_tokens", "maxValue": 4096 }],
     "type": { "primary": "image", "supported": ["image"] },
     "disablePlayground": true
+  },
+  "kwaipilot/kat-coder-air-v2.5": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 80000
+      }
+    ]
+  },
+  "kwaipilot/kat-coder-pro-v2.5": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 80000
+      }
+    ]
+  },
+  "openai/gpt-5.6-luna-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "openai/gpt-5.6-luna": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "openai/gpt-5.6-terra-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "openai/gpt-5.6-terra": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "openai/gpt-5.6-sol-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "openai/gpt-5.6-sol": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "~x-ai/grok-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
+  },
+  "aion-labs/aion-3.0-mini": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
+      }
+    ]
+  },
+  "aion-labs/aion-3.0": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
+      }
+    ]
+  },
+  "tencent/hy3": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 131072
+      }
+    ]
+  },
+  "tencent/hy3:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 262144
+      }
+    ]
+  },
+  "poolside/laguna-xs-2.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
+      }
+    ]
+  },
+  "poolside/laguna-xs-2.1:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
+      }
+    ]
+  },
+  "nex-agi/nex-n2-mini": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 262144
+      }
+    ]
+  },
+  "sakana/fugu-ultra": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "cohere/north-mini-code:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 64000
+      }
+    ]
+  },
+  "openrouter/fusion": {
+    "type": {
+      "primary": "chat"
+    }
+  },
+  "moonshotai/kimi-k2.7-code": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 262144
+      }
+    ]
+  },
+  "~anthropic/claude-fable-latest": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "nex-agi/nex-n2-pro": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 262144
+      }
+    ]
+  },
+  "nvidia/nemotron-3.5-content-safety:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      }
+    ]
+  },
+  "nvidia/nemotron-3-ultra-550b-a55b": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "nvidia/nemotron-3-ultra-550b-a55b:free": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
+  "qwen/qwen3.7-plus": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
+  "minimax/minimax-m3": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 512000
+      }
+    ]
+  },
+  "stepfun/step-3.7-flash": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 256000
+      }
+    ]
+  },
+  "anthropic/claude-opus-4.8-fast": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "x-ai/grok-build-0.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    }
+  },
+  "anthropic/claude-opus-4.7-fast": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image",
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
+  "perceptron/perceptron-mk1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "image"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      }
+    ]
+  },
+  "inclusionai/ring-2.6-1t": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
+  "poolside/laguna-m.1": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
+      }
+    ]
+  },
+  "inclusionai/ling-2.6-1t": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 32768
+      }
+    ]
+  },
+  "tencent/hy3-preview": {
+    "type": {
+      "primary": "chat",
+      "supported": [
+        "tools"
+      ]
+    }
+  },
+  "cognitivecomputations/dolphin-mistral-24b-venice-edition": {
+    "type": {
+      "primary": "chat"
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 8192
+      }
+    ]
+  },
+  "google/gemini-embedding-2": {
+    "type": {
+      "primary": "embedding",
+      "supported": [
+        "image"
+      ]
+    },
+    "disablePlayground": true
   }
 }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -160,10 +160,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000252
+          "price": 0.0000269
         },
         "response_token": {
-          "price": 0.0000378
+          "price": 0.00004
         }
       }
     }
@@ -475,7 +475,7 @@
           "price": 0.0000255
         },
         "response_token": {
-          "price": 0.0001
+          "price": 0.000102
         }
       }
     }
@@ -511,7 +511,7 @@
           "price": 0.0000017
         },
         "response_token": {
-          "price": 0.000011
+          "price": 0.0000112
         }
       }
     }
@@ -568,10 +568,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.0000117
         },
         "response_token": {
-          "price": 0.00005
+          "price": 0.0000455
         }
       }
     }
@@ -616,7 +616,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.00004
         },
         "response_token": {
           "price": 0.00004
@@ -688,10 +688,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000039
+          "price": 0.00005
         },
         "response_token": {
-          "price": 0.00019
+          "price": 0.0002
         }
       }
     }
@@ -796,10 +796,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000021
         },
         "response_token": {
-          "price": 0.000088
+          "price": 0.00019
         }
       }
     }
@@ -859,7 +859,7 @@
           "price": 0.000027
         },
         "response_token": {
-          "price": 0.000095
+          "price": 0.0001
         }
       }
     }
@@ -940,7 +940,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000009
+          "price": 0.00001
         },
         "response_token": {
           "price": 0.00011
@@ -1024,10 +1024,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00006
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.00025
         }
       }
     }
@@ -1096,10 +1096,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.000156
         }
       }
     }
@@ -1156,10 +1156,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.000095
         }
       }
     }
@@ -1300,10 +1300,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000039
+          "price": 0.0000037
         },
         "response_token": {
-          "price": 0.000018
+          "price": 0.000017
         }
       }
     }
@@ -1339,7 +1339,7 @@
           "price": 0.000003
         },
         "response_token": {
-          "price": 0.000014
+          "price": 0.000013
         }
       }
     }
@@ -1384,7 +1384,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000009
+          "price": 0.00001
         },
         "response_token": {
           "price": 0.00003
@@ -1468,10 +1468,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00018
+          "price": 0.0001
         }
       }
     }
@@ -1516,10 +1516,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000071
+          "price": 0.000009
         },
         "response_token": {
-          "price": 0.00001
+          "price": 0.000055
         }
       }
     }
@@ -1744,10 +1744,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.00003
         }
       }
     }
@@ -1756,7 +1756,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.000055
         },
         "response_token": {
           "price": 0.00022
@@ -2104,10 +2104,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000009
+          "price": 0.000012
         },
         "response_token": {
-          "price": 0.000045
+          "price": 0.00005
         }
       }
     }
@@ -2116,10 +2116,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 0.0000117
         },
         "response_token": {
-          "price": 0.00004
+          "price": 0.0000455
         }
       }
     }
@@ -2128,7 +2128,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000006
+          "price": 0.000012
         },
         "response_token": {
           "price": 0.000024
@@ -2143,7 +2143,7 @@
           "price": 0.000008
         },
         "response_token": {
-          "price": 0.000024
+          "price": 0.000028
         }
       }
     }
@@ -2368,10 +2368,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.00002
         },
         "response_token": {
-          "price": 0.00006
+          "price": 0.00008
         }
       }
     }
@@ -2380,7 +2380,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.00001
         },
         "response_token": {
           "price": 0.00003
@@ -2404,10 +2404,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 0.000027
         },
         "response_token": {
-          "price": 0.000077
+          "price": 0.000112
         }
       }
     }
@@ -2440,10 +2440,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000035
+          "price": 0.0000351
         },
         "response_token": {
-          "price": 0.000056
+          "price": 0.0000555
         }
       }
     }
@@ -2476,10 +2476,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000008
+          "price": 0.00001
         }
       }
     }
@@ -2500,10 +2500,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000004
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000013
+          "price": 0.000015
         }
       }
     }
@@ -2563,7 +2563,7 @@
           "price": 0.000008
         },
         "response_token": {
-          "price": 0.000016
+          "price": 0.000045
         }
       }
     }
@@ -2800,10 +2800,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.000075
+          "price": 0.0001
         }
       }
     }
@@ -2908,7 +2908,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007
+          "price": 0.00008
         },
         "response_token": {
           "price": 0.00008
@@ -2944,7 +2944,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000065
+          "price": 0.000007
         },
         "response_token": {
           "price": 0.000014
@@ -2968,10 +2968,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000032
+          "price": 0.00002002
         },
         "response_token": {
-          "price": 0.000089
+          "price": 0.00008001
         }
       }
     }
@@ -3040,10 +3040,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 0.000013
         },
         "response_token": {
-          "price": 0.000032
+          "price": 0.00004
         }
       }
     }
@@ -3292,10 +3292,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000017
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000043
+          "price": 0.00005
         }
       }
     }
@@ -3316,10 +3316,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000051
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000034
+          "price": 0.000033
         }
       }
     }
@@ -3331,7 +3331,7 @@
           "price": 0.0000027
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0.0000201
         }
       }
     }
@@ -3352,10 +3352,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000245
+          "price": 0.0000345
         },
         "response_token": {
-          "price": 0.0000245
+          "price": 0.0000345
         }
       }
     }
@@ -3460,10 +3460,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 0.00007
         },
         "response_token": {
-          "price": 0.00003
+          "price": 0.00007
         }
       }
     }
@@ -3544,10 +3544,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 0.000005
         },
         "response_token": {
-          "price": 0.000005
+          "price": 0.000008
         }
       }
     }
@@ -3583,7 +3583,7 @@
           "price": 0.000002
         },
         "response_token": {
-          "price": 0.000003
+          "price": 0.000004
         }
       }
     }
@@ -4120,10 +4120,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000044
+          "price": 0.000057
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.000285
         }
       }
     }
@@ -4300,10 +4300,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000029
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.000095
+          "price": 0.00012
         }
       }
     }
@@ -4312,10 +4312,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000038
+          "price": 0.00004
         },
         "response_token": {
-          "price": 0.000174
+          "price": 0.000175
         }
       }
     }
@@ -4612,10 +4612,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000039
+          "price": 0.000045
         },
         "response_token": {
-          "price": 0.000234
+          "price": 0.0003
         }
       }
     }
@@ -4627,7 +4627,7 @@
           "price": 0.000015
         },
         "response_token": {
-          "price": 0.000115
+          "price": 0.00009
         }
       }
     }
@@ -4636,10 +4636,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 0.000095
         },
         "response_token": {
-          "price": 0.000192
+          "price": 0.000315
         }
       }
     }
@@ -4768,7 +4768,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000014
         },
         "response_token": {
           "price": 0.0001
@@ -5392,10 +5392,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000105
+          "price": 0.0000966
         },
         "response_token": {
-          "price": 0.00035
+          "price": 0.0003036
         }
       }
     }
@@ -5404,10 +5404,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000094
+          "price": 0.00009702
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.00030492
         }
       }
     }
@@ -5428,10 +5428,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000006
+          "price": 0.00001
         },
         "response_token": {
-          "price": 0.000033
+          "price": 0.00003
         }
       }
     }
@@ -5452,10 +5452,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000038
+          "price": 0.000055
         }
       }
     }
@@ -5476,10 +5476,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0001475
         },
         "response_token": {
-          "price": 0.000375
+          "price": 0.0004425
         }
       }
     }
@@ -5500,10 +5500,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 0.000025
         },
         "response_token": {
-          "price": 0.000085
+          "price": 0.00008
         }
       }
     }
@@ -5512,10 +5512,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0002
+          "price": 0.000125
         },
         "response_token": {
-          "price": 0.0006
+          "price": 0.00025
         }
       }
     }
@@ -5656,10 +5656,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000009
+          "price": 0.000021
         },
         "response_token": {
-          "price": 0.000045
+          "price": 0.0000455
         }
       }
     }
@@ -5932,10 +5932,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.000066
         },
         "response_token": {
-          "price": 0.00035
+          "price": 0.000341
         }
       }
     }
@@ -5944,10 +5944,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 0.00015
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.0009
         }
       }
     }
@@ -5956,10 +5956,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0003
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.001
         }
       }
     }
@@ -5980,10 +5980,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.00003
         },
         "response_token": {
-          "price": 0.00024
+          "price": 0.00018
         }
       }
     }
@@ -5992,10 +5992,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 0.00001875
         },
         "response_token": {
-          "price": 0.00015
+          "price": 0.0001125
         }
       }
     }
@@ -6004,7 +6004,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 0.000014
         },
         "response_token": {
           "price": 0.0001
@@ -6028,10 +6028,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000032
+          "price": 0.000045
         },
         "response_token": {
-          "price": 0.00032
+          "price": 0.00027
         }
       }
     }
@@ -6076,10 +6076,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000014
+          "price": 0.0000098
         },
         "response_token": {
-          "price": 0.000028
+          "price": 0.0000196
         }
       }
     }
@@ -6112,10 +6112,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0001
+          "price": 0.0000435
         },
         "response_token": {
-          "price": 0.0003
+          "price": 0.000087
         }
       }
     }
@@ -6124,10 +6124,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 0.000014
         },
         "response_token": {
-          "price": 0.0002
+          "price": 0.000028
         }
       }
     }
@@ -6148,10 +6148,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000008
+          "price": 0.000001
         },
         "response_token": {
-          "price": 0.000024
+          "price": 0.000003
         }
       }
     }
@@ -6196,10 +6196,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.000066
         },
         "response_token": {
-          "price": 0.00035
+          "price": 0.000341
         }
       }
     }
@@ -6253,6 +6253,462 @@
           "input_image": {
             "price": 0.0008
           }
+        }
+      }
+    }
+  },
+  "kwaipilot/kat-coder-air-v2.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00006
+        }
+      }
+    }
+  },
+  "kwaipilot/kat-coder-pro-v2.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000074
+        },
+        "response_token": {
+          "price": 0.000296
+        }
+      }
+    }
+  },
+  "openai/gpt-5.6-luna-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "openai/gpt-5.6-luna": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "openai/gpt-5.6-terra-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
+  "openai/gpt-5.6-terra": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.0015
+        }
+      }
+    }
+  },
+  "openai/gpt-5.6-sol-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        }
+      }
+    }
+  },
+  "openai/gpt-5.6-sol": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        }
+      }
+    }
+  },
+  "~x-ai/grok-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "aion-labs/aion-3.0-mini": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00007
+        },
+        "response_token": {
+          "price": 0.00014
+        }
+      }
+    }
+  },
+  "aion-labs/aion-3.0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0006
+        }
+      }
+    }
+  },
+  "tencent/hy3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00008
+        }
+      }
+    }
+  },
+  "tencent/hy3:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "poolside/laguna-xs-2.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000006
+        },
+        "response_token": {
+          "price": 0.000012
+        }
+      }
+    }
+  },
+  "poolside/laguna-xs-2.1:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "nex-agi/nex-n2-mini": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000025
+        },
+        "response_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "sakana/fugu-ultra": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        }
+      }
+    }
+  },
+  "cohere/north-mini-code:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "openrouter/fusion": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "moonshotai/kimi-k2.7-code": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000719
+        },
+        "response_token": {
+          "price": 0.000349
+        }
+      }
+    }
+  },
+  "~anthropic/claude-fable-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.005
+        }
+      }
+    }
+  },
+  "nex-agi/nex-n2-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.0001
+        }
+      }
+    }
+  },
+  "nvidia/nemotron-3.5-content-safety:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "nvidia/nemotron-3-ultra-550b-a55b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00006
+        },
+        "response_token": {
+          "price": 0.00036
+        }
+      }
+    }
+  },
+  "nvidia/nemotron-3-ultra-550b-a55b:free": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "qwen/qwen3.7-plus": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000032
+        },
+        "response_token": {
+          "price": 0.000128
+        }
+      }
+    }
+  },
+  "minimax/minimax-m3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
+  "stepfun/step-3.7-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.000115
+        }
+      }
+    }
+  },
+  "anthropic/claude-opus-4.8-fast": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.005
+        }
+      }
+    }
+  },
+  "x-ai/grok-build-0.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0002
+        }
+      }
+    }
+  },
+  "anthropic/claude-opus-4.7-fast": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.003
+        },
+        "response_token": {
+          "price": 0.015
+        }
+      }
+    }
+  },
+  "perceptron/perceptron-mk1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.00015
+        }
+      }
+    }
+  },
+  "inclusionai/ring-2.6-1t": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.0000625
+        }
+      }
+    }
+  },
+  "poolside/laguna-m.1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00004
+        }
+      }
+    }
+  },
+  "inclusionai/ling-2.6-1t": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000075
+        },
+        "response_token": {
+          "price": 0.0000625
+        }
+      }
+    }
+  },
+  "tencent/hy3-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0000063
+        },
+        "response_token": {
+          "price": 0.000021
+        }
+      }
+    }
+  },
+  "cognitivecomputations/dolphin-mistral-24b-venice-edition": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00009
+        }
+      }
+    }
+  },
+  "google/gemini-embedding-2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## 🔄 Models Update: openrouter

### 📊 Summary

| Change Type | Count |
|-------------|-------|
| ➕ Models added | 38 |
| 🔄 Prices updated | 69 |
| 📋 General configs added | 38 |

### ➕ New Models
- `kwaipilot/kat-coder-air-v2.5`
- `kwaipilot/kat-coder-pro-v2.5`
- `openai/gpt-5.6-luna-pro`
- `openai/gpt-5.6-luna`
- `openai/gpt-5.6-terra-pro`
- `openai/gpt-5.6-terra`
- `openai/gpt-5.6-sol-pro`
- `openai/gpt-5.6-sol`
- `~x-ai/grok-latest`
- `aion-labs/aion-3.0-mini`
- `aion-labs/aion-3.0`
- `tencent/hy3`
- `tencent/hy3:free`
- `poolside/laguna-xs-2.1`
- `poolside/laguna-xs-2.1:free`
- `nex-agi/nex-n2-mini`
- `sakana/fugu-ultra`
- `cohere/north-mini-code:free`
- `openrouter/fusion`
- `moonshotai/kimi-k2.7-code`
- `~anthropic/claude-fable-latest`
- `nex-agi/nex-n2-pro`
- `nvidia/nemotron-3.5-content-safety:free`
- `nvidia/nemotron-3-ultra-550b-a55b`
- `nvidia/nemotron-3-ultra-550b-a55b:free`
- `qwen/qwen3.7-plus`
- `minimax/minimax-m3`
- `stepfun/step-3.7-flash`
- `anthropic/claude-opus-4.8-fast`
- `x-ai/grok-build-0.1`
- ... and 8 more

### 🔄 Updated Prices
- `z-ai/glm-5.2`
- `qwen/qwen3.7-max`
- `~moonshotai/kimi-latest`
- `~google/gemini-flash-latest`
- `~anthropic/claude-sonnet-latest`
- `qwen/qwen3.5-plus-20260420`
- `qwen/qwen3.6-flash`
- `qwen/qwen3.6-35b-a3b`
- `qwen/qwen3.6-27b`
- `deepseek/deepseek-v4-flash`
- `xiaomi/mimo-v2.5-pro`
- `xiaomi/mimo-v2.5`
- `inclusionai/ling-2.6-flash`
- `moonshotai/kimi-k2.6`
- `z-ai/glm-5.1`
- `google/gemma-4-26b-a4b-it`
- `google/gemma-4-31b-it`
- `arcee-ai/trinity-large-thinking`
- `x-ai/grok-4.20-multi-agent`
- `nvidia/nemotron-3-super-120b-a12b`
- `qwen/qwen3.5-35b-a3b`
- `qwen/qwen3.5-397b-a17b`
- `minimax/minimax-m2.5`
- `z-ai/glm-5`
- `moonshotai/kimi-k2.5`
- `minimax/minimax-m2.1`
- `z-ai/glm-4.7`
- `deepseek/deepseek-v3.2`
- `minimax/minimax-m2`
- `ibm-granite/granite-4.0-h-micro`
- ... and 39 more

### 📋 New General Configs
- `kwaipilot/kat-coder-air-v2.5`
- `kwaipilot/kat-coder-pro-v2.5`
- `openai/gpt-5.6-luna-pro`
- `openai/gpt-5.6-luna`
- `openai/gpt-5.6-terra-pro`
- `openai/gpt-5.6-terra`
- `openai/gpt-5.6-sol-pro`
- `openai/gpt-5.6-sol`
- `~x-ai/grok-latest`
- `aion-labs/aion-3.0-mini`
- `aion-labs/aion-3.0`
- `tencent/hy3`
- `tencent/hy3:free`
- `poolside/laguna-xs-2.1`
- `poolside/laguna-xs-2.1:free`
- `nex-agi/nex-n2-mini`
- `sakana/fugu-ultra`
- `cohere/north-mini-code:free`
- `openrouter/fusion`
- `moonshotai/kimi-k2.7-code`
- `~anthropic/claude-fable-latest`
- `nex-agi/nex-n2-pro`
- `nvidia/nemotron-3.5-content-safety:free`
- `nvidia/nemotron-3-ultra-550b-a55b`
- `nvidia/nemotron-3-ultra-550b-a55b:free`
- `qwen/qwen3.7-plus`
- `minimax/minimax-m3`
- `stepfun/step-3.7-flash`
- `anthropic/claude-opus-4.8-fast`
- `x-ai/grok-build-0.1`
- ... and 8 more


---
*Generated by Direct Converter on 2026-07-16*