### PR TITLE
Add claude-opus-5 pricing and model config

### DIFF
--- a/general/anthropic.json
+++ b/general/anthropic.json
@@ -631,6 +631,30 @@
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "removeParams": ["temperature", "top_p", "top_k"]
   },
+  "claude-opus-5": {
+    "params": [
+      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["temperature", "top_p", "top_k"]
+  },
   "claude-sonnet-5": {
     "params": [
       { "key": "max_tokens", "maxValue": 128000 },

--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -3885,6 +3885,36 @@
     },
     "removeParams": ["top_p", "temperature", "top_k"]
   },
+  "claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 64000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
   "claude-sonnet-5": {
     "params": [
       {

--- a/general/bedrock-mantle.json
+++ b/general/bedrock-mantle.json
@@ -74,6 +74,36 @@
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "removeParams": ["top_p", "temperature", "top_k"]
   },
+  "anthropic.claude-opus-5": {
+    "params": [
+      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": { "type": "string", "enum": ["adaptive", "disabled"] },
+          "budget_tokens": { "type": "number", "minValue": 1024, "maxValue": 128000 }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          { "value": "none", "name": "None" },
+          { "value": "auto", "name": "Auto" },
+          { "value": "required", "name": "Required" },
+          { "value": "custom", "name": "Custom", "schema": { "type": "json" } }
+        ],
+        "skipValues": [null, []],
+        "rule": { "default": { "condition": "tools", "then": "auto", "else": null } }
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
 
   "anthropic.claude-sonnet-5": {
     "params": [

--- a/general/bedrock.json
+++ b/general/bedrock.json
@@ -4675,6 +4675,262 @@
     },
     "removeParams": ["top_p", "temperature", "top_k"]
   },
+  "anthropic.claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": "none",
+            "name": "None"
+          },
+          {
+            "value": "auto",
+            "name": "Auto"
+          },
+          {
+            "value": "required",
+            "name": "Required"
+          },
+          {
+            "value": "custom",
+            "name": "Custom",
+            "schema": {
+              "type": "json"
+            }
+          }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
+  "us.anthropic.claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": "none",
+            "name": "None"
+          },
+          {
+            "value": "auto",
+            "name": "Auto"
+          },
+          {
+            "value": "required",
+            "name": "Required"
+          },
+          {
+            "value": "custom",
+            "name": "Custom",
+            "schema": {
+              "type": "json"
+            }
+          }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
+  "eu.anthropic.claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": "none",
+            "name": "None"
+          },
+          {
+            "value": "auto",
+            "name": "Auto"
+          },
+          {
+            "value": "required",
+            "name": "Required"
+          },
+          {
+            "value": "custom",
+            "name": "Custom",
+            "schema": {
+              "type": "json"
+            }
+          }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
+  "global.anthropic.claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": "none",
+            "name": "None"
+          },
+          {
+            "value": "auto",
+            "name": "Auto"
+          },
+          {
+            "value": "required",
+            "name": "Required"
+          },
+          {
+            "value": "custom",
+            "name": "Custom",
+            "schema": {
+              "type": "json"
+            }
+          }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
   "anthropic.claude-sonnet-5": {
     "params": [
       {

--- a/general/claude-platform-aws.json
+++ b/general/claude-platform-aws.json
@@ -87,6 +87,30 @@
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "removeParams": ["temperature", "top_p", "top_k"]
   },
+  "claude-opus-5": {
+    "params": [
+      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["temperature", "top_p", "top_k"]
+  },
   "claude-sonnet-5": {
     "params": [
       { "key": "max_tokens", "maxValue": 128000 },

--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -1757,6 +1757,36 @@
     },
     "removeParams": ["temperature", "top_p", "top_k"]
   },
+  "anthropic.claude-opus-5": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 128000
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled", "disabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 1024,
+            "maxValue": 128000
+          }
+        },
+        "defaultValue": null,
+        "withdrawParams": ["top_k", "top_p"],
+        "skipValues": ["disabled", null]
+      }
+    ],
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    },
+    "removeParams": ["temperature", "top_p", "top_k"]
+  },
   "anthropic.claude-sonnet-5": {
     "params": [
       {

--- a/pricing/anthropic.json
+++ b/pricing/anthropic.json
@@ -1146,6 +1146,37 @@
       }
     }
   },
