### PR TITLE
Add gpt-5.6 dated model variants for Azure AI and Azure OpenAI

### DIFF
--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -6179,5 +6179,257 @@
       "supported": ["tools", "image", "chat"],
       "unsupported": ["messages"]
     }
+  },
+  "gpt-5.6-2026-07-09": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      {
+        "key": "max_completion_tokens",
+        "defaultValue": 20000,
+        "minValue": 1,
+        "maxValue": 128000
+      },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [null]
+            }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+    "type": {
+      "primary": "responses",
+      "supported": ["tools", "image", "chat"],
+      "unsupported": ["messages"]
+    }
+  },
+  "gpt-5.6-luna-2026-07-09": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      {
+        "key": "max_completion_tokens",
+        "defaultValue": 20000,
+        "minValue": 1,
+        "maxValue": 128000
+      },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [null]
+            }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+    "type": {
+      "primary": "responses",
+      "supported": ["tools", "image", "chat"],
+      "unsupported": ["messages"]
+    }
+  },
+  "gpt-5.6-sol-2026-07-09": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      {
+        "key": "max_completion_tokens",
+        "defaultValue": 20000,
+        "minValue": 1,
+        "maxValue": 128000
+      },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [null]
+            }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+    "type": {
+      "primary": "responses",
+      "supported": ["tools", "image", "chat"],
+      "unsupported": ["messages"]
+    }
+  },
+  "gpt-5.6-terra-2026-07-09": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      {
+        "key": "max_completion_tokens",
+        "defaultValue": 20000,
+        "minValue": 1,
+        "maxValue": 128000
+      },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [null]
+            }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+    "type": {
+      "primary": "responses",
+      "supported": ["tools", "image", "chat"],
+      "unsupported": ["messages"]
+    }
   }
 }

--- a/general/azure-openai.json
+++ b/general/azure-openai.json
@@ -4409,5 +4409,245 @@
     ],
 
     "type": { "primary": "responses", "supported": ["tools", "image", "chat"], "unsupported": ["messages"] }
+  },
+  "gpt-5.6-2026-07-09": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      {
+        "key": "max_completion_tokens",
+        "defaultValue": 20000,
+        "minValue": 1,
+        "maxValue": 128000
+      },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [null]
+            }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+
+    "type": { "primary": "responses", "supported": ["tools", "image", "chat"], "unsupported": ["messages"] }
+  },
+  "gpt-5.6-luna-2026-07-09": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      {
+        "key": "max_completion_tokens",
+        "defaultValue": 20000,
+        "minValue": 1,
+        "maxValue": 128000
+      },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [null]
+            }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+
+    "type": { "primary": "responses", "supported": ["tools", "image", "chat"], "unsupported": ["messages"] }
+  },
+  "gpt-5.6-sol-2026-07-09": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      {
+        "key": "max_completion_tokens",
+        "defaultValue": 20000,
+        "minValue": 1,
+        "maxValue": 128000
+      },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [null]
+            }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+
+    "type": { "primary": "responses", "supported": ["tools", "image", "chat"], "unsupported": ["messages"] }
+  },
+  "gpt-5.6-terra-2026-07-09": {
+    "removeParams": ["temperature", "top_p", "n", "presence_penalty", "frequency_penalty", "logit_bias", "max_tokens"],
+    "params": [
+      {
+        "key": "max_completion_tokens",
+        "defaultValue": 20000,
+        "minValue": 1,
+        "maxValue": 128000
+      },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_object"
+                }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "value": "json_schema"
+                },
+                "json_schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "params": {
+              "key": "json_schema",
+              "defaultValue": null,
+              "type": "json",
+              "skipValues": [null]
+            }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      }
+    ],
+
+    "type": { "primary": "responses", "supported": ["tools", "image", "chat"], "unsupported": ["messages"] }
   }
 }

--- a/pricing/azure-ai.json
+++ b/pricing/azure-ai.json
@@ -5219,5 +5219,121 @@
         }
       }
     }
+  },
+  "gpt-5.6-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          },
+          "routing_units": {
+            "price": 0.000014
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-luna-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        },
+        "cache_write_input_token": {
+          "price": 0.000125
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          },
+          "routing_units": {
+            "price": 0.000014
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-sol-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          },
+          "routing_units": {
+            "price": 0.000014
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-terra-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.0015
+        },
+        "cache_write_input_token": {
+          "price": 0.0003125
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          },
+          "routing_units": {
+            "price": 0.000014
+          }
+        }
+      }
+    }
   }
 }

--- a/pricing/azure-openai.json
+++ b/pricing/azure-openai.json
@@ -3849,5 +3849,121 @@
         }
       }
     }
+  },
+  "gpt-5.6-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          },
+          "routing_units": {
+            "price": 0.000014
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-luna-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        },
+        "cache_write_input_token": {
+          "price": 0.000125
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          },
+          "routing_units": {
+            "price": 0.000014
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-sol-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          },
+          "routing_units": {
+            "price": 0.000014
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-terra-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.0015
+        },
+        "cache_write_input_token": {
+          "price": 0.0003125
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          },
+          "routing_units": {
+            "price": 0.000014
+          }
+        }
+      }
+    }
   }
 }

--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -772,7 +772,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.00015
@@ -787,7 +787,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.00015
@@ -820,7 +820,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.0001
@@ -880,7 +880,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.00015
@@ -888,10 +888,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
-          "price": 0.00007499999999999999
+          "price": 7.5e-5
         }
       }
     },
@@ -903,7 +903,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.00015
@@ -923,10 +923,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
-                    "price": 0.00007499999999999999
+                    "price": 7.5e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -963,7 +963,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.00015
@@ -1028,7 +1028,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
           "price": 0
@@ -1043,7 +1043,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -1065,7 +1065,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
           "price": 0
