### PR TITLE
Add Grok 4.6 (xAI) pricing and model catalog entries

### DIFF
--- a/general/x-ai.json
+++ b/general/x-ai.json
@@ -329,5 +329,11 @@
       "primary": "chat",
       "supported": ["image", "tools"]
     }
+  },
+  "grok-4.6": {
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    }
   }
 }

--- a/pricing/x-ai.json
+++ b/pricing/x-ai.json
@@ -2527,5 +2527,38 @@
         }
       }
     }
+  },
+  "grok-4.6": {
+    "pricing_config": {
+      "currency": "USD",
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0006
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 0.5
+          },
+          "x_search": {
+            "price": 0.5
+          },
+          "code_execution": {
+            "price": 0.5
+          },
+          "attachment_search": {
+            "price": 1
+          },
+          "file_search": {
+            "price": 0.25
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
Adds xAI's **grok-4.6** (released 2026-08-12) to the x-ai pricing and general catalogs so cost attribution works for the new model.

- `pricing/x-ai.json`: $2/M input, $6/M output, $0.50/M cached input, per [xAI model docs](https://docs.x.ai/docs/models). Additional units mirror grok-4.5.
- `general/x-ai.json`: chat model, image + tools supported (verified via live API: image content parts are accepted and tool_calls are returned).

Note: unlike grok-4.5, xAI serves only the bare `grok-4.6` id — `grok-4.6-latest` returns "Model not found" from the API, so no alias entries are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)