### PR TITLE
Add Gemini 3.5 Flash-Lite pricing across providers

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1763,6 +1763,62 @@
       "supported": ["tools", "image"]
     }
   },
+  "gemini-3.5-flash-lite": {
+    "params": [
+      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_object" }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
+              }
+            },
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 128,
+            "maxValue": 32768
+          }
+        },
+        "defaultValue": null,
+        "skipValues": [null]
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools", "audio"] }
+  },
   "gemini-3.5-flash": {
     "params": [
       { "key": "max_tokens", "maxValue": 65536 },

--- a/general/openrouter.json
+++ b/general/openrouter.json
@@ -4945,6 +4945,18 @@
       }
     ]
   },
+  "google/gemini-3.5-flash-lite": {
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools", "audio"]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 65536
+      }
+    ]
+  },
   "upstage/solar-pro-3": {
     "type": {
       "primary": "chat",

--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1985,6 +1985,62 @@
     ],
     "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools"] }
   },
+  "gemini-3.5-flash-lite": {
+    "params": [
+      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_object" }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
+              }
+            },
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 128,
+            "maxValue": 32768
+          }
+        },
+        "defaultValue": null,
+        "skipValues": [null]
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools", "audio"] }
+  },
   "gemini-3.5-flash": {
     "params": [
       { "key": "max_tokens", "maxValue": 65536 },

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3614,5 +3614,67 @@
         }
       }
     }
+  },
+  "gemini-3.5-flash-lite-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.000125
+        }
+      }
+    }
+  },
+  "gemini-3.5-flash-lite-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.000125
+        }
+      }
+    }
   }
 }

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5208,6 +5208,18 @@
       }
     }
   },
+  "google/gemini-3.5-flash-lite": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        }
+      }
+    }
+  },
   "upstage/solar-pro-3": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -12415,6 +12415,263 @@
       }
     }
   },
+  "gemini-3.5-flash-lite": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00025
+        },
+        "cache_write_input_token": {
+          "price": 0.00003
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          },
+          "maps": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "response_token": {
+          "price": 0.000125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000033
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000033
+                  },
+                  "response_token": {
+                    "price": 0.000275
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000165
+                  },
+                  "response_token": {
+                    "price": 0.0001375
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000165
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000165
+                  },
+                  "response_token": {
+                    "price": 0.0001375
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0000594
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00000594
+                  },
+                  "response_token": {
+                    "price": 0.000495
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "global": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00003
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.000003
+                  },
+                  "response_token": {
+                    "price": 0.00025
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000015
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000015
+                  },
+                  "response_token": {
+                    "price": 0.000125
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.000054
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0000054
+                  },
+                  "response_token": {
+                    "price": 0.00045
+                  },
+                  "additional_units": {
+                    "web_search": {
+                      "price": 1.4
+                    },
+                    "search": {
+                      "price": 1.4
+                    },
+                    "maps": {
+                      "price": 1.4
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "gemini-3.5-flash": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
## Summary
- Adds pricing and capabilities for `gemini-3.5-flash-lite` across Google, Vertex AI, and OpenRouter providers
- Standard pricing: $0.30/1M input, $2.50/1M output, $0.03/1M cached input
- Batch/Flex pricing: $0.15/1M input, $1.25/1M output
- Priority pricing: $0.54/1M input, $4.50/1M output
- Vertex AI includes Global/Non-global (1.1x) pricing and `custom_pricing.regions` with standard/batch/flex/priority execution modes
## Files changed
- `pricing/google.json` — added `gemini-3.5-flash-lite-lte-128k` and `gemini-3.5-flash-lite-gt-128k`
- `general/google.json` — added `gemini-3.5-flash-lite` capabilities
- `pricing/vertex-ai.json` — added `gemini-3.5-flash-lite` with region/execution mode pricing
- `general/vertex-ai.json` — added `gemini-3.5-flash-lite` capabilities
- `pricing/openrouter.json` — added `google/gemini-3.5-flash-lite`
- `general/openn` — added `google/gemini-3.5-flash-lite` capabilities
## References
- https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite
- https://ai.google.dev/gemini-api/docs/pricing#gemini-3.5-flash-lite
- https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing