### PR TITLE
[multi-provider] Add Claude Opus 5

### DIFF
--- a/general/anthropic.json
+++ b/general/anthropic.json
@@ -631,6 +631,30 @@
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "removeParams": ["temperature", "top_p", "top_k"]
   },
+  "claude-opus-5": {
+    "params": [
+      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["temperature", "top_p", "top_k"]
+  },
   "claude-sonnet-5": {
     "params": [
       { "key": "max_tokens", "maxValue": 128000 },

--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -3885,6 +3885,36 @@
     },
     "removeParams": ["top_p", "temperature", "top_k"]
   },
+  "claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
   "claude-sonnet-5": {
     "params": [
       {

--- a/general/bedrock-mantle.json
+++ b/general/bedrock-mantle.json
@@ -74,6 +74,36 @@
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "removeParams": ["top_p", "temperature", "top_k"]
   },
+  "anthropic.claude-opus-5": {
+    "params": [
+      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": { "type": "string", "enum": ["adaptive", "disabled"] },
+          "budget_tokens": { "type": "number", "minValue": 1024, "maxValue": 128000 }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          { "value": "none", "name": "None" },
+          { "value": "auto", "name": "Auto" },
+          { "value": "required", "name": "Required" },
+          { "value": "custom", "name": "Custom", "schema": { "type": "json" } }
+        ],
+        "skipValues": [null, []],
+        "rule": { "default": { "condition": "tools", "then": "auto", "else": null } }
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
 
   "anthropic.claude-sonnet-5": {
     "params": [

--- a/general/bedrock.json
+++ b/general/bedrock.json
@@ -4675,6 +4675,262 @@
     },
     "removeParams": ["top_p", "temperature", "top_k"]
   },
+  "anthropic.claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": "none",
+            "name": "None"
+          },
+          {
+            "value": "auto",
+            "name": "Auto"
+          },
+          {
+            "value": "required",
+            "name": "Required"
+          },
+          {
+            "value": "custom",
+            "name": "Custom",
+            "schema": {
+              "type": "json"
+            }
+          }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
+  "us.anthropic.claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": "none",
+            "name": "None"
+          },
+          {
+            "value": "auto",
+            "name": "Auto"
+          },
+          {
+            "value": "required",
+            "name": "Required"
+          },
+          {
+            "value": "custom",
+            "name": "Custom",
+            "schema": {
+              "type": "json"
+            }
+          }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
+  "eu.anthropic.claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": "none",
+            "name": "None"
+          },
+          {
+            "value": "auto",
+            "name": "Auto"
+          },
+          {
+            "value": "required",
+            "name": "Required"
+          },
+          {
+            "value": "custom",
+            "name": "Custom",
+            "schema": {
+              "type": "json"
+            }
+          }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
+  "global.anthropic.claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": "none",
+            "name": "None"
+          },
+          {
+            "value": "auto",
+            "name": "Auto"
+          },
+          {
+            "value": "required",
+            "name": "Required"
+          },
+          {
+            "value": "custom",
+            "name": "Custom",
+            "schema": {
+              "type": "json"
+            }
+          }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
   "anthropic.claude-sonnet-5": {
     "params": [
       {

--- a/general/claude-platform-aws.json
+++ b/general/claude-platform-aws.json
@@ -87,6 +87,30 @@
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "removeParams": ["temperature", "top_p", "top_k"]
   },
+  "claude-opus-5": {
+    "params": [
+      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["temperature", "top_p", "top_k"]
+  },
   "claude-sonnet-5": {
     "params": [
       { "key": "max_tokens", "maxValue": 128000 },

--- a/general/openrouter.json
+++ b/general/openrouter.json
@@ -5395,6 +5395,18 @@
       }
     ]
   },
+  "anthropic/claude-opus-5": {
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      }
+    ]
+  },
   "anthropic/claude-sonnet-5": {
     "type": {
       "primary": "chat",
@@ -5883,9 +5895,7 @@
   "kwaipilot/kat-coder-air-v2.5": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -5897,9 +5907,7 @@
   "kwaipilot/kat-coder-pro-v2.5": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -5911,10 +5919,7 @@
   "openai/gpt-5.6-luna-pro": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -5926,10 +5931,7 @@
   "openai/gpt-5.6-luna": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -5941,10 +5943,7 @@
   "openai/gpt-5.6-terra-pro": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -5956,10 +5955,7 @@
   "openai/gpt-5.6-terra": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -5971,10 +5967,7 @@
   "openai/gpt-5.6-sol-pro": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -5986,10 +5979,7 @@
   "openai/gpt-5.6-sol": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -6001,18 +5991,13 @@
   "~x-ai/grok-latest": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     }
   },
   "aion-labs/aion-3.0-mini": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -6024,9 +6009,7 @@
   "aion-labs/aion-3.0": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -6038,9 +6021,7 @@
   "tencent/hy3": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -6052,9 +6033,7 @@
   "tencent/hy3:free": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -6066,9 +6045,7 @@
   "poolside/laguna-xs-2.1": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -6080,9 +6057,7 @@
   "poolside/laguna-xs-2.1:free": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -6094,10 +6069,7 @@
   "nex-agi/nex-n2-mini": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -6109,10 +6081,7 @@
   "sakana/fugu-ultra": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -6124,9 +6093,7 @@
   "cohere/north-mini-code:free": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -6143,10 +6110,7 @@
   "moonshotai/kimi-k2.7-code": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -6158,10 +6122,7 @@
   "~anthropic/claude-fable-latest": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -6173,10 +6134,7 @@
   "nex-agi/nex-n2-pro": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -6188,9 +6146,7 @@
   "nvidia/nemotron-3.5-content-safety:free": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image"
-      ]
+      "supported": ["image"]
     },
     "params": [
       {
@@ -6202,17 +6158,13 @@
   "nvidia/nemotron-3-ultra-550b-a55b": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "nvidia/nemotron-3-ultra-550b-a55b:free": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -6224,10 +6176,7 @@
   "qwen/qwen3.7-plus": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -6239,10 +6188,7 @@
   "minimax/minimax-m3": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -6254,10 +6200,7 @@
   "stepfun/step-3.7-flash": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -6269,10 +6212,7 @@
   "anthropic/claude-opus-4.8-fast": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -6284,19 +6224,13 @@
   "x-ai/grok-build-0.1": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     }
   },
   "anthropic/claude-opus-4.7-fast": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image",
