### PR TITLE
[cerebras] Add Gemma 4 31B model config

### DIFF
--- a/general/cerebras.json
+++ b/general/cerebras.json
@@ -76,5 +76,12 @@
     "type": {
       "primary": "chat"
     }
+  },
+  "gemma-4-31b": {
+    "params": [{ "key": "max_tokens", "maxValue": 40960 }],
+    "type": {
+      "primary": "chat",
+      "supported": ["tools", "image"]
+    }
   }
 }

--- a/pricing/cerebras.json
+++ b/pricing/cerebras.json
@@ -179,5 +179,17 @@
         }
       }
     }
+  },
+  "gemma-4-31b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000099
+        },
+        "response_token": {
+          "price": 0.000149
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
# Description

Adds the current Cerebras Gemma 4 31B public model to the general and pricing catalogs. The configuration records its 40,960-token maximum output, tool and image support, and current input and output pricing.

- [x] New model pricing
- [ ] Update existing pricing
- [x] New model configuration
- [ ] Bug fix

## Source Verification

**Source Link:** https://api.cerebras.ai/public/v1/models

The live public catalog reports gemma-4-31b with $0.99 per million input tokens and $1.49 per million output tokens. Portkey prices are stored in cents per token, so these convert to 0.000099 and 0.000149 respectively.

Additional announcement: https://www.cerebras.ai/blog/gemma-4-on-cerebras-the-fastest-inference-is-now-multimodal

## Checklist

- [x] I have validated the JSON using jq
- [x] I have verified that prices are in cents per token, not dollars
- [x] I have included the source link above
- [ ] I have signed the CLA, if required for a first-time contributor

## Validation

- jq syntax validation for both changed files
- duplicate-key validation
- ESLint
- Prettier
- live catalog assertions for model ID, capabilities, output limit, and pricing conversion

## Related Issue

None.