### PR TITLE
pricing-update(vertex-ai): add Grok 4.3 model config and pricing

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -2303,5 +2303,11 @@
   "semantic-ranker-default-002": {
     "type": { "primary": "rerank" },
     "disablePlayground": true
+  },
+  "grok-4.3": {
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    }
   }
 }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -15287,5 +15287,66 @@
         }
       }
     }
+  },
+  "grok-4.3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-200k",
+        "200000": "gt-200k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000125
+                      },
+                      "response_token": {
+                        "price": 0.00025
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00002
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "response_token": {
+                        "price": 0.0005
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00004
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `grok-4.3` to the Vertex AI general schema with support for image input and function calling
- Adds tiered pricing for `grok-4.3` on Vertex AI with context-length-based pricing (≤200k and >200k input tokens)
## Pricing details
| Tier | Input / 1M tokens | Output / 1M tokens | Cached Input / 1M tokens |
|------|-------------------|---------------------|--------------------------|
| ≤ 200k prompt tokens | $1.25 | $2.50 | $0.20 |
| > 200k prompt tokens | $2.50 | $5.00 | $0.40 |
## References
- [Vertex AI Grok 4.3 model card](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/grok/grok-4-3)
- [xAI Grok Vertex AI pricing](https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#grok-models)
## Test plan
- [ ] Verify pricing shows correctly in the model catalog for Vertex AI / Grok 4.3
- [ ] Verify cost attribution works for requests under and over 200k input tokens