-        "tools"
-      ]
+      "supported": ["image", "tools"]
     },
     "params": [
       {
@@ -6308,9 +6242,7 @@
   "perceptron/perceptron-mk1": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "image"
-      ]
+      "supported": ["image"]
     },
     "params": [
       {
@@ -6322,9 +6254,7 @@
   "inclusionai/ring-2.6-1t": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -6336,9 +6266,7 @@
   "poolside/laguna-m.1": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -6350,9 +6278,7 @@
   "inclusionai/ling-2.6-1t": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     },
     "params": [
       {
@@ -6364,9 +6290,7 @@
   "tencent/hy3-preview": {
     "type": {
       "primary": "chat",
-      "supported": [
-        "tools"
-      ]
+      "supported": ["tools"]
     }
   },
   "cognitivecomputations/dolphin-mistral-24b-venice-edition": {
@@ -6383,9 +6307,7 @@
   "google/gemini-embedding-2": {
     "type": {
       "primary": "embedding",
-      "supported": [
-        "image"
-      ]
+      "supported": ["image"]
     },
     "disablePlayground": true
   },

--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1757,6 +1757,36 @@
     },
     "removeParams": ["temperature", "top_p", "top_k"]
   },
+  "anthropic.claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["temperature", "top_p", "top_k"]
+  },
   "anthropic.claude-sonnet-5": {
     "params": [
       {

--- a/pricing/anthropic.json
+++ b/pricing/anthropic.json
@@ -1146,6 +1146,103 @@
       }
     }
   },
+  "claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    },
+    "custom_pricing": {
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.0005
+                  },
+                  "response_token": {
+                    "price": 0.0025
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.000625
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.00005
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.001
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.00025
+                  },
+                  "response_token": {
+                    "price": 0.00125
+                  }
+                }
+              }
+            },
+            "fast": {
+              "pricing_config": {
+                "pay_as_you_go": {
+                  "request_token": {
+                    "price": 0.001
+                  },
+                  "response_token": {
+                    "price": 0.005
+                  },
+                  "cache_write_input_token": {
+                    "price": 0.00125
+                  },
+                  "cache_read_input_token": {
+                    "price": 0.0001
+                  },
+                  "additional_units": {
+                    "cache_write_1h": {
+                      "price": 0.002
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/azure-ai.json
+++ b/pricing/azure-ai.json
@@ -3803,6 +3803,29 @@
       }
     }
   },
+  "claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      }
+    }
+  },
   "claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/bedrock-mantle.json
+++ b/pricing/bedrock-mantle.json
@@ -82,6 +82,29 @@
       }
     }
   },
+  "anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      }
+    }
+  },
   "anthropic.claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -10708,6 +10708,130 @@
       }
     }
   },
+  "anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
+  "us.anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
+  "eu.anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
+  "global.anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
   "anthropic.claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/claude-platform-aws.json
+++ b/pricing/claude-platform-aws.json
@@ -131,6 +131,37 @@
       }
     }
   },
+  "claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
   "claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -5748,6 +5748,18 @@
       }
     }
   },
+  "anthropic/claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        }
+      }
+    }
+  },
   "anthropic/claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -40,7 +40,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.00015
@@ -59,10 +59,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-5
         }
       }
     }
@@ -71,7 +71,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.00015
@@ -90,10 +90,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-5
         }
       }
     }
@@ -133,7 +133,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.00015
@@ -152,10 +152,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-5
         }
       }
     }
@@ -164,7 +164,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.00015
@@ -183,10 +183,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-5
         }
       }
     }
@@ -195,7 +195,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.00015
@@ -214,10 +214,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-5
         }
       }
     }
@@ -226,29 +226,29 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
           "price": 0.000125
         },
         "cache_write_input_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-6
         },
         "additional_units": {
           "cache_write_1h": {
-            "price": 0.00005
+            "price": 5e-5
           }
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "response_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         }
       }
     }
@@ -337,7 +337,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008
+          "price": 8e-5
         },
         "response_token": {
           "price": 0.0004
@@ -346,7 +346,7 @@
           "price": 0.0001
         },
         "cache_read_input_token": {
-          "price": 0.000008
+          "price": 8e-6
         },
         "additional_units": {
           "cache_write_1h": {
@@ -356,7 +356,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "response_token": {
           "price": 0.0002
@@ -392,7 +392,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         },
         "response_token": {
           "price": 0.00025
@@ -423,7 +423,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         },
         "response_token": {
           "price": 0.00025
@@ -454,7 +454,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         },
         "response_token": {
           "price": 0.00025
@@ -466,10 +466,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.000003
+          "price": 3e-6
         },
         "additional_units": {
           "web_search": {
@@ -490,10 +490,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-6
         },
         "response_token": {
-          "price": 0.0000015
+          "price": 1.5e-6
         }
       }
     }
@@ -502,10 +502,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.000003
+          "price": 3e-6
         },
         "additional_units": {
           "web_search": {
@@ -521,10 +521,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-6
         },
         "response_token": {
-          "price": 0.0000015
+          "price": 1.5e-6
         }
       }
     }
@@ -533,7 +533,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "response_token": {
           "price": 0
@@ -541,7 +541,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000002
+          "price": 2e-6
         },
         "response_token": {
           "price": 0
@@ -553,7 +553,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
           "price": 0
@@ -561,7 +561,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000008
+          "price": 8e-6
         },
         "response_token": {
           "price": 0
@@ -573,7 +573,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "response_token": {
           "price": 0
@@ -581,7 +581,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000002
+          "price": 2e-6
         },
         "response_token": {
           "price": 0
@@ -593,7 +593,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
           "price": 0
@@ -601,7 +601,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000008
+          "price": 8e-6
         },
         "response_token": {
           "price": 0
@@ -613,7 +613,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "response_token": {
           "price": 0
@@ -621,7 +621,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000002
+          "price": 2e-6
         },
         "response_token": {
           "price": 0
@@ -633,7 +633,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "response_token": {
           "price": 0
@@ -641,7 +641,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000002
+          "price": 2e-6
         },
         "response_token": {
           "price": 0
@@ -653,7 +653,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
           "price": 0
@@ -661,7 +661,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000008
+          "price": 8e-6
         },
         "response_token": {
           "price": 0
@@ -673,7 +673,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
           "price": 0
@@ -681,7 +681,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000008
+          "price": 8e-6
         },
         "response_token": {
           "price": 0
@@ -693,7 +693,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "response_token": {
           "price": 0
@@ -701,7 +701,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000002
+          "price": 2e-6
         },
         "response_token": {
           "price": 0
@@ -922,7 +922,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         },
         "response_token": {
           "price": 0.00025
@@ -942,7 +942,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         },
         "response_token": {
           "price": 0.00025
@@ -954,10 +954,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.000003
+          "price": 3e-6
         },
         "additional_units": {
           "web_search": {
@@ -978,10 +978,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-6
         },
         "response_token": {
-          "price": 0.0000015
+          "price": 1.5e-6
         }
       }
     }
@@ -990,10 +990,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "additional_units": {
           "web_search": {
@@ -1009,10 +1009,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-6
         },
         "response_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         }
       }
     }
@@ -1021,10 +1021,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "additional_units": {
           "web_search": {
@@ -1043,10 +1043,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         }
       }
     }
@@ -1055,10 +1055,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "additional_units": {
           "web_search": {
@@ -1077,10 +1077,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         }
       }
     }