+  "claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
   "claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/azure-ai.json
+++ b/pricing/azure-ai.json
@@ -3803,6 +3803,29 @@
       }
     }
   },
+  "claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      }
+    }
+  },
   "claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/bedrock-mantle.json
+++ b/pricing/bedrock-mantle.json
@@ -82,6 +82,29 @@
       }
     }
   },
+  "anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      }
+    }
+  },
   "anthropic.claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -10708,6 +10708,254 @@
       }
     }
   },
+  "anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
+  "us.anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
+  "eu.anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
+  "global.anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
+  "anthropic.claude-opus-5-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
+  "us.anthropic.claude-opus-5-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
+  "eu.anthropic.claude-opus-5-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
+  "global.anthropic.claude-opus-5-v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
   "anthropic.claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/claude-platform-aws.json
+++ b/pricing/claude-platform-aws.json
@@ -131,6 +131,37 @@
       }
     }
   },
+  "claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    }
+  },
   "claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -9493,6 +9493,708 @@
       }
     }
   },
+  "anthropic.claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-200k",
+        "200000": "gt-200k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00005
+                      },
+                      "response_token": {
+                        "price": 0.0025
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.001
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00005
+                      },
+                      "response_token": {
+                        "price": 0.0025
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000025
+                      },
+                      "response_token": {
+                        "price": 0.00125
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0005
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000025
+                      },
+                      "response_token": {
+                        "price": 0.00125
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0005
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "claude-opus-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.001
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.00125
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-200k",
+        "200000": "gt-200k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00005
+                      },
+                      "response_token": {
+                        "price": 0.0025
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.001
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00005
+                      },
+                      "response_token": {
+                        "price": 0.0025
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.001
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000025
+                      },
+                      "response_token": {
+                        "price": 0.00125
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0005
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000025
+                      },
+                      "response_token": {
+                        "price": 0.00125
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0005
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "eu": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.00275
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.0011
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-200k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003438
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.001375
+                      },
+                      "additional_units": {
+                        "cache_write_1h": {
+                          "price": 0.00055
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "anthropic.claude-sonnet-5": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
Adds Anthropic's **Claude Opus 5**, launched 2026-07-24 ([announcement](https://www.anthropic.com/news/claude-opus-5), [models overview](https://platform.claude.com/docs/en/about-claude/models/overview)).

Pricing is $5 / $25 per MTok — identical to `claude-opus-4-8` (cache write 1.25x, cache read 0.1x, 1h cache write 2x, batch 50%), so entries mirror the existing `claude-opus-4-8` / `claude-sonnet-5` entries across every provider that serves the model:

- `pricing/anthropic.json` + `general/anthropic.json` — `claude-opus-5`
- `pricing/bedrock.json` (bare / `us.` / `eu.` / `global.` + `-v1` variants) + `general/bedrock.json`
- `pricing/bedrock-mantle.json` + `general/bedrock-mantle.json` — `anthropic.claude-opus-5`
- `pricing/claude-platform-aws.json` + `general/claude-platform-aws.json` — `claude-opus-5`
- `pricing/vertex-ai.json` (bare + `anthropic.`-prefixed, regional custom_pricing kept) + `general/vertex-ai.json`
- `pricing/azure-ai.json` + `general/azure-ai.json`

**Deliberately no fast-mode `custom_pricing` block** (unlike `claude-opus-4-8`): `speed="fast"` is not supported on Claude Opus 5 per the [Opus 4.8 → Opus 5 migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide) — the entries follow the `claude-sonnet-5` shape instead.

Validated with `scripts/check_duplicate_keys.py` and `prettier --check`.