### PR TITLE
[openai] Update GPT-5.6 Terra and Luna pricing

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -13177,16 +13177,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 0.0003125
+          "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -13198,436 +13198,6 @@
         }
       },
       "batch_config": {
-        "request_token": {
-          "price": 0.000125
-        },
-        "response_token": {
-          "price": 0.00075
-        },
-        "cache_write_input_token": {
-          "price": 0.00015625
-        },
-        "cache_read_input_token": {
-          "price": 0.0000125
-        }
-      }
-    },
-    "custom_pricing": {
-      "context_tier_map": {
-        "0": "lte-272k",
-        "272000": "gt-272k"
-      },
-      "regions": {
-        "default": {
-          "execution_modes": {
-            "standard": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00025
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000025
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0003125
-                      },
-                      "response_token": {
-                        "price": 0.0015
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.0005
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.00005
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.000625
-                      },
-                      "response_token": {
-                        "price": 0.00225
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "batch": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000125
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000125
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00015625
-                      },
-                      "response_token": {
-                        "price": 0.00075
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00025
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000025
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0003125
-                      },
-                      "response_token": {
-                        "price": 0.001125
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000125
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000125
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00015625
-                      },
-                      "response_token": {
-                        "price": 0.00075
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00025
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000025
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0003125
-                      },
-                      "response_token": {
-                        "price": 0.001125
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.0005
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.00005
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.000625
-                      },
-                      "response_token": {
-                        "price": 0.003
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "us,eu,au,ca,jp,in,sg,kr,gb,ae": {
-          "execution_modes": {
-            "standard": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000275
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000275
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00034375
-                      },
-                      "response_token": {
-                        "price": 0.00165
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00055
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000055
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0006875
-                      },
-                      "response_token": {
-                        "price": 0.002475
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "batch": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.0001375
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.00001375
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.000171875
-                      },
-                      "response_token": {
-                        "price": 0.000825
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000275
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000275
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00034375
-                      },
-                      "response_token": {
-                        "price": 0.0012375
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.0001375
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.00001375
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.000171875
-                      },
-                      "response_token": {
-                        "price": 0.000825
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000275
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000275
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00034375
-                      },
-                      "response_token": {
-                        "price": 0.0012375
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00055
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000055
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0006875
-                      },
-                      "response_token": {
-                        "price": 0.0033
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "gpt-5.6-luna": {
-    "pricing_config": {
-      "pay_as_you_go": {
         "request_token": {
           "price": 0.0001
         },
@@ -13639,28 +13209,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_write_input_token": {
-          "price": 0.0000625
-        },
-        "cache_read_input_token": {
-          "price": 0.000005
         }
       }
     },
@@ -13673,6 +13221,62 @@
         "default": {
           "execution_modes": {
             "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00002
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00025
+                      },
+                      "response_token": {
+                        "price": 0.0012
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0004
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00004
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0005
+                      },
+                      "response_token": {
+                        "price": 0.0018
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
               "context_tiers": {
                 "lte-272k": {
                   "pricing_config": {
@@ -13728,78 +13332,22 @@
                 }
               }
             },
-            "batch": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00005
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000005
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0000625
-                      },
-                      "response_token": {
-                        "price": 0.0003
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.0001
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.00001
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.000125
-                      },
-                      "response_token": {
-                        "price": 0.00045
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
             "flex": {
               "context_tiers": {
                 "lte-272k": {
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00005
+                        "price": 0.0001
                       },
                       "cache_read_input_token": {
-                        "price": 0.000005
+                        "price": 0.00001
                       },
                       "cache_write_input_token": {
-                        "price": 0.0000625
+                        "price": 0.000125
                       },
                       "response_token": {
-                        "price": 0.0003
+                        "price": 0.0006
                       },
                       "additional_units": {
                         "web_search": {
@@ -13816,16 +13364,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0001
+                        "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.00001
+                        "price": 0.00002
                       },
                       "cache_write_input_token": {
-                        "price": 0.000125
+                        "price": 0.00025
                       },
                       "response_token": {
-                        "price": 0.00045
+                        "price": 0.0009
                       },
                       "additional_units": {
                         "web_search": {
@@ -13846,16 +13394,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0002
+                        "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 0.00004
                       },
                       "cache_write_input_token": {
-                        "price": 0.00025
+                        "price": 0.0005
                       },
                       "response_token": {
-                        "price": 0.0012
+                        "price": 0.0024
                       },
                       "additional_units": {
                         "web_search": {
@@ -13875,6 +13423,62 @@
         "us,eu,au,ca,jp,in,sg,kr,gb,ae": {
           "execution_modes": {
             "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00022
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000022
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000275
+                      },
+                      "response_token": {
+                        "price": 0.00132
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00044
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000044
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00055
+                      },
+                      "response_token": {
+                        "price": 0.00198
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
               "context_tiers": {
                 "lte-272k": {
                   "pricing_config": {
@@ -13930,78 +13534,22 @@
                 }
               }
             },
-            "batch": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000055
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000055
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00006875
-                      },
-                      "response_token": {
-                        "price": 0.00033
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00011
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000011
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0001375
-                      },
-                      "response_token": {
-                        "price": 0.000495
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
             "flex": {
               "context_tiers": {
                 "lte-272k": {
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000055
+                        "price": 0.00011
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000055
+                        "price": 0.000011
                       },
                       "cache_write_input_token": {
-                        "price": 0.00006875
+                        "price": 0.0001375
                       },
                       "response_token": {
-                        "price": 0.00033
+                        "price": 0.00066
                       },
                       "additional_units": {
                         "web_search": {
@@ -14018,16 +13566,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00011
+                        "price": 0.00022
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 0.000022
                       },
                       "cache_write_input_token": {
-                        "price": 0.0001375
+                        "price": 0.000275
                       },
                       "response_token": {
-                        "price": 0.000495
+                        "price": 0.00099
                       },
                       "additional_units": {
                         "web_search": {
@@ -14048,16 +13596,468 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00022
+                        "price": 0.00044
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 0.000044
                       },
                       "cache_write_input_token": {
-                        "price": 0.000275
+                        "price": 0.00055
                       },
                       "response_token": {
-                        "price": 0.00132
+                        "price": 0.00264
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-luna": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_write_input_token": {
+          "price": 0.000025
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_write_input_token": {
+          "price": 0.0000125
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00002
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000002
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000025
+                      },
+                      "response_token": {
+                        "price": 0.00012
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00004
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000004
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00005
+                      },
+                      "response_token": {
+                        "price": 0.00018
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00001
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000001
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000125
+                      },
+                      "response_token": {
+                        "price": 0.00006
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00002
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000002
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000025
+                      },
+                      "response_token": {
+                        "price": 0.00009
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00001
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000001
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000125
+                      },
+                      "response_token": {
+                        "price": 0.00006
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00002
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000002
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000025
+                      },
+                      "response_token": {
+                        "price": 0.00009
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00004
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000004
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00005
+                      },
+                      "response_token": {
+                        "price": 0.00024
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us,eu,au,ca,jp,in,sg,kr,gb,ae": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000022
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000022
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.000132
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000044
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000044
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.000198
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000011
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000011
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00001375
+                      },
+                      "response_token": {
+                        "price": 0.000066
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000022
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000022
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.000099
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000011
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000011
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00001375
+                      },
+                      "response_token": {
+                        "price": 0.000066
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000022
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000022
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.000099
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000044
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000044
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.000264
                       },
                       "additional_units": {
                         "web_search": {
@@ -14985,16 +14985,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0012
         },
         "cache_write_input_token": {
-          "price": 0.0003125
+          "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00002
         },
         "additional_units": {
           "web_search": {
@@ -15006,436 +15006,6 @@
         }
       },
       "batch_config": {
-        "request_token": {
-          "price": 0.000125
-        },
-        "response_token": {
-          "price": 0.00075
-        },
-        "cache_write_input_token": {
-          "price": 0.00015625
-        },
-        "cache_read_input_token": {
-          "price": 0.0000125
-        }
-      }
-    },
-    "custom_pricing": {
-      "context_tier_map": {
-        "0": "lte-272k",
-        "272000": "gt-272k"
-      },
-      "regions": {
-        "default": {
-          "execution_modes": {
-            "standard": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00025
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000025
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0003125
-                      },
-                      "response_token": {
-                        "price": 0.0015
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.0005
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.00005
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.000625
-                      },
-                      "response_token": {
-                        "price": 0.00225
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "batch": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000125
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000125
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00015625
-                      },
-                      "response_token": {
-                        "price": 0.00075
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00025
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000025
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0003125
-                      },
-                      "response_token": {
-                        "price": 0.001125
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000125
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000125
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00015625
-                      },
-                      "response_token": {
-                        "price": 0.00075
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00025
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000025
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0003125
-                      },
-                      "response_token": {
-                        "price": 0.001125
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.0005
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.00005
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.000625
-                      },
-                      "response_token": {
-                        "price": 0.003
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "us,eu,au,ca,jp,in,sg,kr,gb,ae": {
-          "execution_modes": {
-            "standard": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000275
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000275
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00034375
-                      },
-                      "response_token": {
-                        "price": 0.00165
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00055
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000055
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0006875
-                      },
-                      "response_token": {
-                        "price": 0.002475
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "batch": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.0001375
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.00001375
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.000171875
-                      },
-                      "response_token": {
-                        "price": 0.000825
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000275
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000275
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00034375
-                      },
-                      "response_token": {
-                        "price": 0.0012375
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "flex": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.0001375
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.00001375
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.000171875
-                      },
-                      "response_token": {
-                        "price": 0.000825
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000275
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000275
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00034375
-                      },
-                      "response_token": {
-                        "price": 0.0012375
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "priority": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00055
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000055
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0006875
-                      },
-                      "response_token": {
-                        "price": 0.0033
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "gpt-5.6-luna-2026-07-09": {
-    "pricing_config": {
-      "pay_as_you_go": {
         "request_token": {
           "price": 0.0001
         },
@@ -15447,28 +15017,6 @@
         },
         "cache_read_input_token": {
           "price": 0.00001
-        },
-        "additional_units": {
-          "web_search": {
-            "price": 1
-          },
-          "file_search": {
-            "price": 0.25
-          }
-        }
-      },
-      "batch_config": {
-        "request_token": {
-          "price": 0.00005
-        },
-        "response_token": {
-          "price": 0.0003
-        },
-        "cache_write_input_token": {
-          "price": 0.0000625
-        },
-        "cache_read_input_token": {
-          "price": 0.000005
         }
       }
     },
@@ -15481,6 +15029,62 @@
         "default": {
           "execution_modes": {
             "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00002
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00025
+                      },
+                      "response_token": {
+                        "price": 0.0012
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0004
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00004
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0005
+                      },
+                      "response_token": {
+                        "price": 0.0018
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
               "context_tiers": {
                 "lte-272k": {
                   "pricing_config": {
@@ -15536,78 +15140,22 @@
                 }
               }
             },
-            "batch": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00005
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000005
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0000625
-                      },
-                      "response_token": {
-                        "price": 0.0003
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.0001
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.00001
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.000125
-                      },
-                      "response_token": {
-                        "price": 0.00045
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
             "flex": {
               "context_tiers": {
                 "lte-272k": {
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00005
+                        "price": 0.0001
                       },
                       "cache_read_input_token": {
-                        "price": 0.000005
+                        "price": 0.00001
                       },
                       "cache_write_input_token": {
-                        "price": 0.0000625
+                        "price": 0.000125
                       },
                       "response_token": {
-                        "price": 0.0003
+                        "price": 0.0006
                       },
                       "additional_units": {
                         "web_search": {
@@ -15624,16 +15172,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0001
+                        "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.00001
+                        "price": 0.00002
                       },
                       "cache_write_input_token": {
-                        "price": 0.000125
+                        "price": 0.00025
                       },
                       "response_token": {
-                        "price": 0.00045
+                        "price": 0.0009
                       },
                       "additional_units": {
                         "web_search": {
@@ -15654,16 +15202,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0002
+                        "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00002
+                        "price": 0.00004
                       },
                       "cache_write_input_token": {
-                        "price": 0.00025
+                        "price": 0.0005
                       },
                       "response_token": {
-                        "price": 0.0012
+                        "price": 0.0024
                       },
                       "additional_units": {
                         "web_search": {
@@ -15683,6 +15231,62 @@
         "us,eu,au,ca,jp,in,sg,kr,gb,ae": {
           "execution_modes": {
             "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00022
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000022
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000275
+                      },
+                      "response_token": {
+                        "price": 0.00132
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00044
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000044
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00055
+                      },
+                      "response_token": {
+                        "price": 0.00198
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
               "context_tiers": {
                 "lte-272k": {
                   "pricing_config": {
@@ -15738,78 +15342,22 @@
                 }
               }
             },
-            "batch": {
-              "context_tiers": {
-                "lte-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.000055
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.0000055
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.00006875
-                      },
-                      "response_token": {
-                        "price": 0.00033
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                },
-                "gt-272k": {
-                  "pricing_config": {
-                    "pay_as_you_go": {
-                      "request_token": {
-                        "price": 0.00011
-                      },
-                      "cache_read_input_token": {
-                        "price": 0.000011
-                      },
-                      "cache_write_input_token": {
-                        "price": 0.0001375
-                      },
-                      "response_token": {
-                        "price": 0.000495
-                      },
-                      "additional_units": {
-                        "web_search": {
-                          "price": 1
-                        },
-                        "file_search": {
-                          "price": 0.25
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
             "flex": {
               "context_tiers": {
                 "lte-272k": {
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000055
+                        "price": 0.00011
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000055
+                        "price": 0.000011
                       },
                       "cache_write_input_token": {
-                        "price": 0.00006875
+                        "price": 0.0001375
                       },
                       "response_token": {
-                        "price": 0.00033
+                        "price": 0.00066
                       },
                       "additional_units": {
                         "web_search": {
@@ -15826,16 +15374,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00011
+                        "price": 0.00022
                       },
                       "cache_read_input_token": {
-                        "price": 0.000011
+                        "price": 0.000022
                       },
                       "cache_write_input_token": {
-                        "price": 0.0001375
+                        "price": 0.000275
                       },
                       "response_token": {
-                        "price": 0.000495
+                        "price": 0.00099
                       },
                       "additional_units": {
                         "web_search": {
@@ -15856,16 +15404,468 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00022
+                        "price": 0.00044
                       },
                       "cache_read_input_token": {
-                        "price": 0.000022
+                        "price": 0.000044
                       },
                       "cache_write_input_token": {
-                        "price": 0.000275
+                        "price": 0.00055
                       },
                       "response_token": {
-                        "price": 0.00132
+                        "price": 0.00264
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "gpt-5.6-luna-2026-07-09": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_write_input_token": {
+          "price": 0.000025
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.00001
+        },
+        "response_token": {
+          "price": 0.00006
+        },
+        "cache_write_input_token": {
+          "price": 0.0000125
+        },
+        "cache_read_input_token": {
+          "price": 0.000001
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00002
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000002
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000025
+                      },
+                      "response_token": {
+                        "price": 0.00012
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00004
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000004
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00005
+                      },
+                      "response_token": {
+                        "price": 0.00018
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00001
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000001
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000125
+                      },
+                      "response_token": {
+                        "price": 0.00006
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00002
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000002
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000025
+                      },
+                      "response_token": {
+                        "price": 0.00009
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00001
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000001
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000125
+                      },
+                      "response_token": {
+                        "price": 0.00006
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00002
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000002
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000025
+                      },
+                      "response_token": {
+                        "price": 0.00009
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00004
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000004
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00005
+                      },
+                      "response_token": {
+                        "price": 0.00024
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "us,eu,au,ca,jp,in,sg,kr,gb,ae": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000022
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000022
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.000132
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000044
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000044
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.000198
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "batch": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000011
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000011
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00001375
+                      },
+                      "response_token": {
+                        "price": 0.000066
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000022
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000022
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.000099
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flex": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000011
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000011
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00001375
+                      },
+                      "response_token": {
+                        "price": 0.000066
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000022
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000022
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000275
+                      },
+                      "response_token": {
+                        "price": 0.000099
+                      },
+                      "additional_units": {
+                        "web_search": {
+                          "price": 1
+                        },
+                        "file_search": {
+                          "price": 0.25
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "priority": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000044
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000044
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000055
+                      },
+                      "response_token": {
+                        "price": 0.000264
                       },
                       "additional_units": {
                         "web_search": {


### PR DESCRIPTION
## Summary

- update GPT-5.6 Terra pricing after OpenAI’s 20% reduction
- update GPT-5.6 Luna pricing after OpenAI’s 80% reduction
- apply the new rates to aliases and dated snapshots across standard, long-context, Batch, Flex, Fast/priority, and regional pricing

## Sources

- https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/
- https://developers.openai.com/api/docs/pricing

## Validation

- `npx eslint . --ext .json --quiet`
- `npx prettier --check pricing/openai.json`
- validated every file in `pricing/` and `general/` with `jq empty`
- verified the semantic diff only changes the four intended model entries and preserves additional-unit pricing