### PR TITLE
feat: add OpenAI GPT-5.6 Sol/Terra/Luna pricing with context tiers for Bedrock CRIS

### DIFF
--- a/general/bedrock.json
+++ b/general/bedrock.json
@@ -2112,6 +2112,46 @@
     "params": [{ "key": "max_tokens", "maxValue": 32768 }],
     "type": { "primary": "chat" }
   },
+  "us.openai.gpt-5.6-sol": {
+    "params": [{ "key": "max_tokens", "maxValue": 272000 }],
+    "type": { "primary": "chat", "supported": ["image"] },
+    "removeParams": ["temperature", "top_p"]
+  },
+  "global.openai.gpt-5.6-sol": {
+    "params": [{ "key": "max_tokens", "maxValue": 272000 }],
+    "type": { "primary": "chat", "supported": ["image"] },
+    "removeParams": ["temperature", "top_p"]
+  },
+  "us.openai.gpt-5.6-terra": {
+    "params": [{ "key": "max_tokens", "maxValue": 272000 }],
+    "type": { "primary": "chat", "supported": ["image"] },
+    "removeParams": ["temperature", "top_p"]
+  },
+  "in.openai.gpt-5.6-terra": {
+    "params": [{ "key": "max_tokens", "maxValue": 272000 }],
+    "type": { "primary": "chat", "supported": ["image"] },
+    "removeParams": ["temperature", "top_p"]
+  },
+  "global.openai.gpt-5.6-terra": {
+    "params": [{ "key": "max_tokens", "maxValue": 272000 }],
+    "type": { "primary": "chat", "supported": ["image"] },
+    "removeParams": ["temperature", "top_p"]
+  },
+  "us.openai.gpt-5.6-luna": {
+    "params": [{ "key": "max_tokens", "maxValue": 272000 }],
+    "type": { "primary": "chat", "supported": ["image"] },
+    "removeParams": ["temperature", "top_p"]
+  },
+  "in.openai.gpt-5.6-luna": {
+    "params": [{ "key": "max_tokens", "maxValue": 272000 }],
+    "type": { "primary": "chat", "supported": ["image"] },
+    "removeParams": ["temperature", "top_p"]
+  },
+  "global.openai.gpt-5.6-luna": {
+    "params": [{ "key": "max_tokens", "maxValue": 272000 }],
+    "type": { "primary": "chat", "supported": ["image"] },
+    "removeParams": ["temperature", "top_p"]
+  },
   "qwen.qwen3-235b-a22b-2507-v1:0": {
     "type": { "primary": "chat" }
   },

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -14515,5 +14515,565 @@
         }
       }
     }