@@ -1073,7 +1073,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 5e-6
         },
         "response_token": {
           "price": 0
@@ -1088,7 +1088,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -1110,7 +1110,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000002
+          "price": 2e-6
         },
         "response_token": {
           "price": 0
@@ -1118,7 +1118,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000001
+          "price": 1e-6
         },
         "response_token": {
           "price": 0
@@ -1133,7 +1133,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000002
+                    "price": 2e-6
                   },
                   "additional_units": {
                     "web_search": {
@@ -1155,7 +1155,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000013
+          "price": 1.3e-5
         },
         "response_token": {
           "price": 0
@@ -1163,7 +1163,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000065
+          "price": 6.5e-6
         },
         "response_token": {
           "price": 0
@@ -1178,7 +1178,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000013
+                    "price": 1.3e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -1502,7 +1502,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "response_token": {
           "price": 0.00012
@@ -1511,7 +1511,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "additional_units": {
           "web_search": {
@@ -1957,16 +1957,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "additional_units": {
           "web_search": {
@@ -1979,10 +1979,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "response_token": {
-          "price": 0.00003
+          "price": 3e-5
         }
       }
     },
@@ -1994,13 +1994,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000075
+                    "price": 7.5e-6
                   },
                   "response_token": {
-                    "price": 0.00005999999999999999
+                    "price": 5.999999999999999e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -2017,10 +2017,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000075
+                    "price": 7.5e-6
                   },
                   "response_token": {
-                    "price": 0.00003
+                    "price": 3e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -2037,10 +2037,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.0001
@@ -2065,16 +2065,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "additional_units": {
           "web_search": {
@@ -2099,13 +2099,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000075
+                    "price": 7.5e-6
                   },
                   "response_token": {
-                    "price": 0.00005999999999999999
+                    "price": 5.999999999999999e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -2122,10 +2122,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000075
+                    "price": 7.5e-6
                   },
                   "response_token": {
-                    "price": 0.00003
+                    "price": 3e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -2142,10 +2142,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.0001
@@ -2483,7 +2483,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000055
+          "price": 5.5e-5
         },
         "additional_units": {
           "file_search": {
@@ -2493,7 +2493,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000055
+          "price": 5.5e-5
         },
         "response_token": {
           "price": 0.00022
@@ -2511,7 +2511,7 @@
                     "price": 0.00011
                   },
                   "cache_read_input_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "response_token": {
                     "price": 0.00044
@@ -2531,7 +2531,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "response_token": {
                     "price": 0.00022
@@ -2585,7 +2585,7 @@
                     "price": 0.00011
                   },
                   "cache_read_input_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "response_token": {
                     "price": 0.00044
@@ -2605,7 +2605,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "response_token": {
                     "price": 0.00022
@@ -2719,7 +2719,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00007499999999999999
+          "price": 7.5e-5
         },
         "response_token": {
           "price": 0.0001
@@ -3053,7 +3053,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
           "price": 0
@@ -3115,7 +3115,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0
@@ -3202,7 +3202,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000055
+          "price": 5.5e-5
         },
         "additional_units": {
           "file_search": {
@@ -3222,7 +3222,7 @@
                     "price": 0.00011
                   },
                   "cache_read_input_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "response_token": {
                     "price": 0.00044
@@ -3242,7 +3242,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "response_token": {
                     "price": 0.00022
@@ -3276,7 +3276,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000055
+          "price": 5.5e-5
         },
         "additional_units": {
           "file_search": {
@@ -3286,7 +3286,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000055
+          "price": 5.5e-5
         },
         "response_token": {
           "price": 0.00022
@@ -3304,7 +3304,7 @@
                     "price": 0.00011
                   },
                   "cache_read_input_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "response_token": {
                     "price": 0.00044
@@ -3324,7 +3324,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "response_token": {
                     "price": 0.00022
@@ -3647,7 +3647,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "web_search": {
@@ -3675,7 +3675,7 @@
                     "price": 0.0002
                   },
                   "cache_read_input_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.0008
@@ -3718,7 +3718,7 @@
                     "price": 0.00035
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "response_token": {
                     "price": 0.0014
@@ -3752,7 +3752,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "web_search": {
@@ -3783,7 +3783,7 @@
                     "price": 0.0002
                   },
                   "cache_read_input_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.0008
@@ -3826,7 +3826,7 @@
                     "price": 0.00035
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "response_token": {
                     "price": 0.0014
@@ -3851,7 +3851,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "response_token": {
           "price": 0.00016
@@ -3860,7 +3860,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "additional_units": {
           "web_search": {
@@ -3885,10 +3885,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00004
+                    "price": 4e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "response_token": {
                     "price": 0.00016
@@ -3908,10 +3908,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "response_token": {
-                    "price": 0.00008000000000000001
+                    "price": 8e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -3928,10 +3928,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00006999999999999999
+                    "price": 7e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000175
+                    "price": 1.75e-5
                   },
                   "response_token": {
                     "price": 0.00028
@@ -3956,7 +3956,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "response_token": {
           "price": 0.00016
@@ -3965,7 +3965,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "additional_units": {
           "web_search": {
@@ -3978,10 +3978,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "response_token": {
-          "price": 0.00008000000000000001
+          "price": 8e-5
         }
       }
     },
@@ -3993,10 +3993,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00004
+                    "price": 4e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "response_token": {
                     "price": 0.00016
@@ -4016,10 +4016,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "response_token": {
-                    "price": 0.00008000000000000001
+                    "price": 8e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -4036,10 +4036,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00006999999999999999
+                    "price": 7e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000175
+                    "price": 1.75e-5
                   },
                   "response_token": {
                     "price": 0.00028
@@ -4064,16 +4064,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-6
         }
       },
       "finetune_config": {
@@ -4090,13 +4090,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000025
+                    "price": 2.5e-6
                   },
                   "response_token": {
-                    "price": 0.00004
+                    "price": 4e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -4113,10 +4113,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -4133,13 +4133,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
-                    "price": 0.00008000000000000001
+                    "price": 8e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -4161,16 +4161,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "response_token": {
-          "price": 0.00008000000000000001
+          "price": 8e-5
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 5e-6
         }
       }
     }
@@ -4179,16 +4179,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "response_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000003
+          "price": 3e-6
         },
         "additional_units": {
           "web_search": {
@@ -4201,10 +4201,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000005
+          "price": 5e-6
         },
         "response_token": {
-          "price": 0.00002
+          "price": 2e-5
         }
       }
     },
@@ -4216,13 +4216,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00001
+                    "price": 1e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000025
+                    "price": 2.5e-6
                   },
                   "response_token": {
-                    "price": 0.00004
+                    "price": 4e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -4239,10 +4239,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -4259,13 +4259,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "response_token": {
-                    "price": 0.00008000000000000001
+                    "price": 8e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -4296,7 +4296,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "web_search": {
@@ -4327,7 +4327,7 @@
                     "price": 0.0002
                   },
                   "cache_read_input_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.0008
@@ -4370,7 +4370,7 @@
                     "price": 0.0001
                   },
                   "cache_read_input_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.0004
@@ -4393,7 +4393,7 @@
                     "price": 0.00035
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "response_token": {
                     "price": 0.0014
@@ -4427,7 +4427,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "file_search": {
@@ -4447,7 +4447,7 @@
                     "price": 0.0002
                   },
                   "cache_read_input_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.0008
@@ -4490,7 +4490,7 @@
                     "price": 0.0001
                   },
                   "cache_read_input_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.0004
@@ -4513,7 +4513,7 @@
                     "price": 0.00035
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "response_token": {
                     "price": 0.0014
@@ -4685,7 +4685,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000275
+          "price": 2.75e-5
         },
         "additional_units": {
           "web_search": {
@@ -4698,7 +4698,7 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000055
+          "price": 5.5e-5
         },
         "response_token": {
           "price": 0.00022
@@ -4716,7 +4716,7 @@
                     "price": 0.00011
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000275
+                    "price": 2.75e-5
                   },
                   "response_token": {
                     "price": 0.00044
@@ -4736,7 +4736,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "response_token": {
                     "price": 0.00022
@@ -4756,10 +4756,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000138
+                    "price": 1.38e-5
                   },
                   "response_token": {
                     "price": 0.00022
@@ -4782,7 +4782,7 @@
                     "price": 0.0002
                   },
                   "cache_read_input_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.0008
@@ -4816,7 +4816,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000275
+          "price": 2.75e-5
         },
         "additional_units": {
           "web_search": {
@@ -4844,7 +4844,7 @@
                     "price": 0.00011
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000275
+                    "price": 2.75e-5
                   },
                   "response_token": {
                     "price": 0.00044
@@ -4864,7 +4864,7 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "response_token": {
                     "price": 0.00022
@@ -4884,10 +4884,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000055
+                    "price": 5.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000138
+                    "price": 1.38e-5
                   },
                   "response_token": {
                     "price": 0.00022
@@ -4910,7 +4910,7 @@
                     "price": 0.0002
                   },
                   "cache_read_input_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.0008
@@ -4990,7 +4990,7 @@
                     "price": 0.0002
                   },
                   "cache_read_input_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.0008
@@ -5038,7 +5038,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "response_token": {
           "price": 0.00012
@@ -5047,7 +5047,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "additional_units": {
           "web_search": {
@@ -5073,7 +5073,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00007499999999999999
+          "price": 7.5e-5
         },
         "additional_units": {
           "web_search": {
@@ -5099,7 +5099,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00007499999999999999
+          "price": 7.5e-5
         },
         "additional_units": {
           "web_search": {
@@ -5116,7 +5116,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008000000000000001
+          "price": 8e-5
         },
         "response_token": {
           "price": 0.00032
@@ -5125,7 +5125,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "additional_units": {
           "web_search": {
@@ -5142,7 +5142,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00008000000000000001
+          "price": 8e-5
         },
         "response_token": {
           "price": 0.00032
@@ -5151,7 +5151,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "additional_units": {
           "web_search": {
@@ -5362,7 +5362,7 @@
                     "price": 0.0002
                   },
                   "cache_read_input_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.0008
@@ -5416,7 +5416,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "web_search": {
@@ -5447,7 +5447,7 @@
                     "price": 0.0002
                   },
                   "cache_read_input_token": {
-                    "price": 0.00005
+                    "price": 5e-5
                   },
                   "response_token": {
                     "price": 0.0008
@@ -5492,7 +5492,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0.00024
@@ -5519,7 +5519,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0.00024
@@ -5636,10 +5636,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         }
       }
     },
@@ -5651,10 +5651,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
-                    "price": 0.00005999999999999999
+                    "price": 5.999999999999999e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -5676,10 +5676,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         }
       }
     },
@@ -5691,10 +5691,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000015
+                    "price": 1.5e-5
                   },
                   "response_token": {
-                    "price": 0.00005999999999999999
+                    "price": 5.999999999999999e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -5725,7 +5725,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000375
+          "price": 3.75e-5
         }
       }
     },
@@ -5740,7 +5740,7 @@
                     "price": 0.00015
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000375
+                    "price": 3.75e-5
                   },
                   "response_token": {
                     "price": 0.0006
@@ -5814,7 +5814,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "additional_units": {
           "web_search": {
@@ -5837,7 +5837,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.001
@@ -5857,10 +5857,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -5880,10 +5880,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -5906,7 +5906,7 @@
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.002
@@ -5940,7 +5940,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "additional_units": {
           "web_search": {
@@ -5953,13 +5953,13 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         },
         "response_token": {
           "price": 0.0005
         },
         "cache_read_input_token": {
-          "price": 0.00000625
+          "price": 6.25e-6
         }
       }
     },
@@ -5974,7 +5974,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.001
@@ -5994,10 +5994,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -6017,10 +6017,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -6043,7 +6043,7 @@
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.002
@@ -6068,7 +6068,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
           "price": 0.0002
@@ -6077,7 +6077,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "additional_units": {
           "web_search": {
@@ -6090,13 +6090,13 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "response_token": {
           "price": 0.0001
         },
         "cache_read_input_token": {
-          "price": 0.00000125
+          "price": 1.25e-6
         }
       }
     },
@@ -6108,10 +6108,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000025
+                    "price": 2.5e-6
                   },
                   "response_token": {
                     "price": 0.0002
@@ -6131,10 +6131,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000125
+                    "price": 1.25e-6
                   },
                   "response_token": {
                     "price": 0.0001
@@ -6154,10 +6154,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000125
+                    "price": 1.25e-6
                   },
                   "response_token": {
                     "price": 0.0001
@@ -6177,10 +6177,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000045
+                    "price": 4.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000045
+                    "price": 4.5e-6
                   },
                   "response_token": {
                     "price": 0.00036
@@ -6205,7 +6205,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
           "price": 0.0002
@@ -6214,7 +6214,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "additional_units": {
           "web_search": {
@@ -6234,10 +6234,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000025
+                    "price": 2.5e-6
                   },
                   "response_token": {
                     "price": 0.0002
@@ -6257,10 +6257,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000125
+                    "price": 1.25e-6
                   },
                   "response_token": {
                     "price": 0.0001
@@ -6280,10 +6280,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000125
+                    "price": 1.25e-6
                   },
                   "response_token": {
                     "price": 0.0001
@@ -6303,10 +6303,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000045
+                    "price": 4.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000045
+                    "price": 4.5e-6
                   },
                   "response_token": {
                     "price": 0.00036
@@ -6331,27 +6331,27 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 5e-6
         },
         "response_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000005
+          "price": 5e-7
         }
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "response_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "cache_read_input_token": {
-          "price": 0.00000025
+          "price": 2.5e-7
         }
       }
     },
@@ -6363,13 +6363,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000005
+                    "price": 5e-7
                   },
                   "response_token": {
-                    "price": 0.00004
+                    "price": 4e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -6386,13 +6386,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000025
+                    "price": 2.5e-6
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000025
+                    "price": 2.5e-7
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -6409,13 +6409,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000025
+                    "price": 2.5e-6
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000025
+                    "price": 2.5e-7
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -6437,16 +6437,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000005
+          "price": 5e-6
         },
         "response_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "cache_write_input_token": {
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000005
+          "price": 5e-7
         }
       }
     },
@@ -6458,13 +6458,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000005
+                    "price": 5e-6
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000005
+                    "price": 5e-7
                   },
                   "response_token": {
-                    "price": 0.00004
+                    "price": 4e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -6481,13 +6481,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000025
+                    "price": 2.5e-6
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000025
+                    "price": 2.5e-7
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -6504,13 +6504,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000025
+                    "price": 2.5e-6
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000025
+                    "price": 2.5e-7
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -6541,7 +6541,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "additional_units": {
           "web_search": {
@@ -6564,7 +6564,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.001
@@ -6584,10 +6584,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -6607,10 +6607,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -6633,7 +6633,7 @@
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.002
@@ -6667,7 +6667,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "additional_units": {
           "web_search": {
@@ -6690,7 +6690,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.001
@@ -6713,7 +6713,7 @@
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.002
@@ -6738,10 +6738,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_audio_token": {
           "price": 0.002
@@ -6756,10 +6756,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000015
+          "price": 1.5e-5
         },
         "response_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_audio_token": {
           "price": 0.001
@@ -6783,7 +6783,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000005
+          "price": 5e-7
         },
         "additional_units": {
           "web_search": {
@@ -6865,7 +6865,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000005
+          "price": 5e-7
         },
         "additional_units": {
           "web_search": {
@@ -6936,7 +6936,7 @@
           "price": 0.0016
         },
         "cache_write_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "cache_read_input_token": {
           "price": 0.0016
@@ -6963,7 +6963,7 @@
           "price": 0.0016
         },
         "cache_write_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "cache_read_input_token": {
           "price": 0.0016
@@ -7002,7 +7002,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0.00024
@@ -7280,7 +7280,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "additional_units": {
           "web_search": {
@@ -7293,13 +7293,13 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         },
         "response_token": {
           "price": 0.0005
         },
         "cache_read_input_token": {
-          "price": 0.00000625
+          "price": 6.25e-6
         }
       }
     },
@@ -7314,7 +7314,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.001
@@ -7334,10 +7334,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -7357,10 +7357,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -7383,7 +7383,7 @@
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.002
@@ -7417,7 +7417,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "additional_units": {
           "web_search": {
@@ -7440,7 +7440,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.001
@@ -7460,10 +7460,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -7483,10 +7483,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -7509,7 +7509,7 @@
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.002
@@ -7543,7 +7543,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "additional_units": {
           "web_search": {
@@ -7566,7 +7566,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.001
@@ -7589,7 +7589,7 @@
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.002
@@ -7614,7 +7614,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "response_token": {
           "price": 0.0002
@@ -7623,7 +7623,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000025
+          "price": 2.5e-6
         },
         "additional_units": {
           "web_search": {
@@ -7643,10 +7643,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000025
+                    "price": 2.5e-6
                   },
                   "response_token": {
                     "price": 0.0002
@@ -7680,7 +7680,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "additional_units": {
           "web_search": {
@@ -7703,7 +7703,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.001
@@ -7723,10 +7723,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -7746,10 +7746,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000625
+                    "price": 6.25e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000625
+                    "price": 6.25e-6
                   },
                   "response_token": {
                     "price": 0.0005
@@ -7772,7 +7772,7 @@
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.002
@@ -7806,7 +7806,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "additional_units": {
           "web_search": {
@@ -7829,7 +7829,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.001
@@ -7863,7 +7863,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "additional_units": {
           "web_search": {
@@ -7886,7 +7886,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.001
@@ -7920,7 +7920,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 1.75e-5
         },
         "additional_units": {
           "web_search": {
@@ -7933,13 +7933,13 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.0000875
+          "price": 8.75e-5
         },
         "response_token": {
           "price": 0.0007
         },
         "cache_read_input_token": {
-          "price": 0.00000875
+          "price": 8.75e-6
         }
       }
     },
@@ -7954,7 +7954,7 @@
                     "price": 0.000175
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000175
+                    "price": 1.75e-5
                   },
                   "response_token": {
                     "price": 0.0014
@@ -7974,10 +7974,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000875
+                    "price": 8.75e-6
                   },
                   "response_token": {
                     "price": 0.0007
@@ -7997,10 +7997,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000875
+                    "price": 8.75e-6
                   },
                   "response_token": {
                     "price": 0.0007
@@ -8023,7 +8023,7 @@
                     "price": 0.00035
                   },
                   "cache_read_input_token": {
-                    "price": 0.000035
+                    "price": 3.5e-5
                   },
                   "response_token": {
                     "price": 0.0028
@@ -8057,7 +8057,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 1.75e-5
         },
         "additional_units": {
           "web_search": {
@@ -8080,7 +8080,7 @@
                     "price": 0.000175
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000175
+                    "price": 1.75e-5
                   },
                   "response_token": {
                     "price": 0.0014
@@ -8100,10 +8100,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000875
+                    "price": 8.75e-6
                   },
                   "response_token": {
                     "price": 0.0007
@@ -8123,10 +8123,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000875
+                    "price": 8.75e-6
                   },
                   "response_token": {
                     "price": 0.0007
@@ -8149,7 +8149,7 @@
                     "price": 0.00035
                   },
                   "cache_read_input_token": {
-                    "price": 0.000035
+                    "price": 3.5e-5
                   },
                   "response_token": {
                     "price": 0.0028
@@ -8183,7 +8183,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 1.75e-5
         },
         "additional_units": {
           "web_search": {
@@ -8206,7 +8206,7 @@
                     "price": 0.000175
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000175
+                    "price": 1.75e-5
                   },
                   "response_token": {
                     "price": 0.0014
@@ -8226,10 +8226,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000875
+                    "price": 8.75e-6
                   },
                   "response_token": {
                     "price": 0.0007
@@ -8249,10 +8249,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000875
+                    "price": 8.75e-6
                   },
                   "response_token": {
                     "price": 0.0007
@@ -8275,7 +8275,7 @@
                     "price": 0.00035
                   },
                   "cache_read_input_token": {
-                    "price": 0.000035
+                    "price": 3.5e-5
                   },
                   "response_token": {
                     "price": 0.0028
@@ -8309,7 +8309,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 1.75e-5
         },
         "additional_units": {
           "web_search": {
@@ -8332,7 +8332,7 @@
                     "price": 0.000175
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000175
+                    "price": 1.75e-5
                   },
                   "response_token": {
                     "price": 0.0014
@@ -8352,10 +8352,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000875
+                    "price": 8.75e-6
                   },
                   "response_token": {
                     "price": 0.0007
@@ -8375,10 +8375,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.0000875
+                    "price": 8.75e-5
                   },
                   "cache_read_input_token": {
-                    "price": 0.00000875
+                    "price": 8.75e-6
                   },
                   "response_token": {
                     "price": 0.0007
@@ -8401,7 +8401,7 @@
                     "price": 0.00035
                   },
                   "cache_read_input_token": {
-                    "price": 0.000035
+                    "price": 3.5e-5
                   },
                   "response_token": {
                     "price": 0.0028
@@ -8585,7 +8585,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         },
         "additional_units": {
           "web_search": {
@@ -8608,7 +8608,7 @@
                     "price": 0.000125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000125
+                    "price": 1.25e-5
                   },
                   "response_token": {
                     "price": 0.001
@@ -8631,7 +8631,7 @@
                     "price": 0.00025
                   },
                   "cache_read_input_token": {
-                    "price": 0.000025
+                    "price": 2.5e-5
                   },
                   "response_token": {
                     "price": 0.002
@@ -8656,7 +8656,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0.00024
@@ -8665,10 +8665,10 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 6e-6
         },
         "cache_read_audio_input_token": {
-          "price": 0.000008
+          "price": 8e-6
         },
         "request_audio_token": {
           "price": 0.001
@@ -9053,7 +9053,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 1.75e-5
         },
         "additional_units": {
           "web_search": {
@@ -9076,7 +9076,7 @@
                     "price": 0.000175
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000175
+                    "price": 1.75e-5
                   },
                   "response_token": {
                     "price": 0.0014
@@ -9099,7 +9099,7 @@
                     "price": 0.00035
                   },
                   "cache_read_input_token": {
-                    "price": 0.000035
+                    "price": 3.5e-5
                   },
                   "response_token": {
                     "price": 0.0028
@@ -9133,7 +9133,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 1.75e-5
         },
         "additional_units": {
           "web_search": {
@@ -9156,7 +9156,7 @@
                     "price": 0.000175
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000175
+                    "price": 1.75e-5
                   },
                   "response_token": {
                     "price": 0.0014
@@ -9179,7 +9179,7 @@
                     "price": 0.00035
                   },
                   "cache_read_input_token": {
-                    "price": 0.000035
+                    "price": 3.5e-5
                   },
                   "response_token": {
                     "price": 0.0028
@@ -9204,13 +9204,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 6e-6
         },
         "request_audio_token": {
           "price": 0.001
@@ -9219,13 +9219,13 @@
           "price": 0.002
         },
         "cache_read_audio_input_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "request_image_token": {
-          "price": 0.00008000000000000001
+          "price": 8e-5
         },
         "cache_read_image_input_token": {
-          "price": 0.000008
+          "price": 8e-6
         }
       }
     }
@@ -9234,13 +9234,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0.00024
         },
         "cache_read_input_token": {
-          "price": 0.000006
+          "price": 6e-6
         },
         "request_audio_token": {
           "price": 0.001
@@ -9249,13 +9249,13 @@
           "price": 0.002
         },
         "cache_read_audio_input_token": {
-          "price": 0.00003
+          "price": 3e-5
         },
         "request_image_token": {
-          "price": 0.00008000000000000001
+          "price": 8e-5
         },
         "cache_read_image_input_token": {
-          "price": 0.000008
+          "price": 8e-6
         }
       }
     }
@@ -9309,7 +9309,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0.00024
@@ -9330,7 +9330,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0.00024
@@ -9393,7 +9393,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0
@@ -9408,7 +9408,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00006
+          "price": 6e-5
         },
         "response_token": {
           "price": 0
@@ -9507,13 +9507,13 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "request_image_token": {
           "price": 0.00025
         },
         "cache_read_image_input_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         }
       }
     }
@@ -9708,10 +9708,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "response_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "cache_write_input_token": {
           "price": 0
@@ -9726,10 +9726,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00004
+                    "price": 4e-5
                   },
                   "response_token": {
-                    "price": 0.00004
+                    "price": 4e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -9746,10 +9746,10 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "response_token": {
-                    "price": 0.00002
+                    "price": 2e-5
                   },
                   "additional_units": {
                     "web_search": {
@@ -9780,7 +9780,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "request_audio_token": {
           "price": 0.0032
@@ -9789,7 +9789,7 @@
           "price": 0.0064
         },
         "cache_read_audio_input_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "request_image_token": {
           "price": 0.0005
@@ -9810,7 +9810,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "request_audio_token": {
           "price": 0.0032
@@ -9819,13 +9819,13 @@
           "price": 0.0064
         },
         "cache_read_audio_input_token": {
-          "price": 0.00004
+          "price": 4e-5
         },
         "request_image_token": {
           "price": 0.0005
         },
         "cache_read_image_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         }
       }
     }
@@ -9927,7 +9927,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.0000175
+          "price": 1.75e-5
         },
         "additional_units": {
           "web_search": {
@@ -9950,7 +9950,7 @@
                     "price": 0.000175
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000175
+                    "price": 1.75e-5
                   },
                   "response_token": {
                     "price": 0.0014
@@ -9981,7 +9981,7 @@
           "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "additional_units": {
           "web_search": {
@@ -10010,7 +10010,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -10033,7 +10033,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.00225
@@ -10060,7 +10060,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000013
+                        "price": 1.3e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -10083,7 +10083,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.001125
@@ -10110,7 +10110,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000013
+                        "price": 1.3e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -10133,7 +10133,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.001125
@@ -10160,7 +10160,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.003
@@ -10191,7 +10191,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -10214,7 +10214,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -10241,7 +10241,7 @@
                         "price": 0.0001375
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000143
+                        "price": 1.43e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -10264,7 +10264,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.0012375
@@ -10291,7 +10291,7 @@
                         "price": 0.0001375
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000143
+                        "price": 1.43e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -10314,7 +10314,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.0012375
@@ -10341,7 +10341,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.0033
@@ -10374,7 +10374,7 @@
           "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "additional_units": {
           "web_search": {
@@ -10403,7 +10403,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -10426,7 +10426,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.00225
@@ -10453,7 +10453,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000013
+                        "price": 1.3e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -10476,7 +10476,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.001125
@@ -10503,7 +10503,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.000013
+                        "price": 1.3e-5
                       },
                       "response_token": {
                         "price": 0.00075
@@ -10526,7 +10526,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.001125
@@ -10553,7 +10553,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.003
@@ -10584,7 +10584,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -10607,7 +10607,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -10634,7 +10634,7 @@
                         "price": 0.0001375
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000143
+                        "price": 1.43e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -10657,7 +10657,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.0012375
@@ -10684,7 +10684,7 @@
                         "price": 0.0001375
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000143
+                        "price": 1.43e-5
                       },
                       "response_token": {
                         "price": 0.000825
@@ -10707,7 +10707,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.0012375
@@ -10734,7 +10734,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.0033
@@ -11361,13 +11361,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007499999999999999
+          "price": 7.5e-5
         },
         "response_token": {
           "price": 0.00045
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "additional_units": {
           "web_search": {
@@ -11393,10 +11393,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00007499999999999999
+                        "price": 7.5e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000075
+                        "price": 7.5e-6
                       },
                       "response_token": {
                         "price": 0.00045
@@ -11420,10 +11420,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000375
+                        "price": 3.75e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.00000375
+                        "price": 3.75e-6
                       },
                       "response_token": {
                         "price": 0.000225
@@ -11447,10 +11447,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000375
+                        "price": 3.75e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.00000375
+                        "price": 3.75e-6
                       },
                       "response_token": {
                         "price": 0.000225
@@ -11477,7 +11477,7 @@
                         "price": 0.00015
                       },
                       "cache_read_input_token": {
-                        "price": 0.000015
+                        "price": 1.5e-5
                       },
                       "response_token": {
                         "price": 0.0009
@@ -11505,10 +11505,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000825
+                        "price": 8.25e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.00000825
+                        "price": 8.25e-6
                       },
                       "response_token": {
                         "price": 0.000495
@@ -11532,10 +11532,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00004125
+                        "price": 4.125e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000004125
+                        "price": 4.125e-6
                       },
                       "response_token": {
                         "price": 0.0002475
@@ -11559,10 +11559,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00004125
+                        "price": 4.125e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000004125
+                        "price": 4.125e-6
                       },
                       "response_token": {
                         "price": 0.0002475
@@ -11589,7 +11589,7 @@
                         "price": 0.000165
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000165
+                        "price": 1.65e-5
                       },
                       "response_token": {
                         "price": 0.00099
@@ -11616,13 +11616,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00007499999999999999
+          "price": 7.5e-5
         },
         "response_token": {
           "price": 0.00045
         },
         "cache_read_input_token": {
-          "price": 0.0000075
+          "price": 7.5e-6
         },
         "additional_units": {
           "web_search": {
@@ -11648,10 +11648,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00007499999999999999
+                        "price": 7.5e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000075
+                        "price": 7.5e-6
                       },
                       "response_token": {
                         "price": 0.00045
@@ -11675,10 +11675,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000375
+                        "price": 3.75e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.00000375
+                        "price": 3.75e-6
                       },
                       "response_token": {
                         "price": 0.000225
@@ -11702,10 +11702,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000375
+                        "price": 3.75e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.00000375
+                        "price": 3.75e-6
                       },
                       "response_token": {
                         "price": 0.000225
@@ -11732,7 +11732,7 @@
                         "price": 0.00015
                       },
                       "cache_read_input_token": {
-                        "price": 0.000015
+                        "price": 1.5e-5
                       },
                       "response_token": {
                         "price": 0.0009
@@ -11760,10 +11760,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0000825
+                        "price": 8.25e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.00000825
+                        "price": 8.25e-6
                       },
                       "response_token": {
                         "price": 0.000495
@@ -11787,10 +11787,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00004125
+                        "price": 4.125e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000004125
+                        "price": 4.125e-6
                       },
                       "response_token": {
                         "price": 0.0002475
@@ -11814,10 +11814,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00004125
+                        "price": 4.125e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000004125
+                        "price": 4.125e-6
                       },
                       "response_token": {
                         "price": 0.0002475
@@ -11844,7 +11844,7 @@
                         "price": 0.000165
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000165
+                        "price": 1.65e-5
                       },
                       "response_token": {
                         "price": 0.00099
@@ -11871,13 +11871,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "response_token": {
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 2e-6
         },
         "additional_units": {
           "web_search": {
@@ -11903,10 +11903,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000002
+                        "price": 2e-6
                       },
                       "response_token": {
                         "price": 0.000125
@@ -11930,13 +11930,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00001
+                        "price": 1e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000001
+                        "price": 1e-6
                       },
                       "response_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "additional_units": {
                         "web_search": {
@@ -11957,13 +11957,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00001
+                        "price": 1e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000001
+                        "price": 1e-6
                       },
                       "response_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "additional_units": {
                         "web_search": {
@@ -11988,10 +11988,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000022
+                        "price": 2.2e-6
                       },
                       "response_token": {
                         "price": 0.0001375
@@ -12015,13 +12015,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000011
+                        "price": 1.1e-6
                       },
                       "response_token": {
-                        "price": 0.00006875
+                        "price": 6.875e-5
                       },
                       "additional_units": {
                         "web_search": {
@@ -12042,13 +12042,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000011
+                        "price": 1.1e-6
                       },
                       "response_token": {
-                        "price": 0.00006875
+                        "price": 6.875e-5
                       },
                       "additional_units": {
                         "web_search": {
@@ -12072,13 +12072,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00002
+          "price": 2e-5
         },
         "response_token": {
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.000002
+          "price": 2e-6
         },
         "additional_units": {
           "web_search": {
@@ -12104,10 +12104,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000002
+                        "price": 2e-6
                       },
                       "response_token": {
                         "price": 0.000125
@@ -12131,13 +12131,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00001
+                        "price": 1e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000001
+                        "price": 1e-6
                       },
                       "response_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "additional_units": {
                         "web_search": {
@@ -12158,13 +12158,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00001
+                        "price": 1e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000001
+                        "price": 1e-6
                       },
                       "response_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "additional_units": {
                         "web_search": {
@@ -12189,10 +12189,10 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000022
+                        "price": 2.2e-6
                       },
                       "response_token": {
                         "price": 0.0001375
@@ -12216,13 +12216,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000011
+                        "price": 1.1e-6
                       },
                       "response_token": {
-                        "price": 0.00006875
+                        "price": 6.875e-5
                       },
                       "additional_units": {
                         "web_search": {
@@ -12243,13 +12243,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000011
+                        "price": 1.1e-6
                       },
                       "response_token": {
-                        "price": 0.00006875
+                        "price": 6.875e-5
                       },
                       "additional_units": {
                         "web_search": {
@@ -12282,7 +12282,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "web_search": {
@@ -12304,7 +12304,7 @@
           "price": 0.0003125
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         }
       }
     },
@@ -12325,7 +12325,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000625
@@ -12381,7 +12381,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0003125
@@ -12407,7 +12407,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000625
@@ -12437,7 +12437,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0003125
@@ -12463,7 +12463,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000625
@@ -12527,7 +12527,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0006875
@@ -12583,7 +12583,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.00034375
@@ -12609,7 +12609,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0006875
@@ -12639,7 +12639,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.00034375
@@ -12665,7 +12665,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0006875
@@ -12734,7 +12734,7 @@
           "price": 0.000625
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "web_search": {
@@ -12756,7 +12756,7 @@
           "price": 0.0003125
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         }
       }
     },
@@ -12777,7 +12777,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000625
@@ -12833,7 +12833,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0003125
@@ -12859,7 +12859,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000625
@@ -12889,7 +12889,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0003125
@@ -12915,7 +12915,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000625
@@ -12979,7 +12979,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0006875
@@ -13035,7 +13035,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.00034375
@@ -13061,7 +13061,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0006875
@@ -13091,7 +13091,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.00034375
@@ -13117,7 +13117,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0006875
@@ -13186,7 +13186,7 @@
           "price": 0.0003125
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         },
         "additional_units": {
           "web_search": {
@@ -13208,7 +13208,7 @@
           "price": 0.00015625
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 1.25e-5
         }
       }
     },
@@ -13229,7 +13229,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0003125
@@ -13255,7 +13255,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000625
@@ -13285,7 +13285,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000125
+                        "price": 1.25e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.00015625
@@ -13311,7 +13311,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0003125
@@ -13341,7 +13341,7 @@
                         "price": 0.000125
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000125
+                        "price": 1.25e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.00015625
@@ -13367,7 +13367,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0003125
@@ -13397,7 +13397,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000625
@@ -13431,7 +13431,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.00034375
@@ -13457,7 +13457,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0006875
@@ -13487,7 +13487,7 @@
                         "price": 0.0001375
                       },
                       "cache_read_input_token": {
-                        "price": 0.00001375
+                        "price": 1.375e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000171875
@@ -13513,7 +13513,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.00034375
@@ -13543,7 +13543,7 @@
                         "price": 0.0001375
                       },
                       "cache_read_input_token": {
-                        "price": 0.00001375
+                        "price": 1.375e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000171875
@@ -13569,7 +13569,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.00034375
@@ -13599,7 +13599,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0006875
@@ -13638,7 +13638,7 @@
           "price": 0.000125
         },
         "cache_read_input_token": {
-          "price": 0.00001
+          "price": 1e-5
         },
         "additional_units": {
           "web_search": {
@@ -13651,16 +13651,16 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "response_token": {
           "price": 0.0003
         },
         "cache_write_input_token": {
-          "price": 0.0000625
+          "price": 6.25e-5
         },
         "cache_read_input_token": {
-          "price": 0.000005
+          "price": 5e-6
         }
       }
     },
@@ -13681,7 +13681,7 @@
                         "price": 0.0001
                       },
                       "cache_read_input_token": {
-                        "price": 0.00001
+                        "price": 1e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000125
@@ -13707,7 +13707,7 @@
                         "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.00025
@@ -13734,13 +13734,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000005
+                        "price": 5e-6
                       },
                       "cache_write_input_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "response_token": {
                         "price": 0.0003
@@ -13763,7 +13763,7 @@
                         "price": 0.0001
                       },
                       "cache_read_input_token": {
-                        "price": 0.00001
+                        "price": 1e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000125
@@ -13790,13 +13790,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.000005
+                        "price": 5e-6
                       },
                       "cache_write_input_token": {
-                        "price": 0.0000625
+                        "price": 6.25e-5
                       },
                       "response_token": {
                         "price": 0.0003
@@ -13819,7 +13819,7 @@
                         "price": 0.0001
                       },
                       "cache_read_input_token": {
-                        "price": 0.00001
+                        "price": 1e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000125
@@ -13849,7 +13849,7 @@
                         "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 2e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.00025
@@ -13883,7 +13883,7 @@
                         "price": 0.00011
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0001375
@@ -13909,7 +13909,7 @@
                         "price": 0.00022
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000275
@@ -13936,13 +13936,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000055
+                        "price": 5.5e-6
                       },
                       "cache_write_input_token": {
-                        "price": 0.00006875
+                        "price": 6.875e-5
                       },
                       "response_token": {
                         "price": 0.00033
@@ -13965,7 +13965,7 @@
                         "price": 0.00011
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0001375
@@ -13992,13 +13992,13 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000055
+                        "price": 5.5e-6
                       },
                       "cache_write_input_token": {
-                        "price": 0.00006875
+                        "price": 6.875e-5
                       },
                       "response_token": {
                         "price": 0.00033
@@ -14021,7 +14021,7 @@
                         "price": 0.00011
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 1.1e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.0001375
@@ -14051,7 +14051,7 @@
                         "price": 0.00022
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 2.2e-5
                       },
                       "cache_write_input_token": {
                         "price": 0.000275
@@ -14090,7 +14090,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "web_search": {
@@ -14109,7 +14109,7 @@
           "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         }
       }
     },
@@ -14130,7 +14130,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.003
@@ -14180,7 +14180,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -14203,7 +14203,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.00225
@@ -14230,7 +14230,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -14253,7 +14253,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.00225
@@ -14311,7 +14311,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.0033
@@ -14361,7 +14361,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -14384,7 +14384,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -14411,7 +14411,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -14434,7 +14434,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -14497,7 +14497,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "web_search": {
@@ -14516,7 +14516,7 @@
           "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 2.5e-5
         }
       }
     },
@@ -14537,7 +14537,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.003
@@ -14587,7 +14587,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -14610,7 +14610,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.00225
@@ -14637,7 +14637,7 @@
                         "price": 0.00025
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 2.5e-5
                       },
                       "response_token": {
                         "price": 0.0015
@@ -14660,7 +14660,7 @@
                         "price": 0.0005
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 5e-5
                       },
                       "response_token": {
                         "price": 0.00225
@@ -14718,7 +14718,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.0033
@@ -14768,7 +14768,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -14791,7 +14791,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -14818,7 +14818,7 @@
                         "price": 0.000275
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 2.75e-5
                       },
                       "response_token": {
                         "price": 0.00165
@@ -14841,7 +14841,7 @@
                         "price": 0.00055
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 5.5e-5
                       },
                       "response_token": {
                         "price": 0.002475
@@ -15378,7 +15378,7 @@
           "price": 0
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 5e-5
         },
         "additional_units": {
           "web_search": {
@@ -15397,7 +15397,1815 @@
           "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 2.5e-5
+        }
+      }
+    }
+  },
+  "gpt-5.6-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 5e-5
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.0015
+        },
+        "cache_write_input_token": {
+          "price": 0.0003125
+        },
+        "cache_read_input_token": {
+          "price": 2.5e-5
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "response_token": {
+                        "price": 0.003
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.001
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0001
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00125
+                      },
+                      "response_token": {
+                        "price": 0.0045
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "response_token": {
+                        "price": 0.0015
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "response_token": {
+                        "price": 0.00225
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "response_token": {
+                        "price": 0.0015
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "response_token": {
+                        "price": 0.00225
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.001
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0001
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00125
+                      },
+                      "response_token": {
+                        "price": 0.006
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us,eu,au,ca,jp,in,sg,kr,gb,ae": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "response_token": {
+                        "price": 0.0033
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0011
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00011
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.001375
+                      },
+                      "response_token": {
+                        "price": 0.00495
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00034375
+                      },
+                      "response_token": {
+                        "price": 0.00165
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "response_token": {
+                        "price": 0.002475
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00034375
+                      },
+                      "response_token": {
+                        "price": 0.00165
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "response_token": {
+                        "price": 0.002475
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0011
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00011
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.001375
+                      },
+                      "response_token": {
+                        "price": 0.0066
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-luna-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.0006
+        },
+        "cache_write_input_token": {
+          "price": 0.000125
+        },
+        "cache_read_input_token": {
+          "price": 1e-5
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 5e-5
+        },
+        "response_token": {
+          "price": 0.0003
+        },
+        "cache_write_input_token": {
+          "price": 6.25e-5
+        },
+        "cache_read_input_token": {
+          "price": 5e-6
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0001
+                      },
+                      "cache_read_input_token": {
+                        "price": 1e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000125
+                      },
+                      "response_token": {
+                        "price": 0.0006
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "cache_read_input_token": {
+                        "price": 2e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00025
+                      },
+                      "response_token": {
+                        "price": 0.0009
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 5e-5
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-6
+                      },
+                      "cache_write_input_token": {
+                        "price": 6.25e-5
+                      },
+                      "response_token": {
+                        "price": 0.0003
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0001
+                      },
+                      "cache_read_input_token": {
+                        "price": 1e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000125
+                      },
+                      "response_token": {
+                        "price": 0.00045
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 5e-5
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-6
+                      },
+                      "cache_write_input_token": {
+                        "price": 6.25e-5
+                      },
+                      "response_token": {
+                        "price": 0.0003
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0001
+                      },
+                      "cache_read_input_token": {
+                        "price": 1e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000125
+                      },
+                      "response_token": {
+                        "price": 0.00045
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "cache_read_input_token": {
+                        "price": 2e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00025
+                      },
+                      "response_token": {
+                        "price": 0.0012
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us,eu,au,ca,jp,in,sg,kr,gb,ae": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00011
+                      },
+                      "cache_read_input_token": {
+                        "price": 1.1e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0001375
+                      },
+                      "response_token": {
+                        "price": 0.00066
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00022
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.2e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000275
+                      },
+                      "response_token": {
+                        "price": 0.00099
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 5.5e-5
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-6
+                      },
+                      "cache_write_input_token": {
+                        "price": 6.875e-5
+                      },
+                      "response_token": {
+                        "price": 0.00033
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00011
+                      },
+                      "cache_read_input_token": {
+                        "price": 1.1e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0001375
+                      },
+                      "response_token": {
+                        "price": 0.000495
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 5.5e-5
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-6
+                      },
+                      "cache_write_input_token": {
+                        "price": 6.875e-5
+                      },
+                      "response_token": {
+                        "price": 0.00033
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00011
+                      },
+                      "cache_read_input_token": {
+                        "price": 1.1e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0001375
+                      },
+                      "response_token": {
+                        "price": 0.000495
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00022
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.2e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000275
+                      },
+                      "response_token": {
+                        "price": 0.00132
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-sol-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 5e-5
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.0015
+        },
+        "cache_write_input_token": {
+          "price": 0.0003125
+        },
+        "cache_read_input_token": {
+          "price": 2.5e-5
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "response_token": {
+                        "price": 0.003
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.001
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0001
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00125
+                      },
+                      "response_token": {
+                        "price": 0.0045
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "response_token": {
+                        "price": 0.0015
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "response_token": {
+                        "price": 0.00225
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "response_token": {
+                        "price": 0.0015
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "response_token": {
+                        "price": 0.00225
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.001
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0001
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00125
+                      },
+                      "response_token": {
+                        "price": 0.006
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us,eu,au,ca,jp,in,sg,kr,gb,ae": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "response_token": {
+                        "price": 0.0033
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0011
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00011
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.001375
+                      },
+                      "response_token": {
+                        "price": 0.00495
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00034375
+                      },
+                      "response_token": {
+                        "price": 0.00165
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "response_token": {
+                        "price": 0.002475
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00034375
+                      },
+                      "response_token": {
+                        "price": 0.00165
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "response_token": {
+                        "price": 0.002475
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0011
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00011
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.001375
+                      },
+                      "response_token": {
+                        "price": 0.0066
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-terra-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00025
+        },
+        "response_token": {
+          "price": 0.0015
+        },
+        "cache_write_input_token": {
+          "price": 0.0003125
+        },
+        "cache_read_input_token": {
+          "price": 2.5e-5
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.00075
+        },
+        "cache_write_input_token": {
+          "price": 0.00015625
+        },
+        "cache_read_input_token": {
+          "price": 1.25e-5
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "response_token": {
+                        "price": 0.0015
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "response_token": {
+                        "price": 0.00225
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000125
+                      },
+                      "cache_read_input_token": {
+                        "price": 1.25e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00015625
+                      },
+                      "response_token": {
+                        "price": 0.00075
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "response_token": {
+                        "price": 0.001125
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000125
+                      },
+                      "cache_read_input_token": {
+                        "price": 1.25e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00015625
+                      },
+                      "response_token": {
+                        "price": 0.00075
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00025
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0003125
+                      },
+                      "response_token": {
+                        "price": 0.001125
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "cache_read_input_token": {
+                        "price": 5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "response_token": {
+                        "price": 0.003
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us,eu,au,ca,jp,in,sg,kr,gb,ae": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00034375
+                      },
+                      "response_token": {
+                        "price": 0.00165
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "response_token": {
+                        "price": 0.002475
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0001375
+                      },
+                      "cache_read_input_token": {
+                        "price": 1.375e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000171875
+                      },
+                      "response_token": {
+                        "price": 0.000825
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00034375
+                      },
+                      "response_token": {
+                        "price": 0.0012375
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0001375
+                      },
+                      "cache_read_input_token": {
+                        "price": 1.375e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000171875
+                      },
+                      "response_token": {
+                        "price": 0.000825
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000275
+                      },
+                      "cache_read_input_token": {
+                        "price": 2.75e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00034375
+                      },
+                      "response_token": {
+                        "price": 0.0012375
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "cache_read_input_token": {
+                        "price": 5.5e-5
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "response_token": {
+                        "price": 0.0033
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Adds pricing and model config for:
- gpt-5.6-2026-07-09
- gpt-5.6-luna-2026-07-09
- gpt-5.6-sol-2026-07-09
- gpt-5.6-terra-2026-07-09

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- [ ] New model pricing
- [ ] Update existing pricing
- [ ] New model configuration
- [ ] Bug fix

## Source Verification

**Source Link:** [Add link here]

> [!IMPORTANT]
> Please include a link to the official pricing page from the provider. Simple "I heard it from somewhere" or screenshot sources are not accepted.

## Checklist

- [ ] I have validated the JSON using `jq` or an online validator
- [ ] I have verified that prices are in **cents per token** (not dollars)
- [ ] I have included the source link above
- [ ] I have signed the CLA (if first-time contributor)

## Related Issue

Fixes # (issue)