@@ -1129,10 +1129,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "additional_units": {
           "web_search": {
@@ -1148,10 +1148,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-6
         },
         "response_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         }
       }
     }
@@ -1160,10 +1160,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "additional_units": {
           "web_search": {
@@ -1182,10 +1182,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00000375
+          "price": 3.75e-6
         },
         "response_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         }
       }
     }
@@ -1216,7 +1216,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         },
         "response_token": {
           "price": 0.0005
@@ -1240,7 +1240,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000013
+                        "price": 1.3e-5
                       },
                       "response_token": {
                         "price": 0.001
@@ -1269,7 +1269,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -1299,7 +1299,7 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "response_token": {
                         "price": 0.0005
@@ -1355,7 +1355,7 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "response_token": {
                         "price": 0.0005
@@ -1414,7 +1414,7 @@
                         "price": 0.000225
                       },
                       "cache_read_input_token": {
-                        "price": 0.000023
+                        "price": 2.3e-5
                       },
                       "response_token": {
                         "price": 0.0018
@@ -1443,7 +1443,7 @@
                         "price": 0.00045
                       },
                       "cache_read_input_token": {
-                        "price": 0.000045
+                        "price": 4.5e-5
                       },
                       "response_token": {
                         "price": 0.0027
@@ -1498,7 +1498,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         },
         "response_token": {
           "price": 0.0005
@@ -1522,7 +1522,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000013
+                        "price": 1.3e-5
                       },
                       "response_token": {
                         "price": 0.001
@@ -1551,7 +1551,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -1581,7 +1581,7 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "response_token": {
                         "price": 0.0005
@@ -1637,7 +1637,7 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "response_token": {
                         "price": 0.0005
@@ -1696,7 +1696,7 @@
                         "price": 0.000225
                       },
                       "cache_read_input_token": {
-                        "price": 0.000023
+                        "price": 2.3e-5
                       },
                       "response_token": {
                         "price": 0.0018
@@ -1725,7 +1725,7 @@
                         "price": 0.00045
                       },
                       "cache_read_input_token": {
-                        "price": 0.000045
+                        "price": 4.5e-5
                       },
                       "response_token": {
                         "price": 0.0027
@@ -1764,10 +1764,10 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "additional_units": {
           "web_search": {
@@ -1813,7 +1813,7 @@
                         "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "response_token": {
                         "price": 0.0012
@@ -1845,7 +1845,7 @@
                         "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00004
+                        "price": 4e-5
                       },
                       "response_token": {
                         "price": 0.0018
@@ -2005,7 +2005,7 @@
                         "price": 0.00036
                       },
                       "cache_read_input_token": {
-                        "price": 0.000036
+                        "price": 3.6e-5
                       },
                       "response_token": {
                         "price": 0.00216
@@ -2037,7 +2037,7 @@
                         "price": 0.00072
                       },
                       "cache_read_input_token": {
-                        "price": 0.000072
+                        "price": 7.2e-5
                       },
                       "response_token": {
                         "price": 0.00324
@@ -2079,7 +2079,7 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "cache_read_input_token": {
           "price": 0.00045
@@ -2122,7 +2122,7 @@
                         "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "response_token": {
                         "price": 0.0012
@@ -2148,7 +2148,7 @@
                         "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00004
+                        "price": 4e-5
                       },
                       "response_token": {
                         "price": 0.0018
@@ -2278,7 +2278,7 @@
                         "price": 0.00036
                       },
                       "cache_read_input_token": {
-                        "price": 0.000036
+                        "price": 3.6e-5
                       },
                       "response_token": {
                         "price": 0.00216
@@ -2304,7 +2304,7 @@
                         "price": 0.00072
                       },
                       "cache_read_input_token": {
-                        "price": 0.000072
+                        "price": 7.2e-5
                       },
                       "response_token": {
                         "price": 0.00324
@@ -2334,10 +2334,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "additional_units": {
           "web_search": {
@@ -2353,10 +2353,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         }
       }
     },
@@ -2368,10 +2368,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00003
+                    "price": 3e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000003
+                    "price": 3e-6
                   },
                   "response_token": {
                     "price": 0.00025
@@ -2394,7 +2394,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -2417,7 +2417,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -2440,10 +2440,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000054
+                    "price": 5.4e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
                     "price": 0.00045
@@ -2471,10 +2471,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "additional_units": {
           "web_search": {
@@ -2490,10 +2490,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         }
       }
     },
@@ -2505,10 +2505,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00003
+                    "price": 3e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000003
+                    "price": 3e-6
                   },
                   "response_token": {
                     "price": 0.00025
@@ -2531,7 +2531,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -2554,7 +2554,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -2577,10 +2577,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000054
+                    "price": 5.4e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
                     "price": 0.00045
@@ -2611,7 +2611,7 @@
           "price": 0
         },
         "response_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "additional_units": {
           "input_image": {
@@ -2633,7 +2633,7 @@
           "price": 0
         },
         "response_token": {
-          "price": 0.000016
+          "price": 1.6e-5
         }
       }
     }
@@ -2651,7 +2651,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -2682,7 +2682,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -2735,10 +2735,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "additional_units": {
           "web_search": {
@@ -2754,10 +2754,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 5e-6
         },
         "response_token": {
-          "price": 0.00002
+          "price": 2e-5
         }
       }
     },
@@ -2769,13 +2769,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000001
+                    "price": 1e-6
                   },
                   "response_token": {
-                    "price": 0.00004
+                    "price": 4e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -2795,10 +2795,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -2818,10 +2818,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -2841,13 +2841,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000018
+                    "price": 1.8e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000002
+                    "price": 2e-6
                   },
                   "response_token": {
-                    "price": 0.000072
+                    "price": 7.2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -2872,7 +2872,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "response_token": {
           "price": 0.00025
@@ -2895,7 +2895,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-6
         }
       },
       "finetune_config": {
@@ -2905,7 +2905,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
           "price": 0.000125
@@ -2920,10 +2920,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00003
+                    "price": 3e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000003
+                    "price": 3e-6
                   },
                   "response_token": {
                     "price": 0.00025
@@ -2952,7 +2952,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -2981,7 +2981,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -3010,10 +3010,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000054
+                    "price": 5.4e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
                     "price": 0.00045
@@ -3047,7 +3047,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "response_token": {
           "price": 0.00025
@@ -3070,7 +3070,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-6
         }
       },
       "finetune_config": {
@@ -3080,7 +3080,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
           "price": 0.000125
@@ -3095,7 +3095,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00003
+                    "price": 3e-5
                   },
                   "response_token": {
                     "price": 0.00025
@@ -3124,7 +3124,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -3153,7 +3153,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -3207,7 +3207,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         }
       },
       "finetune_config": {
@@ -3335,7 +3335,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         }
       },
       "finetune_config": {
@@ -3463,7 +3463,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         }
       },
       "finetune_config": {
@@ -3473,7 +3473,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         },
         "response_token": {
           "price": 0.0005
@@ -3497,7 +3497,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000013
+                        "price": 1.3e-5
                       },
                       "response_token": {
                         "price": 0.001
@@ -3526,7 +3526,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -3556,7 +3556,7 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "response_token": {
                         "price": 0.0005
@@ -3612,7 +3612,7 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "response_token": {
                         "price": 0.0005
@@ -3671,7 +3671,7 @@
                         "price": 0.000225
                       },
                       "cache_read_input_token": {
-                        "price": 0.000023
+                        "price": 2.3e-5
                       },
                       "response_token": {
                         "price": 0.0018
@@ -3700,7 +3700,7 @@
                         "price": 0.00045
                       },
                       "cache_read_input_token": {
-                        "price": 0.000045
+                        "price": 4.5e-5
                       },
                       "response_token": {
                         "price": 0.0027
@@ -3733,10 +3733,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "additional_units": {
           "web_search": {
@@ -3753,7 +3753,7 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 1e-6
         }
       },
       "finetune_config": {
@@ -3763,10 +3763,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 5e-6
         },
         "response_token": {
-          "price": 0.00002
+          "price": 2e-5
         }
       }
     },
@@ -3778,13 +3778,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000001
+                    "price": 1e-6
                   },
                   "response_token": {
-                    "price": 0.00004
+                    "price": 4e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -3807,10 +3807,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -3833,10 +3833,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -3859,13 +3859,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000018
+                    "price": 1.8e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000002
+                    "price": 2e-6
                   },
                   "response_token": {
-                    "price": 0.000072
+                    "price": 7.2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -3934,7 +3934,7 @@
       "pay_as_you_go": {},
       "finetune_config": {
         "pay_per_token": {
-          "price": 0.000067
+          "price": 6.7e-5
         }
       }
     }
