### PR TITLE
Add mistral-medium-3-5 for Azure AI Foundry

### DIFF
--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -3062,6 +3062,12 @@
       "primary": "chat"
     }
   },
+  "mistral-medium-3-5": {
+    "type": {
+      "primary": "chat",
+      "supported": ["tools", "image"]
+    }
+  },
   "mistral-small-2503": {
     "type": {
       "primary": "chat"

--- a/pricing/azure-ai.json
+++ b/pricing/azure-ai.json
@@ -5569,6 +5569,10 @@
         },
         "cache_read_input_token": {
           "price": 0
+        }
+      }
+    }
+  },
   "accounts/fireworks/models/deepseek-v4-pro": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/azure-ai.json
+++ b/pricing/azure-ai.json
@@ -5554,5 +5554,23 @@
         }
       }
     }
+  },
+  "mistral-medium-3-5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00015
+        },
+        "response_token": {
+          "price": 0.00075
+        },
+        "cache_write_input_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `mistral-medium-3-5` general schema (chat with tools + image support) to `azure-ai`
- Adds pricing: $1.50/1M input, $7.50/1M output (Global Standard tier)

## Context
Mistral Medium 3.5 is now available on Azure AI Foundry — 128B dense model, 256K context, multimodal (text + image), native function calling.

Ref: https://ai.azure.com/catalog/models/mistral-medium-3-5