### PR TITLE
[saladcloud] Add AI Gateway model configuration

### DIFF
--- a/general/saladcloud.json
+++ b/general/saladcloud.json
@@ -1,0 +1,19 @@
+{
+  "name": "saladcloud",
+  "description": "OpenAI-compatible AI Gateway from SaladCloud.",
+  "default": {
+    "params": [
+      { "key": "max_tokens", "defaultValue": 256, "minValue": 1, "maxValue": 262144 },
+      { "key": "temperature", "defaultValue": 0.7, "minValue": 0, "maxValue": 2 },
+      { "key": "top_p", "defaultValue": 1, "minValue": 0, "maxValue": 1 },
+      { "key": "stop", "defaultValue": null, "type": "array-of-strings", "skipValues": [null, []] },
+      { "key": "stream", "defaultValue": true, "type": "boolean" }
+    ],
+    "messages": { "options": ["system", "user", "assistant"] },
+    "type": { "primary": "chat", "supported": ["tools", "image"] }
+  },
+  "qwen3.6-35b-a3b": {
+    "params": [{ "key": "max_tokens", "maxValue": 262144 }],
+    "type": { "primary": "chat", "supported": ["tools", "image"] }
+  }
+}

--- a/pricing/saladcloud.json
+++ b/pricing/saladcloud.json
@@ -5,6 +5,16 @@
         "request_token": { "price": 0 },
         "response_token": { "price": 0 }
       },
+      "calculate": {
+        "request": {
+          "operation": "multiply",
+          "operands": [{ "value": "input_tokens" }, { "value": "rates.request_token" }]
+        },
+        "response": {
+          "operation": "multiply",
+          "operands": [{ "value": "output_tokens" }, { "value": "rates.response_token" }]
+        }
+      },
       "currency": "USD"
     }
   },

--- a/pricing/saladcloud.json
+++ b/pricing/saladcloud.json
@@ -1,0 +1,19 @@
+{
+  "default": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": { "price": 0 },
+        "response_token": { "price": 0 }
+      },
+      "currency": "USD"
+    }
+  },
+  "qwen3.6-35b-a3b": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": { "price": 0.000009 },
+        "response_token": { "price": 0.00006 }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

Adds SaladCloud AI Gateway pricing and model configuration for `qwen3.6-35b-a3b`.

This intentionally lists only the 35B model. Portkey stores prices in cents per token, so the published rates convert as follows:

- $0.09 per million input tokens = `0.000009` cents per token
- $0.60 per million output tokens = `0.00006` cents per token

- [x] New model pricing
- [ ] Update existing pricing
- [x] New model configuration
- [ ] Bug fix

## Source Verification

**Source Links:**

- https://docs.salad.com/ai-gateway/reference/pricing
- https://docs.salad.com/ai-gateway/reference/models

> [!IMPORTANT]
> Pricing and model capabilities come from the official Salad AI Gateway documentation.

## Validation

- `jq empty general/saladcloud.json pricing/saladcloud.json`
- `npx prettier --check general/saladcloud.json pricing/saladcloud.json`
- `npx eslint general/saladcloud.json pricing/saladcloud.json`
- `npm run lint`
- `python3 scripts/check_duplicate_keys.py`
- `git diff --check`

## Checklist

- [x] I have validated the JSON using `jq`
- [x] I have verified that prices are in **cents per token** (not dollars)
- [x] I have included the official source links above
- [x] I have signed the CLA (if first-time contributor)

## Related Pull Request

Supersedes #608 with current single-model scope.