@@ -3944,7 +3944,7 @@
       "pay_as_you_go": {},
       "finetune_config": {
         "pay_per_token": {
-          "price": 0.000028
+          "price": 2.8e-5
         }
       }
     }
@@ -3954,7 +3954,7 @@
       "pay_as_you_go": {},
       "finetune_config": {
         "pay_per_token": {
-          "price": 0.000061
+          "price": 6.1e-5
         }
       }
     }
@@ -3994,18 +3994,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         }
       }
     }
@@ -4319,7 +4319,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -4356,7 +4356,7 @@
                         "price": 0.000375
                       },
                       "cache_read_input_token": {
-                        "price": 0.00003
+                        "price": 3e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -4379,7 +4379,7 @@
                         "price": 0.000375
                       },
                       "cache_read_input_token": {
-                        "price": 0.00003
+                        "price": 3e-5
                       },
                       "response_token": {
                         "price": 0.00225
@@ -4406,7 +4406,7 @@
                         "price": 0.000188
                       },
                       "cache_read_input_token": {
-                        "price": 0.000015
+                        "price": 1.5e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -4429,7 +4429,7 @@
                         "price": 0.000188
                       },
                       "cache_read_input_token": {
-                        "price": 0.000015
+                        "price": 1.5e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -4460,7 +4460,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -4483,7 +4483,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -4510,7 +4510,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -4533,7 +4533,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -4564,7 +4564,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -4587,7 +4587,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -4614,7 +4614,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -4637,7 +4637,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -4668,7 +4668,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -4691,7 +4691,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -4718,7 +4718,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -4741,7 +4741,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -4774,7 +4774,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -4811,7 +4811,7 @@
                         "price": 0.000375
                       },
                       "cache_read_input_token": {
-                        "price": 0.00003
+                        "price": 3e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -4834,7 +4834,7 @@
                         "price": 0.000375
                       },
                       "cache_read_input_token": {
-                        "price": 0.00003
+                        "price": 3e-5
                       },
                       "response_token": {
                         "price": 0.00225
@@ -4861,7 +4861,7 @@
                         "price": 0.000188
                       },
                       "cache_read_input_token": {
-                        "price": 0.000015
+                        "price": 1.5e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -4884,7 +4884,7 @@
                         "price": 0.000188
                       },
                       "cache_read_input_token": {
-                        "price": 0.000015
+                        "price": 1.5e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -4915,7 +4915,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -4938,7 +4938,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -4965,7 +4965,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -4988,7 +4988,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -5019,7 +5019,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -5042,7 +5042,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -5069,7 +5069,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -5092,7 +5092,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -5123,7 +5123,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -5146,7 +5146,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -5173,7 +5173,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -5196,7 +5196,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -5229,7 +5229,7 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -5239,7 +5239,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.00025
@@ -5260,7 +5260,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "response_token": {
                     "price": 0.0005
@@ -5277,13 +5277,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
                     "price": 0.00025
@@ -5310,7 +5310,7 @@
                     "price": 0.0001375
                   },
                   "cache_read_input_token": {
-                    "price": 0.000011
+                    "price": 1.1e-5
                   },
                   "response_token": {
                     "price": 0.00055
@@ -5327,13 +5327,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 6.88e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000055
+                    "price": 5.5e-6
                   },
                   "response_token": {
                     "price": 0.000275
@@ -5360,7 +5360,7 @@
                     "price": 0.0001375
                   },
                   "cache_read_input_token": {
-                    "price": 0.000011
+                    "price": 1.1e-5
                   },
                   "response_token": {
                     "price": 0.00055
@@ -5377,13 +5377,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 6.88e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000055
+                    "price": 5.5e-6
                   },
                   "response_token": {
                     "price": 0.000275
@@ -5410,7 +5410,7 @@
                     "price": 0.0001375
                   },
                   "cache_read_input_token": {
-                    "price": 0.000011
+                    "price": 1.1e-5
                   },
                   "response_token": {
                     "price": 0.00055
@@ -5427,13 +5427,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 6.88e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000055
+                    "price": 5.5e-6
                   },
                   "response_token": {
                     "price": 0.000275
@@ -5464,7 +5464,7 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -5474,7 +5474,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.00025
@@ -5495,7 +5495,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "response_token": {
                     "price": 0.0005
@@ -5512,13 +5512,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
                     "price": 0.00025
@@ -5545,7 +5545,7 @@
                     "price": 0.0001375
                   },
                   "cache_read_input_token": {
-                    "price": 0.000011
+                    "price": 1.1e-5
                   },
                   "response_token": {
                     "price": 0.00055
@@ -5562,13 +5562,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 6.88e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000055
+                    "price": 5.5e-6
                   },
                   "response_token": {
                     "price": 0.000275
@@ -5595,7 +5595,7 @@
                     "price": 0.0001375
                   },
                   "cache_read_input_token": {
-                    "price": 0.000011
+                    "price": 1.1e-5
                   },
                   "response_token": {
                     "price": 0.00055
@@ -5612,13 +5612,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 6.88e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000055
+                    "price": 5.5e-6
                   },
                   "response_token": {
                     "price": 0.000275
@@ -5645,7 +5645,7 @@
                     "price": 0.0001375
                   },
                   "cache_read_input_token": {
-                    "price": 0.000011
+                    "price": 1.1e-5
                   },
                   "response_token": {
                     "price": 0.00055
@@ -5662,13 +5662,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 6.88e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000055
+                    "price": 5.5e-6
                   },
                   "response_token": {
                     "price": 0.000275
@@ -5710,7 +5710,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
           "price": 0
@@ -5718,7 +5718,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000012
+          "price": 1.2e-5
         },
         "response_token": {
           "price": 0
@@ -5946,7 +5946,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -5983,7 +5983,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -6006,7 +6006,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -6033,7 +6033,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -6056,7 +6056,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -6087,7 +6087,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6110,7 +6110,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6137,7 +6137,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6160,7 +6160,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6191,7 +6191,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6214,7 +6214,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6241,7 +6241,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6264,7 +6264,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6295,7 +6295,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6318,7 +6318,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6345,7 +6345,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6368,7 +6368,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6401,7 +6401,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -6438,7 +6438,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -6461,7 +6461,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -6488,7 +6488,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -6511,7 +6511,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -6542,7 +6542,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6565,7 +6565,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6592,7 +6592,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6615,7 +6615,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6646,7 +6646,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6669,7 +6669,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6696,7 +6696,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6719,7 +6719,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6750,7 +6750,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6773,7 +6773,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -6800,7 +6800,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6823,7 +6823,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -6847,7 +6847,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "response_token": {
           "price": 0.00025
@@ -6870,12 +6870,12 @@
           }
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-6
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
           "price": 0.000125
@@ -6890,7 +6890,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00003
+                    "price": 3e-5
                   },
                   "response_token": {
                     "price": 0.00025
@@ -6919,7 +6919,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -6948,7 +6948,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -7028,16 +7028,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.0003
         },
         "cache_write_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 5e-6
         },
         "additional_units": {
           "web_search": {
@@ -7053,7 +7053,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
           "price": 0.00015
@@ -7068,10 +7068,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
                     "price": 0.0003
@@ -7094,7 +7094,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.00015
@@ -7117,7 +7117,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.00015
@@ -7140,10 +7140,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00009
+                    "price": 9e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000009
+                    "price": 9e-6
                   },
                   "response_token": {
                     "price": 0.00054
@@ -7192,7 +7192,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -7229,7 +7229,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -7252,7 +7252,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -7279,7 +7279,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -7302,7 +7302,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -7333,7 +7333,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -7356,7 +7356,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -7383,7 +7383,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -7406,7 +7406,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -7437,7 +7437,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -7460,7 +7460,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -7487,7 +7487,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -7510,7 +7510,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -7541,7 +7541,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -7564,7 +7564,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -7591,7 +7591,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -7614,7 +7614,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -7647,7 +7647,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -7684,7 +7684,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -7707,7 +7707,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -7734,7 +7734,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -7757,7 +7757,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -7788,7 +7788,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -7811,7 +7811,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -7838,7 +7838,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -7861,7 +7861,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -7892,7 +7892,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -7915,7 +7915,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -7942,7 +7942,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -7965,7 +7965,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -7996,7 +7996,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8019,7 +8019,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8046,7 +8046,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -8069,7 +8069,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -8102,7 +8102,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -8139,7 +8139,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -8162,7 +8162,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -8189,7 +8189,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -8212,7 +8212,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -8243,7 +8243,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8266,7 +8266,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8293,7 +8293,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -8316,7 +8316,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -8347,7 +8347,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8370,7 +8370,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8397,7 +8397,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -8420,7 +8420,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -8453,7 +8453,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -8490,7 +8490,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -8513,7 +8513,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -8540,7 +8540,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -8563,7 +8563,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -8594,7 +8594,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8617,7 +8617,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8644,7 +8644,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -8667,7 +8667,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -8698,7 +8698,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8721,7 +8721,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8748,7 +8748,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -8771,7 +8771,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -8804,7 +8804,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -8841,7 +8841,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -8864,7 +8864,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -8891,7 +8891,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -8914,7 +8914,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -8945,7 +8945,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8968,7 +8968,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -8995,7 +8995,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -9018,7 +9018,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -9049,7 +9049,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -9072,7 +9072,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -9099,7 +9099,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -9122,7 +9122,358 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 5e-5
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-200k",
+        "200000": "gt-200k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "response_token": {
+                        "price": 0.0025
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.001
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "response_token": {
+                        "price": 0.0025
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00125
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0005
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00125
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0005
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -9155,7 +9506,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -9192,7 +9543,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -9215,7 +9566,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -9242,7 +9593,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -9265,7 +9616,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -9296,7 +9647,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -9319,7 +9670,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -9346,7 +9697,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -9369,7 +9720,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -9400,7 +9751,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -9423,7 +9774,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -9450,7 +9801,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -9473,7 +9824,358 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 5e-5
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-200k",
+        "200000": "gt-200k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "response_token": {
+                        "price": 0.0025
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.001
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "response_token": {
+                        "price": 0.0025
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00125
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0005
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00125
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0005
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -9506,7 +10208,7 @@
           "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -9543,7 +10245,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "response_token": {
                         "price": 0.001
@@ -9566,7 +10268,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "response_token": {
                         "price": 0.001
@@ -9593,7 +10295,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.00001
+                        "price": 1e-5
                       },
                       "response_token": {
                         "price": 0.0005
@@ -9616,7 +10318,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.00001
+                        "price": 1e-5
                       },
                       "response_token": {
                         "price": 0.0005
@@ -9647,7 +10349,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "response_token": {
                         "price": 0.0011
@@ -9670,7 +10372,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "response_token": {
                         "price": 0.0011
@@ -9697,7 +10399,7 @@
                         "price": 0.000138
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "response_token": {
                         "price": 0.00055
@@ -9720,7 +10422,7 @@
                         "price": 0.000138
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "response_token": {
                         "price": 0.00055
@@ -9751,7 +10453,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "response_token": {
                         "price": 0.0011
@@ -9774,7 +10476,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "response_token": {
                         "price": 0.0011
@@ -9801,7 +10503,7 @@
                         "price": 0.000138
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "response_token": {
                         "price": 0.00055
@@ -9824,7 +10526,7 @@
                         "price": 0.000138
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "response_token": {
                         "price": 0.00055
@@ -9857,7 +10559,7 @@
           "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -9894,7 +10596,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "response_token": {
                         "price": 0.001
@@ -9917,7 +10619,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "response_token": {
                         "price": 0.001
@@ -9944,7 +10646,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.00001
+                        "price": 1e-5
                       },
                       "response_token": {
                         "price": 0.0005
@@ -9967,7 +10669,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.00001
+                        "price": 1e-5
                       },
                       "response_token": {
                         "price": 0.0005
@@ -9998,7 +10700,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "response_token": {
                         "price": 0.0011
@@ -10021,7 +10723,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "response_token": {
                         "price": 0.0011
@@ -10048,7 +10750,7 @@
                         "price": 0.000138
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "response_token": {
                         "price": 0.00055
@@ -10071,7 +10773,7 @@
                         "price": 0.000138
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "response_token": {
                         "price": 0.00055
@@ -10102,7 +10804,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "response_token": {
                         "price": 0.0011
@@ -10125,7 +10827,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "response_token": {
                         "price": 0.0011
@@ -10152,7 +10854,7 @@
                         "price": 0.000138
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "response_token": {
                         "price": 0.00055
@@ -10175,7 +10877,7 @@
                         "price": 0.000138
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "response_token": {
                         "price": 0.00055
@@ -10295,7 +10997,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -10318,7 +11020,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -10399,7 +11101,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -10422,7 +11124,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -10503,7 +11205,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -10526,7 +11228,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -10646,7 +11348,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -10669,7 +11371,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -10750,7 +11452,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -10773,7 +11475,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -10854,7 +11556,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -10877,7 +11579,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -10910,7 +11612,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -10947,7 +11649,7 @@
                         "price": 0.000375
                       },
                       "cache_read_input_token": {
-                        "price": 0.00003
+                        "price": 3e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -10970,7 +11672,7 @@
                         "price": 0.000375
                       },
                       "cache_read_input_token": {
-                        "price": 0.00003
+                        "price": 3e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -10997,7 +11699,7 @@
                         "price": 0.000188
                       },
                       "cache_read_input_token": {
-                        "price": 0.000015
+                        "price": 1.5e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -11020,7 +11722,7 @@
                         "price": 0.000188
                       },
                       "cache_read_input_token": {
-                        "price": 0.000015
+                        "price": 1.5e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -11051,7 +11753,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -11074,7 +11776,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -11101,7 +11803,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -11124,7 +11826,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -11155,7 +11857,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -11178,7 +11880,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -11205,7 +11907,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -11228,7 +11930,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -11259,7 +11961,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -11282,7 +11984,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -11309,7 +12011,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -11332,7 +12034,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -11362,10 +12064,10 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "additional_units": {
           "web_search": {
@@ -11408,7 +12110,7 @@
                         "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "response_token": {
                         "price": 0.0012
@@ -11437,7 +12139,7 @@
                         "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00004
+                        "price": 4e-5
                       },
                       "response_token": {
                         "price": 0.0018
@@ -11582,7 +12284,7 @@
                         "price": 0.00036
                       },
                       "cache_read_input_token": {
-                        "price": 0.000036
+                        "price": 3.6e-5
                       },
                       "response_token": {
                         "price": 0.00216
@@ -11611,7 +12313,7 @@
                         "price": 0.00072
                       },
                       "cache_read_input_token": {
-                        "price": 0.000072
+                        "price": 7.2e-5
                       },
                       "response_token": {
                         "price": 0.00324
@@ -11650,7 +12352,7 @@
           "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "cache_read_input_token": {
           "price": 0.00045
@@ -11693,7 +12395,7 @@
                         "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "response_token": {
                         "price": 0.0012
@@ -11719,7 +12421,7 @@
                         "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00004
+                        "price": 4e-5
                       },
                       "response_token": {
                         "price": 0.0018
@@ -11849,7 +12551,7 @@
                         "price": 0.00036
                       },
                       "cache_read_input_token": {
-                        "price": 0.000036
+                        "price": 3.6e-5
                       },
                       "response_token": {
                         "price": 0.00216
@@ -11875,7 +12577,7 @@
                         "price": 0.00072
                       },
                       "cache_read_input_token": {
-                        "price": 0.000072
+                        "price": 7.2e-5
                       },
                       "response_token": {
                         "price": 0.00324
@@ -11905,16 +12607,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
           "price": 0.00015
         },
         "cache_write_input_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "additional_units": {
           "web_search": {
@@ -11930,10 +12632,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-5
         }
       }
     },
@@ -11945,10 +12647,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000275
+                    "price": 2.75e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000275
+                    "price": 2.75e-6
                   },
                   "response_token": {
                     "price": 0.000165
@@ -11971,13 +12673,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00001375
+                    "price": 1.375e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000001375
+                    "price": 1.375e-6
                   },
                   "response_token": {
-                    "price": 0.0000825
+                    "price": 8.25e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -11997,13 +12699,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00001375
+                    "price": 1.375e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000001375
+                    "price": 1.375e-6
                   },
                   "response_token": {
-                    "price": 0.0000825
+                    "price": 8.25e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -12023,10 +12725,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000495
+                    "price": 4.95e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000495
+                    "price": 4.95e-6
                   },
                   "response_token": {
                     "price": 0.000297
@@ -12053,10 +12755,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000025
+                    "price": 2.5e-6
                   },
                   "response_token": {
                     "price": 0.00015
@@ -12079,13 +12781,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000125
+                    "price": 1.25e-6
                   },
                   "response_token": {
-                    "price": 0.000075
+                    "price": 7.5e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -12105,13 +12807,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000125
+                    "price": 1.25e-6
                   },
                   "response_token": {
-                    "price": 0.000075
+                    "price": 7.5e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -12131,10 +12833,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000045
+                    "price": 4.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000045
+                    "price": 4.5e-6
                   },
                   "response_token": {
                     "price": 0.00027
@@ -12162,16 +12864,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
           "price": 0.00015
         },
         "cache_write_input_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "additional_units": {
           "web_search": {
@@ -12187,10 +12889,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-5
         }
       }
     },
@@ -12202,10 +12904,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000275
+                    "price": 2.75e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000275
+                    "price": 2.75e-6
                   },
                   "response_token": {
                     "price": 0.000165
@@ -12228,13 +12930,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00001375
+                    "price": 1.375e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000001375
+                    "price": 1.375e-6
                   },
                   "response_token": {
-                    "price": 0.0000825
+                    "price": 8.25e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -12254,13 +12956,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00001375
+                    "price": 1.375e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000001375
+                    "price": 1.375e-6
                   },
                   "response_token": {
-                    "price": 0.0000825
+                    "price": 8.25e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -12280,10 +12982,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000495
+                    "price": 4.95e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000495
+                    "price": 4.95e-6
                   },
                   "response_token": {
                     "price": 0.000297
@@ -12310,10 +13012,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000025
+                    "price": 2.5e-6
                   },
                   "response_token": {
                     "price": 0.00015
@@ -12336,13 +13038,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000125
+                    "price": 1.25e-6
                   },
                   "response_token": {
-                    "price": 0.000075
+                    "price": 7.5e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -12362,13 +13064,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000125
+                    "price": 1.25e-6
                   },
                   "response_token": {
-                    "price": 0.000075
+                    "price": 7.5e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -12388,10 +13090,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000045
+                    "price": 4.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000045
+                    "price": 4.5e-6
                   },
                   "response_token": {
                     "price": 0.00027
@@ -12419,16 +13121,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "response_token": {
           "price": 0.00025
         },
         "cache_write_input_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-6
         },
         "additional_units": {
           "web_search": {
@@ -12444,7 +13146,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
           "price": 0.000125
@@ -12459,10 +13161,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000033
+                    "price": 3.3e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000033
+                    "price": 3.3e-6
                   },
                   "response_token": {
                     "price": 0.000275
@@ -12485,10 +13187,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000165
+                    "price": 1.65e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000165
+                    "price": 1.65e-6
                   },
                   "response_token": {
                     "price": 0.0001375
@@ -12511,10 +13213,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000165
+                    "price": 1.65e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000165
+                    "price": 1.65e-6
                   },
                   "response_token": {
                     "price": 0.0001375
@@ -12537,10 +13239,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000594
+                    "price": 5.94e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000594
+                    "price": 5.94e-6
                   },
                   "response_token": {
                     "price": 0.000495
@@ -12567,10 +13269,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00003
+                    "price": 3e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000003
+                    "price": 3e-6
                   },
                   "response_token": {
                     "price": 0.00025
@@ -12593,10 +13295,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000015
+                    "price": 1.5e-6
                   },
                   "response_token": {
                     "price": 0.000125
@@ -12619,10 +13321,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000015
+                    "price": 1.5e-6
                   },
                   "response_token": {
                     "price": 0.000125
@@ -12645,10 +13347,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000054
+                    "price": 5.4e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000054
+                    "price": 5.4e-6
                   },
                   "response_token": {
                     "price": 0.00045
@@ -12685,7 +13387,7 @@
           "price": 0.00015
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "additional_units": {
           "web_search": {
@@ -12704,7 +13406,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000075
+          "price": 7.5e-5
         },
         "response_token": {
           "price": 0.00045
@@ -12722,7 +13424,7 @@
                     "price": 0.000165
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000165
+                    "price": 1.65e-5
                   },
                   "response_token": {
                     "price": 0.00099
@@ -12748,10 +13450,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000825
+                    "price": 8.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000825
+                    "price": 8.25e-6
                   },
                   "response_token": {
                     "price": 0.000495
@@ -12777,10 +13479,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000825
+                    "price": 8.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000825
+                    "price": 8.25e-6
                   },
                   "response_token": {
                     "price": 0.000495
@@ -12809,7 +13511,7 @@
                     "price": 0.000297
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000297
+                    "price": 2.97e-5
                   },
                   "response_token": {
                     "price": 0.001782
@@ -12842,7 +13544,7 @@
                     "price": 0.00015
                   },
                   "cache_read_input_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.0009
@@ -12868,10 +13570,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000075
+                    "price": 7.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000075
+                    "price": 7.5e-6
                   },
                   "response_token": {
                     "price": 0.00045
@@ -12897,10 +13599,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000075
+                    "price": 7.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000008
+                    "price": 8e-6
                   },
                   "response_token": {
                     "price": 0.00045
@@ -12929,7 +13631,7 @@
                     "price": 0.00027
                   },
                   "cache_read_input_token": {
-                    "price": 0.000027
+                    "price": 2.7e-5
                   },
                   "response_token": {
                     "price": 0.00162
@@ -13244,7 +13946,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.0003
@@ -13266,7 +13968,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
           "price": 0.00015
@@ -13281,7 +13983,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.0003
@@ -13307,7 +14009,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.00015
@@ -13333,7 +14035,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.00015
@@ -13364,7 +14066,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.0003
@@ -13386,7 +14088,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
           "price": 0.00015
@@ -13401,7 +14103,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.0003
@@ -13427,7 +14129,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.00015
@@ -13453,7 +14155,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.00015
@@ -13484,7 +14186,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
           "price": 0.00015
@@ -13497,10 +14199,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "response_token": {
-          "price": 0.000075
+          "price": 7.5e-5
         }
       }
     },
@@ -13512,7 +14214,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.00015
@@ -13529,10 +14231,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
-                    "price": 0.000075
+                    "price": 7.5e-5
                   },
                   "additional_units": {
                     "image_token": {
@@ -13546,10 +14248,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
-                    "price": 0.000075
+                    "price": 7.5e-5
                   },
                   "additional_units": {
                     "image_token": {
@@ -13605,13 +14307,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "response_token": {
           "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-6
         },
         "additional_units": {
           "web_search": {
@@ -13633,7 +14335,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
           "price": 0.000125
@@ -13648,10 +14350,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00003
+                    "price": 3e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000003
+                    "price": 3e-6
                   },
                   "response_token": {
                     "price": 0.00025
@@ -13680,7 +14382,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -13709,7 +14411,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
                     "price": 0.000125
@@ -13738,10 +14440,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000054
+                    "price": 5.4e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
                     "price": 0.00045
@@ -13775,13 +14477,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "cache_read_input_token": {
-          "price": 0.000001
+          "price": 1e-6
         },
         "additional_units": {
           "web_search": {
@@ -13800,10 +14502,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 5e-6
         },
         "response_token": {
-          "price": 0.00002
+          "price": 2e-5
         }
       }
     },
@@ -13815,13 +14517,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000001
+                    "price": 1e-6
                   },
                   "response_token": {
-                    "price": 0.00004
+                    "price": 4e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -13844,10 +14546,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -13870,10 +14572,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -13896,13 +14598,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000018
+                    "price": 1.8e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000002
+                    "price": 2e-6
                   },
                   "response_token": {
-                    "price": 0.000072
+                    "price": 7.2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -14024,7 +14726,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "response_token": {
           "price": 0
@@ -14036,7 +14738,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "response_token": {
           "price": 0
@@ -14087,7 +14789,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "response_token": {
           "price": 0
@@ -14099,7 +14801,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "response_token": {
           "price": 0
@@ -14125,18 +14827,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000009
+          "price": 9e-6
         },
         "response_token": {
-          "price": 0.000036
+          "price": 3.6e-5
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000045
+          "price": 4.5e-6
         },
         "response_token": {
-          "price": 0.000018
+          "price": 1.8e-5
         }
       }
     }
@@ -14145,18 +14847,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000072
+          "price": 7.2e-5
         },
         "response_token": {
-          "price": 0.000072
+          "price": 7.2e-5
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000036
+          "price": 3.6e-5
         },
         "response_token": {
-          "price": 0.000036
+          "price": 3.6e-5
         }
       }
     }
@@ -14165,7 +14867,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000035
+          "price": 3.5e-5
         },
         "response_token": {
           "price": 0.000115
@@ -14173,10 +14875,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000175
+          "price": 1.75e-5
         },
         "response_token": {
-          "price": 0.0000575
+          "price": 5.75e-5
         }
       }
     }
@@ -14185,10 +14887,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         }
       }
     }
@@ -14197,7 +14899,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "response_token": {
           "price": 0.0002
@@ -14209,10 +14911,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "response_token": {
-          "price": 0.00009
+          "price": 9e-5
         }
       }
     }
@@ -14229,7 +14931,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000675
+          "price": 6.75e-5
         },
         "response_token": {
           "price": 0.00027
@@ -14241,21 +14943,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0.00017
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 6e-6
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "response_token": {
-          "price": 0.000085
+          "price": 8.5e-5
         }
       }
     }
@@ -14264,21 +14966,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000056
+          "price": 5.6e-5
         },
         "response_token": {
           "price": 0.000168
         },
         "cache_read_input_token": {
-          "price": 0.0000056
+          "price": 5.6e-6
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000028
+          "price": 2.8e-5
         },
         "response_token": {
-          "price": 0.000084
+          "price": 8.4e-5
         }
       }
     }
@@ -14299,18 +15001,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 2.2e-5
         },
         "response_token": {
-          "price": 0.000088
+          "price": 8.8e-5
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000011
+          "price": 1.1e-5
         },
         "response_token": {
-          "price": 0.000044
+          "price": 4.4e-5
         }
       }
     }
@@ -14319,21 +15021,21 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000022
+          "price": 2.2e-5
         },
         "response_token": {
           "price": 0.00018
         },
         "cache_read_input_token": {
-          "price": 0.0000022
+          "price": 2.2e-6
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000011
+          "price": 1.1e-5
         },
         "response_token": {
-          "price": 0.00009
+          "price": 9e-5
         }
       }
     }
@@ -14342,7 +15044,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
           "price": 0.00012
@@ -14354,7 +15056,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
           "price": 0.00012
@@ -14366,13 +15068,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "response_token": {
           "price": 0.00012
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-6
         }
       }
     }
