### PR TITLE
[google][vertex-ai] Correct multimodal embedding pricing

### DIFF
--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -2608,10 +2608,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0
+          "price": 0.00008
         },
         "response_token": {
-          "price": 0.00002
+          "price": 0
         },
         "additional_units": {
           "input_image": {
@@ -2630,10 +2630,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0
+          "price": 0.000064
         },
         "response_token": {
-          "price": 0.000016
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
# Description

Corrects multimodalembedding@001 text-input pricing for pay-as-you-go and batch usage. The values remain represented in cents per token and preserve the existing 20 percent batch discount.

- [ ] New model pricing
- [x] Update existing pricing
- [ ] New model configuration
- [x] Bug fix

## Source Verification

**Source Link:** https://cloud.google.com/vertex-ai/generative-ai/pricing

## Checklist

- [x] Validated the JSON using jq
- [x] Verified that prices are in cents per token
- [x] Included the official provider source link above
- [ ] CLA status is pending the repository check

## Related Issue

Fixes #117