### PR TITLE
Add pricing & general schema for new Novita AI models

### DIFF
--- a/general/novita-ai.json
+++ b/general/novita-ai.json
@@ -137,6 +137,12 @@
       "primary": "chat"
     }
   },
+  "moonshotai/kimi-k2.7-code": {
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "video", "tools"]
+    }
+  },
   "moonshotai/kimi-k3": {
     "type": {
       "primary": "chat",
@@ -148,9 +154,27 @@
       "primary": "chat"
     }
   },
+  "minimax/minimax-m3": {
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "video", "tools"]
+    }
+  },
+  "tencent/hy3": {
+    "type": {
+      "primary": "chat",
+      "supported": ["tools"]
+    }
+  },
   "zai-org/glm-4.7": {
     "type": {
       "primary": "chat"
+    }
+  },
+  "zai-org/glm-5.2": {
+    "type": {
+      "primary": "chat",
+      "supported": ["tools"]
     }
   },
   "xiaomi/mimo-v2-flash": {

--- a/pricing/novita-ai.json
+++ b/pricing/novita-ai.json
@@ -215,10 +215,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000164
+          "price": 0.00016
         },
         "response_token": {
-          "price": 0.000338
+          "price": 0.00032
         },
         "cache_read_input_token": {
           "price": 0.0000135
@@ -391,6 +391,21 @@
       }
     }
   },
+  "minimax/minimax-m3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
   "minimaxai/minimax-m1-80k": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -453,6 +468,21 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
+        }
+      }
+    }
+  },
+  "moonshotai/kimi-k2.7-code": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000095
+        },
+        "response_token": {
+          "price": 0.0004
+        },
+        "cache_read_input_token": {
+          "price": 0.000019
         }
       }
     }
@@ -748,6 +778,21 @@
       }
     }
   },
+  "tencent/hy3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000014
+        },
+        "response_token": {
+          "price": 0.000058
+        },
+        "cache_read_input_token": {
+          "price": 0.0000035
+        }
+      }
+    }
+  },
   "xiaomimimo/mimo-v2-flash": {
     "pricing_config": {
       "pay_as_you_go": {
@@ -786,6 +831,21 @@
         },
         "cache_read_input_token": {
           "price": 0.000011
+        }
+      }
+    }
+  },
+  "zai-org/glm-5.2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.000026
         }
       }
     }


### PR DESCRIPTION
## Summary

- Added pricing and general schema for new models: `moonshotai/kimi-k2.7-code`, `minimax/minimax-m3`, `tencent/hy3`, `zai-org/glm-5.2`
- Updated `deepseek-v4-pro` pricing (minor rounding correction for request/response token prices)

## Caveat

**minimax-m3 tiered pricing:** Novita AI lists tiered pricing for minimax-m3 (price drops at higher volume tiers). The prices used here reflect the base tier (Tier 1). If tiered pricing support is added later, this entry will need updating to account for volume discounts.

## Test plan

- [ ] Validate JSON is well-formed
- [x] Verify pricing values against Novita AI docs