### PR TITLE
feat(meta): Add pricing and capabilities configuration

### DIFF
--- a/general/meta.json
+++ b/general/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "meta",
-  "description": "Meta Model API - Muse Spark reasoning models",
+  "description": "Meta AI offers Muse Spark models for agentic and coding workflows via the Model API.",
   "default": {
     "params": [
       { "key": "max_tokens", "defaultValue": 4096, "minValue": 1, "maxValue": 1048576 },

--- a/general/meta.json
+++ b/general/meta.json
@@ -1,0 +1,26 @@
+{
+  "name": "meta",
+  "description": "Meta Model API - Muse Spark reasoning models",
+  "default": {
+    "params": [
+      { "key": "max_tokens", "defaultValue": 4096, "minValue": 1, "maxValue": 1048576 },
+      { "key": "temperature", "defaultValue": 1.0, "minValue": 0, "maxValue": 2 },
+      { "key": "top_p", "defaultValue": 1, "minValue": 0, "maxValue": 1 },
+      { "key": "stream", "defaultValue": true, "type": "boolean" }
+    ],
+    "messages": { "options": ["system", "developer", "user", "assistant", "tool"] },
+    "type": { "primary": "chat", "supported": ["tools"] }
+  },
+  "muse-spark-1.1": {
+    "params": [{ "key": "max_tokens", "maxValue": 1048576 }],
+    "type": { "primary": "chat", "supported": ["tools", "image", "video"] }
+  },
+  "muse-spark-1.2": {
+    "params": [{ "key": "max_tokens", "maxValue": 1048576 }],
+    "type": { "primary": "chat", "supported": ["tools", "image", "video"] }
+  },
+  "muse-spark-1.2-contributor": {
+    "params": [{ "key": "max_tokens", "maxValue": 1048576 }],
+    "type": { "primary": "chat", "supported": ["tools", "image", "video"] }
+  }
+}

--- a/general/meta.json
+++ b/general/meta.json
@@ -22,5 +22,13 @@
   "muse-spark-1.2-contributor": {
     "params": [{ "key": "max_tokens", "maxValue": 1048576 }],
     "type": { "primary": "chat", "supported": ["tools", "image", "video"] }
+  },
+  "muse-spark-1.3": {
+    "params": [{ "key": "max_tokens", "maxValue": 1048576 }],
+    "type": { "primary": "chat", "supported": ["tools", "image", "video"] }
+  },
+  "muse-spark-1.3-contributor": {
+    "params": [{ "key": "max_tokens", "maxValue": 1048576 }],
+    "type": { "primary": "chat", "supported": ["tools", "image", "video"] }
   }
 }

--- a/pricing/meta.json
+++ b/pricing/meta.json
@@ -1,0 +1,86 @@
+{
+  "default": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": { "price": 0 },
+        "response_token": { "price": 0 },
+        "cache_read_input_token": { "price": 0 },
+        "cache_write_input_token": { "price": 0 },
+        "additional_units": {
+          "web_search": { "price": 0 }
+        }
+      },
+      "calculate": {
+        "request": {
+          "operation": "sum",
+          "operands": [
+            {
+              "operation": "multiply",
+              "operands": [
+                { "value": "input_tokens" },
+                { "value": "rates.request_token" }
+              ]
+            },
+            {
+              "operation": "multiply",
+              "operands": [
+                { "value": "cache_read_input_tokens" },
+                { "value": "rates.cache_read_input_token" }
+              ]
+            }
+          ]
+        },
+        "response": {
+          "operation": "multiply",
+          "operands": [
+            { "value": "output_tokens" },
+            { "value": "rates.response_token" }
+          ]
+        }
+      },
+      "currency": "USD"
+    }
+  },
+  "muse-spark-1.1": {
+    "pricing_config": {
+      "currency": "USD",
+      "pay_as_you_go": {
+        "request_token": { "price": 0.000125 },
+        "response_token": { "price": 0.000425 },
+        "cache_read_input_token": { "price": 0.000015 },
+        "cache_write_input_token": { "price": 0 },
+        "additional_units": {
+          "web_search": { "price": 0.0025 }
+        }
+      }
+    }
+  },
+  "muse-spark-1.2": {
+    "pricing_config": {
+      "currency": "USD",
+      "pay_as_you_go": {
+        "request_token": { "price": 0.000125 },
+        "response_token": { "price": 0.000425 },
+        "cache_read_input_token": { "price": 0.000015 },
+        "cache_write_input_token": { "price": 0 },
+        "additional_units": {
+          "web_search": { "price": 0.0025 }
+        }
+      }
+    }
+  },
+  "muse-spark-1.2-contributor": {
+    "pricing_config": {
+      "currency": "USD",
+      "pay_as_you_go": {
+        "request_token": { "price": 0.00001 },
+        "response_token": { "price": 0.00002 },
+        "cache_read_input_token": { "price": 0.0000002 },
+        "cache_write_input_token": { "price": 0 },
+        "additional_units": {
+          "web_search": { "price": 0.0025 }
+        }
+      }
+    }
+  }
+}

--- a/pricing/meta.json
+++ b/pricing/meta.json
@@ -82,5 +82,33 @@
         }
       }
     }
+  },
+  "muse-spark-1.3": {
+    "pricing_config": {
+      "currency": "USD",
+      "pay_as_you_go": {
+        "request_token": { "price": 0.000125 },
+        "response_token": { "price": 0.000425 },
+        "cache_read_input_token": { "price": 0.000015 },
+        "cache_write_input_token": { "price": 0 },
+        "additional_units": {
+          "web_search": { "price": 0.0025 }
+        }
+      }
+    }
+  },
+  "muse-spark-1.3-contributor": {
+    "pricing_config": {
+      "currency": "USD",
+      "pay_as_you_go": {
+        "request_token": { "price": 0.00001 },
+        "response_token": { "price": 0.00002 },
+        "cache_read_input_token": { "price": 0.0000002 },
+        "cache_write_input_token": { "price": 0 },
+        "additional_units": {
+          "web_search": { "price": 0.0025 }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Pricing and model capabilities configuration for Meta AI provider (Muse Spark models).

## Models (5)

| Model | Tier | Input ($/1M) | Output ($/1M) | Cached ($/1M) |
|---|---|---|---|---|
| `muse-spark-1.1` | Standard | $1.25 | $4.25 | $0.15 |
| `muse-spark-1.2` | Standard | $1.25 | $4.25 | $0.15 |
| `muse-spark-1.3` | Standard | $1.25 | $4.25 | $0.15 |
| `muse-spark-1.2-contributor` | Contributor | $0.10 | $0.20 | $0.002 |
| `muse-spark-1.3-contributor` | Contributor | $0.10 | $0.20 | $0.002 |

Web search: $2.50/1K queries (all models).

## Files

- `pricing/meta.json` — per-token pricing for all 5 models + zero-cost default
- `general/meta.json` — capabilities (chat, tools, image, video), 1M context window

## Related PRs

- Gateway: Portkey-AI/gateway-enterprise-node#1907
- Albus: Portkey-AI/albus#2477
- Protego: Portkey-AI/protego#97
- Luna: Portkey-AI/luna#1963