### PR TITLE
[mistral-ai, azure-ai] Add OCR model pricing and config

### DIFF
--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -6179,5 +6179,23 @@
       "supported": ["tools", "image", "chat"],
       "unsupported": ["messages"]
     }
+  },
+  "mistral-ocr-4-0": {
+    "type": {
+      "primary": "ocr"
+    },
+    "disablePlayground": true
+  },
+  "mistral-document-ai-2505": {
+    "type": {
+      "primary": "ocr"
+    },
+    "disablePlayground": true
+  },
+  "mistral-document-ai-2512": {
+    "type": {
+      "primary": "ocr"
+    },
+    "disablePlayground": true
   }
 }

--- a/general/mistral-ai.json
+++ b/general/mistral-ai.json
@@ -323,5 +323,23 @@
       "primary": "chat",
       "supported": ["tools", "image"]
     }
+  },
+  "mistral-ocr-latest": {
+    "type": {
+      "primary": "ocr"
+    },
+    "disablePlayground": true
+  },
+  "mistral-ocr-4-0": {
+    "type": {
+      "primary": "ocr"
+    },
+    "disablePlayground": true
+  },
+  "mistral-ocr-4": {
+    "type": {
+      "primary": "ocr"
+    },
+    "disablePlayground": true
   }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -497,7 +497,7 @@ components:
       properties:
         primary:
           type: string
-          enum: [chat, text, embedding, image, audio, moderation]
+          enum: [chat, text, embedding, image, audio, moderation, rerank, ocr]
           description: Primary model type
         supported:
           type: array

--- a/pricing/azure-ai.json
+++ b/pricing/azure-ai.json
@@ -5335,5 +5335,41 @@
         }
       }
     }
+  },
+  "mistral-ocr-4-0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-document-ai-2505": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-document-ai-2512": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.3
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
   }
 }

--- a/pricing/mistral-ai.json
+++ b/pricing/mistral-ai.json
@@ -671,5 +671,41 @@
         }
       }
     }
+  },
+  "mistral-ocr-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-ocr-4-0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "mistral-ocr-4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.4
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Add pricing and general config for Mistral AI OCR models (`mistral-ocr-latest`, `mistral-ocr-4-0`, `mistral-ocr-4`)
- Add pricing and general config for Azure AI Foundry OCR models (`mistral-ocr-4-0`, `mistral-document-ai-2505`, `mistral-document-ai-2512`)
- All models typed as `"ocr"` with `disablePlayground: true`

## Pricing

| Provider | Model | Price (cents/page) | $/1K pages |
|----------|-------|-------------------|------------|
| Mistral AI | `mistral-ocr-latest` | 0.4 | $4 |
| Mistral AI | `mistral-ocr-4-0` | 0.4 | $4 |
| Mistral AI | `mistral-ocr-4` | 0.4 | $4 |
| Azure AI | `mistral-ocr-4-0` | 0.4 | $4 |
| Azure AI | `mistral-document-ai-2505` | 0.3 | $3 |
| Azure AI | `mistral-document-ai-2512` | 0.3 | $3 |

## Pricing Sources

- Mistral AI: https://docs.mistral.ai/models/model-selection-guide
- Azure AI Foundry: https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral-ai/
- Azure Blog (Document AI 2505): https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/deepening-our-partnership-with-mistral-ai-on-azure-ai-foundry/4434656

## Notes

- OCR pricing is page-based, not token-based. `request_token.price` represents cost per page (in cents), following the same pattern as rerank models using `request_token` for per-unit pricing.
- `response_token.price` is 0 for all OCR models (no output token cost).
- Region-based tiers (Data Zone vs Global) and annotated vs non-annotated pricing tiers are not represented — using Global Standard base prices.