+  },
+  "us.openai.gpt-5.6-sol": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00055
+        },
+        "response_token": {
+          "price": 0.0033
+        },
+        "cache_write_input_token": {
+          "price": 0.0006875
+        },
+        "cache_read_input_token": {
+          "price": 0.000055
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00055
+                      },
+                      "response_token": {
+                        "price": 0.0033
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0006875
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000055
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0011
+                      },
+                      "response_token": {
+                        "price": 0.00495
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.001375
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00011
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "global.openai.gpt-5.6-sol": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.003
+        },
+        "cache_write_input_token": {
+          "price": 0.000625
+        },
+        "cache_read_input_token": {
+          "price": 0.00005
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0005
+                      },
+                      "response_token": {
+                        "price": 0.003
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000625
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00005
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.001
+                      },
+                      "response_token": {
+                        "price": 0.0045
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00125
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0001
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "us.openai.gpt-5.6-terra": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00022
+        },
+        "response_token": {
+          "price": 0.00132
+        },
+        "cache_write_input_token": {
+          "price": 0.000275
+        },
+        "cache_read_input_token": {
+          "price": 0.000022
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00022
+                      },
+                      "response_token": {
+                        "price": 0.00132
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000275
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000022
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00044
+                      },
+                      "response_token": {
+                        "price": 0.00198
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00055
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000044
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "in.openai.gpt-5.6-terra": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00022
+        },
+        "response_token": {
+          "price": 0.00132
+        },
+        "cache_write_input_token": {
+          "price": 0.000275
+        },
+        "cache_read_input_token": {
+          "price": 0.000022
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00022
+                      },
+                      "response_token": {
+                        "price": 0.00132
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000275
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000022
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00044
+                      },
+                      "response_token": {
+                        "price": 0.00198
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00055
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000044
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "global.openai.gpt-5.6-terra": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0012
+        },
+        "cache_write_input_token": {
+          "price": 0.00025
+        },
+        "cache_read_input_token": {
+          "price": 0.00002
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0002
+                      },
+                      "response_token": {
+                        "price": 0.0012
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00025
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00002
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.0004
+                      },
+                      "response_token": {
+                        "price": 0.0018
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0005
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.00004
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "us.openai.gpt-5.6-luna": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.000132
+        },
+        "cache_write_input_token": {
+          "price": 0.0000275
+        },
+        "cache_read_input_token": {
+          "price": 0.0000022
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000022
+                      },
+                      "response_token": {
+                        "price": 0.000132
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000275
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000022
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000044
+                      },
+                      "response_token": {
+                        "price": 0.000198
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000055
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000044
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "in.openai.gpt-5.6-luna": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000022
+        },
+        "response_token": {
+          "price": 0.000132
+        },
+        "cache_write_input_token": {
+          "price": 0.0000275
+        },
+        "cache_read_input_token": {
+          "price": 0.0000022
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000022
+                      },
+                      "response_token": {
+                        "price": 0.000132
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.0000275
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000022
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.000044
+                      },
+                      "response_token": {
+                        "price": 0.000198
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000055
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.0000044
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "global.openai.gpt-5.6-luna": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00002
+        },
+        "response_token": {
+          "price": 0.00012
+        },
+        "cache_write_input_token": {
+          "price": 0.000025
+        },
+        "cache_read_input_token": {
+          "price": 0.000002
+        }
+      }
+    },
+    "custom_pricing": {
+      "context_tier_map": {
+        "0": "lte-272k",
+        "272000": "gt-272k"
+      },
+      "regions": {
+        "default": {
+          "execution_modes": {
+            "standard": {
+              "context_tiers": {
+                "lte-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00002
+                      },
+                      "response_token": {
+                        "price": 0.00012
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.000025
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000002
+                      }
+                    }
+                  }
+                },
+                "gt-272k": {
+                  "pricing_config": {
+                    "pay_as_you_go": {
+                      "request_token": {
+                        "price": 0.00004
+                      },
+                      "response_token": {
+                        "price": 0.00018
+                      },
+                      "cache_write_input_token": {
+                        "price": 0.00005
+                      },
+                      "cache_read_input_token": {
+                        "price": 0.000004
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Add pricing and general config entries for OpenAI GPT-5.6 Sol, Terra, and Luna models on AWS Bedrock (`bedrock-runtime` endpoint) with cross-region inference profiles
- 8 model IDs added: `us.` (Geo CRIS), `in.` (Geo CRIS, Terra/Luna only), `global.` (Global CRIS)
- Pricing includes `custom_pricing` with `context_tier_map` for Short (≤272K) and Long (>272K) context window tiers, following the same structure as `vertex-ai.json`

### Models added to `pricing/bedrock.json`:
- `us.openai.gpt-5.6-sol`, `global.openai.gpt-5.6-sol`
- `us.openai.gpt-5.6-terra`, `in.openai.gpt-5.6-terra`, `global.openai.gpt-5.6-terra`
- `us.openai.gpt-5.6-luna`, `in.openai.gpt-5.6-luna`, `global.openai.gpt-5.6-luna`

### Models added to `general/bedrock.json`:
- Same 8 model IDs with Converse API-aligned config (max_tokens: 272000, image support, temperature/top_p removed as reasoning models)

### Pricing structure

- `pricing_config` (top-level): Short context fallback pricing
- `custom_pricing.context_tier_map`: `{"0": "lte-272k", "272000": "gt-272k"}`
- `custom_pricing.regions.default.execution_modes.standard.context_tiers`: Short and Long tier pricing

Region-based pricing (`custom_pricing.regions`) uses `"default"` because these models are only available via cross-region inference profiles on `bedrock-runtime` — AWS charges a flat rate per inference option (Geo/Global), not per individual AWS region. The Geo vs Global price difference is encoded in separate model IDs (`us.`/`in.` vs `global.`).

### Pricing source

- `us.*` / `in.*` entries: Geo CRIS pricing from AWS model cards
- `global.*` entries: Global CRIS pricing
- [Sol model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html)
- [Terra model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html)
- [Luna model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html)

**Ref:** [Pylon #8200](https://app.usepylon.com/support/issues/views/4305f6d4-1eeb-4039-92aa-1867128acd4f?view=fs&issueNumber=8200)

## Test plan

- [x] Pricing values verified against AWS model cards for all 3 models × all inference options × both context tiers
- [x] Structure consistent with existing `vertex-ai.json` context tier pattern
- [ ] E2E tested with live Bedrock requests (200 OK responses with correct model routing)