### PR TITLE
[arcee] Add hosted model pricing

### DIFF
--- a/pricing/arcee.json
+++ b/pricing/arcee.json
@@ -1,0 +1,163 @@
+{
+  "default": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        },
+        "cache_read_input_token": {
+          "price": 0
+        }
+      },
+      "calculate": {
+        "request": {
+          "operation": "sum",
+          "operands": [
+            {
+              "operation": "multiply",
+              "operands": [
+                {
+                  "value": "input_tokens"
+                },
+                {
+                  "value": "rates.request_token"
+                }
+              ]
+            },
+            {
+              "operation": "multiply",
+              "operands": [
+                {
+                  "value": "cache_read_tokens"
+                },
+                {
+                  "value": "rates.cache_read_input_token"
+                }
+              ]
+            }
+          ]
+        },
+        "response": {
+          "operation": "multiply",
+          "operands": [
+            {
+              "value": "output_tokens"
+            },
+            {
+              "value": "rates.response_token"
+            }
+          ]
+        }
+      },
+      "currency": "USD"
+    }
+  },
+  "deepseek/deepseek-v4-flash-latest": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000014
+        },
+        "response_token": {
+          "price": 0.000028
+        },
+        "cache_read_input_token": {
+          "price": 0.0000028
+        }
+      }
+    }
+  },
+  "trinity-large-thinking": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000025
+        },
+        "response_token": {
+          "price": 0.00008
+        },
+        "cache_read_input_token": {
+          "price": 0.000006
+        }
+      }
+    }
+  },
+  "thinkingmachines/inkling-small": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00005
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
+  "deepseek/deepseek-v4-pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000174
+        },
+        "response_token": {
+          "price": 0.000348
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    }
+  },
+  "zai-org/glm-5.2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "response_token": {
+          "price": 0.00044
+        },
+        "cache_read_input_token": {
+          "price": 0.000026
+        }
+      }
+    }
+  },
+  "moonshotai/kimi-k3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0003
+        },
+        "response_token": {
+          "price": 0.0015
+        },
+        "cache_read_input_token": {
+          "price": 0.00003
+        }
+      }
+    }
+  },
+  "deepseek/deepseek-v4-pro-0813": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000132
+        },
+        "response_token": {
+          "price": 0.000396
+        },
+        "cache_read_input_token": {
+          "price": 0.0000044
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

Adds `pricing/arcee.json` with input, cached-input-read, and output pricing for seven models served through Arcee:

- `deepseek/deepseek-v4-flash-latest`
- `deepseek/deepseek-v4-pro`
- `deepseek/deepseek-v4-pro-0813`
- `moonshotai/kimi-k3`
- `thinkingmachines/inkling-small`
- `trinity-large-thinking`
- `zai-org/glm-5.2`

Prices are converted from the published USD-per-million-token rates into Portkey's cents-per-token representation.

- [x] New model pricing
- [ ] Update existing pricing
- [ ] New model configuration
- [ ] Bug fix

## Source Verification

**Official pricing:** https://docs.arcee.ai/get-started/pricing

**Official models endpoint:** https://api.arcee.ai/api/v1/models

The public pricing page lists six models. Pricing for `deepseek/deepseek-v4-pro-0813` was verified through Arcee's authenticated `/models` endpoint.

Cache-write pricing is omitted because Arcee does not currently publish it.

## Validation

- `jq empty pricing/arcee.json`
- `npm run lint`
- Prettier formatting check
- Duplicate-key check
- `git diff --check`

## Checklist

- [x] I have validated the JSON using `jq`
- [x] I have verified that prices are in **cents per token**, not dollars
- [x] I have included the official source links above
- [ ] I have signed the CLA, if required as a first-time contributor

## Related Issue

Not applicable — this is a new provider pricing contribution.