@@ -14381,13 +15083,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 6e-6
         }
       }
     }
@@ -14396,7 +15098,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0.00022
@@ -14414,7 +15116,7 @@
           "price": 0.00032
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 1e-5
         }
       }
     }
@@ -14423,13 +15125,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "cache_read_input_token": {
-          "price": 0.0000015
+          "price": 1.5e-6
         }
       }
     }
@@ -14438,18 +15140,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         }
       }
     }
@@ -14529,7 +15231,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -14560,7 +15262,7 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -14570,7 +15272,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.00025
@@ -14591,7 +15293,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "response_token": {
                     "price": 0.0005
@@ -14608,13 +15310,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
                     "price": 0.00025
@@ -14641,7 +15343,7 @@
                     "price": 0.0001375
                   },
                   "cache_read_input_token": {
-                    "price": 0.000011
+                    "price": 1.1e-5
                   },
                   "response_token": {
                     "price": 0.00055
@@ -14658,13 +15360,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 6.88e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000055
+                    "price": 5.5e-6
                   },
                   "response_token": {
                     "price": 0.000275
@@ -14691,7 +15393,7 @@
                     "price": 0.0001375
                   },
                   "cache_read_input_token": {
-                    "price": 0.000011
+                    "price": 1.1e-5
                   },
                   "response_token": {
                     "price": 0.00055
@@ -14708,13 +15410,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 6.88e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000055
+                    "price": 5.5e-6
                   },
                   "response_token": {
                     "price": 0.000275
@@ -14741,7 +15443,7 @@
                     "price": 0.0001375
                   },
                   "cache_read_input_token": {
-                    "price": 0.000011
+                    "price": 1.1e-5
                   },
                   "response_token": {
                     "price": 0.00055
@@ -14758,13 +15460,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "cache_write_input_token": {
-                    "price": 0.0000688
+                    "price": 6.88e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000055
+                    "price": 5.5e-6
                   },
                   "response_token": {
                     "price": 0.000275
@@ -14795,7 +15497,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -14832,7 +15534,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -14855,7 +15557,7 @@
                         "price": 0.000625
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.0025
@@ -14882,7 +15584,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -14905,7 +15607,7 @@
                         "price": 0.0003125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.00125
@@ -14936,7 +15638,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -14959,7 +15661,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -14986,7 +15688,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -15009,7 +15711,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -15040,7 +15742,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -15063,7 +15765,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -15090,7 +15792,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -15113,7 +15815,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -15144,7 +15846,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -15167,7 +15869,7 @@
                         "price": 0.0006875
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.00275
@@ -15194,7 +15896,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -15217,7 +15919,7 @@
                         "price": 0.0003438
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.001375
@@ -15250,7 +15952,7 @@
           "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "additional_units": {
           "cache_write_1h": {
@@ -15287,7 +15989,7 @@
                         "price": 0.000375
                       },
                       "cache_read_input_token": {
-                        "price": 0.00003
+                        "price": 3e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -15310,7 +16012,7 @@
                         "price": 0.000375
                       },
                       "cache_read_input_token": {
-                        "price": 0.00003
+                        "price": 3e-5
                       },
                       "response_token": {
                         "price": 0.00225
@@ -15337,7 +16039,7 @@
                         "price": 0.000188
                       },
                       "cache_read_input_token": {
-                        "price": 0.000015
+                        "price": 1.5e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -15360,7 +16062,7 @@
                         "price": 0.000188
                       },
                       "cache_read_input_token": {
-                        "price": 0.000015
+                        "price": 1.5e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -15391,7 +16093,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -15414,7 +16116,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -15441,7 +16143,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -15464,7 +16166,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -15495,7 +16197,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -15518,7 +16220,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -15545,7 +16247,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -15568,7 +16270,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -15599,7 +16301,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -15622,7 +16324,7 @@
                         "price": 0.000413
                       },
                       "cache_read_input_token": {
-                        "price": 0.000033
+                        "price": 3.3e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -15649,7 +16351,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -15672,7 +16374,7 @@
                         "price": 0.000206
                       },
                       "cache_read_input_token": {
-                        "price": 0.000017
+                        "price": 1.7e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -15696,18 +16398,18 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         }
       }
     }
@@ -15776,7 +16478,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.001
@@ -15788,7 +16490,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.001


### PR DESCRIPTION
## Summary
- Adds `claude-opus-5` model config and pricing across **7 providers**: anthropic, claude-platform-aws, bedrock (with regional variants), bedrock-mantle, vertex-ai, azure-ai, and openrouter
- Pricing sourced from official Anthropic pricing page: standard ($5/$25 per MTok input/output), batch ($2.50/$12.50), cache write ($6.25 for 5m, $10 for 1h), cache read ($0.50), and fast tier ($10/$50) where applicable
- 1M token context window, 128K max output, supports chat, vision, tools, and extended thinking

**Source:** https://platform.claude.com/docs/en/about-claude/pricing

## Test plan
- [x] `jq empty` validates all modified JSON files
- [x] `python3 scripts/check_duplicate_keys.py` — no duplicates
- [x] `npm run format` (prettier) — passed
- [x] `npm run lint` (eslint) — passed
- [ ] CI checks pass


Made with [Cursor](https://cursor.com)