### PR TITLE
chore(google, vertex-ai): add veo-3.1-lite model and update video pricing by resolution

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1849,6 +1849,12 @@
     },
     "disablePlayground": true
   },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
   "veo-3.0-generate-001": {
     "type": {
       "primary": "video"

--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1553,6 +1553,12 @@
     },
     "disablePlayground": true
   },
+  "veo-3.1-lite-generate-001": {
+    "type": {
+      "primary": "video"
+    },
+    "disablePlayground": true
+  },
   "gemini-3-flash-preview": {
     "name": "gemini-3-flash-preview",
     "params": [

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3085,8 +3085,14 @@
           "price": 0
         },
         "additional_units": {
-          "video_seconds": {
+          "video_duration_seconds_1280_720": {
             "price": 40
+          },
+          "video_duration_seconds_1920_1080": {
+            "price": 40
+          },
+          "video_duration_seconds_3840_2160": {
+            "price": 60
           },
           "default_duration_seconds": {
             "price": 8
@@ -3108,8 +3114,14 @@
           "price": 0
         },
         "additional_units": {
-          "video_seconds": {
+          "video_duration_seconds_1280_720": {
             "price": 40
+          },
+          "video_duration_seconds_1920_1080": {
+            "price": 40
+          },
+          "video_duration_seconds_3840_2160": {
+            "price": 60
           },
           "default_duration_seconds": {
             "price": 8
@@ -3131,8 +3143,14 @@
           "price": 0
         },
         "additional_units": {
-          "video_seconds": {
-            "price": 15
+          "video_duration_seconds_1280_720": {
+            "price": 10
+          },
+          "video_duration_seconds_1920_1080": {
+            "price": 12
+          },
+          "video_duration_seconds_3840_2160": {
+            "price": 30
           },
           "default_duration_seconds": {
             "price": 8
@@ -3154,8 +3172,66 @@
           "price": 0
         },
         "additional_units": {
-          "video_seconds": {
-            "price": 15
+          "video_duration_seconds_1280_720": {
+            "price": 10
+          },
+          "video_duration_seconds_1920_1080": {
+            "price": 12
+          },
+          "video_duration_seconds_3840_2160": {
+            "price": 30
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_duration_seconds_1280_720": {
+            "price": 5
+          },
+          "video_duration_seconds_1920_1080": {
+            "price": 8
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_duration_seconds_1280_720": {
+            "price": 5
+          },
+          "video_duration_seconds_1920_1080": {
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -5736,8 +5736,14 @@
           "price": 0
         },
         "additional_units": {
-          "video_seconds": {
-            "price": 20
+          "video_duration_seconds_1280_720": {
+            "price": 40
+          },
+          "video_duration_seconds_1920_1080": {
+            "price": 40
+          },
+          "video_duration_seconds_3840_2160": {
+            "price": 60
           },
           "default_duration_seconds": {
             "price": 8
@@ -5759,8 +5765,40 @@
           "price": 0
         },
         "additional_units": {
-          "video_seconds": {
+          "video_duration_seconds_1280_720": {
             "price": 10
+          },
+          "video_duration_seconds_1920_1080": {
+            "price": 12
+          },
+          "video_duration_seconds_3840_2160": {
+            "price": 30
+          },
+          "default_duration_seconds": {
+            "price": 8
+          },
+          "default_sample_count": {
+            "price": 1
+          }
+        }
+      }
+    }
+  },
+  "veo-3.1-lite-generate-preview": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        },
+        "additional_units": {
+          "video_duration_seconds_1280_720": {
+            "price": 5
+          },
+          "video_duration_seconds_1920_1080": {
+            "price": 8
           },
           "default_duration_seconds": {
             "price": 8


### PR DESCRIPTION
# Description

Added resolution based pricing for veo 3.1 models, the older veo models like veo 3.0 and veo 2 are deprecated and will be shut down by google soon.

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- [ ] New model pricing
- [x] Update existing pricing
- [ ] New model configuration
- [ ] Bug fix

## Source Verification
https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#veo

## Checklist

- [ ] I have validated the JSON using `jq` or an online validator
- [ ] I have verified that prices are in **cents per token** (not dollars)
- [ ] I have included the source link above
- [ ] I have signed the CLA (if first-time contributor)

