### PR TITLE
Add Gemini 3.6 Flash pricing across providers

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1875,6 +1875,62 @@
     ],
     "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools", "audio"] }
   },
+  "gemini-3.6-flash": {
+    "params": [
+      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_object" }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
+              }
+            },
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 128,
+            "maxValue": 32768
+          }
+        },
+        "defaultValue": null,
+        "skipValues": [null]
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools", "audio"] }
+  },
   "gemini-3.1-flash-image-preview": {
     "type": {
       "primary": "image"

--- a/general/openrouter.json
+++ b/general/openrouter.json
@@ -4957,6 +4957,18 @@
       }
     ]
   },
+  "google/gemini-3.6-flash": {
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools", "audio"]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
   "upstage/solar-pro-3": {
     "type": {
       "primary": "chat",

--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -2097,6 +2097,62 @@
     ],
     "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools", "audio"] }
   },
+  "gemini-3.6-flash": {
+    "params": [
+      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_object" }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
+              }
+            },
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 128,
+            "maxValue": 32768
+          }
+        },
+        "defaultValue": null,
+        "skipValues": [null]
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools", "audio"] }
+  },
   "gemini-3.1-pro-preview-customtools": {
     "params": [
       { "key": "max_tokens", "maxValue": 65536 },

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3676,5 +3676,67 @@
         }
       }
     }
+  },
+  "gemini-3.6-flash-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.00075
+        },
+        "cache_read_input_token": {
+          "price": 0.000015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000075
+        },
+        "response_token": {
+          "price": 0.000375
+        }
+      }
+    }
+  },
+  "gemini-3.6-flash-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.00075
+        },
+        "cache_read_input_token": {
+          "price": 0.000015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000075
+        },
+        "response_token": {
+          "price": 0.000375
+        }
+      }
+    }
   }
 }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5220,6 +5220,18 @@
       }
     }
   },
+  "google/gemini-3.6-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.00075
+        }
+      }
+    }
+  },
   "upstage/solar-pro-3": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -12956,6 +12956,290 @@
       }
     }
   },
+  "gemini-3.6-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.00075
+        },
+        "cache_write_input_token": {
+          "price": 0.00015
+        },
+        "cache_read_input_token": {
+          "price": 0.000015
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "enterprise_web_search": {
+            "price": 1.4
+          },
+          "maps": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000075
+        },
+        "response_token": {
+          "price": 0.000375
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00075
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000075
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.000375
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000075
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.000375
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00027
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000027
+                  },
+                  "response_token": {
+                    "price": 0.00135
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "global": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00015
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000015
+                  },
+                  "response_token": {
+                    "price": 0.00075
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000075
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.000375
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000075
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000075
+                  },
+                  "response_token": {
+                    "price": 0.000375
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00027
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000027
+                  },
+                  "response_token": {
+                    "price": 0.00135
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "enterprise_web_search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "gemini-3.1-flash-image-preview": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
## Summary
- Adds pricing and capabilities for `gemini-3.6-flash` across Google, Vertex AI, and OpenRouter providers
- Standard pricing: $1.50/1M input, $7.50/1M output, $0.15/1M cached input
- Batch/Flex pricing: $0.75/1M input, $3.75/1M output
- Priority pricing (Vertex AI): $2.70/1M input, $13.50/1M output
- Includes Vertex AI `custom_pricing.regions` with standard/batch/flex/priority execution modes
## Files changed
- `pricing/google.json` — added `gemini-3.6-flash-lte-128k` and `gemini-3.6-flash-gt-128k`
- `general/google.json` — added `gemini-3.6-flash` capabilities
- `pricing/vertex-ai.json` — added `gemini-3.6-flash` with region/execution mode pricing
- `general/vertex-ai.json` — added `gemini-3.6-flash` capabilities
- `pricing/openrouter.json` — added `google/gemini-3.6-flash`
- `general/openrouter.json` — added `google/gemini-3.6-flash` capabilities
## References
- https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash
- https://ai.google.dev/gemini-api/docs/pricing#gemini-3.6-flash
- https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing