### PR TITLE
feat: add ElevenLabs pricing

### DIFF
--- a/general/elevenlabs.json
+++ b/general/elevenlabs.json
@@ -1,0 +1,34 @@
+{
+  "name": "elevenlabs",
+  "description": "",
+  "default": {
+    "params": [],
+    "type": { "primary": "audio", "supported": [] },
+    "disablePlayground": true
+  },
+  "eleven_multilingual_v2": {
+    "params": [],
+    "type": { "primary": "audio" },
+    "disablePlayground": true
+  },
+  "eleven_v3": {
+    "params": [],
+    "type": { "primary": "audio" },
+    "disablePlayground": true
+  },
+  "eleven_flash_v2_5": {
+    "params": [],
+    "type": { "primary": "audio" },
+    "disablePlayground": true
+  },
+  "eleven_turbo_v2_5": {
+    "params": [],
+    "type": { "primary": "audio" },
+    "disablePlayground": true
+  },
+  "scribe_v1": {
+    "params": [],
+    "type": { "primary": "audio" },
+    "disablePlayground": true
+  }
+}

--- a/pricing/elevenlabs.json
+++ b/pricing/elevenlabs.json
@@ -1,0 +1,93 @@
+{
+  "eleven_multilingual_v2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.01
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "currency": "USD"
+    }
+  },
+  "eleven_v3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.01
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "currency": "USD"
+    }
+  },
+  "eleven_flash_v2_5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.005
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "currency": "USD"
+    }
+  },
+  "eleven_turbo_v2_5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.005
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "currency": "USD"
+    }
+  },
+  "text-to-speech": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.01
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "currency": "USD"
+    }
+  },
+  "scribe_v1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0.00611111
+        }
+      },
+      "currency": "USD"
+    }
+  },
+  "speech-to-text": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0.00611111
+        }
+      },
+      "currency": "USD"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `pricing/elevenlabs.json` — no ElevenLabs entry existed before this.
- Text-to-speech: $0.0001/character (multilingual v2, v3), $0.00005/character (flash, turbo v2.5) — stored per this repo's cents-per-unit convention (0.01 / 0.005).
- Speech-to-text (`scribe_v1`): $0.22/hour, stored as cents/second (0.00611111).
- Rates taken directly from ElevenLabs' published API pricing page (elevenlabs.io/pricing/api), not estimated.
- Companion PR on the gateway side ([Portkey-AI/gateway-enterprise-node#1940](https://github.com/Portkey-AI/gateway-enterprise-node/pull/1940)) adds ElevenLabs as a provider and consumes this file via `npm run sync:pricing`.

## Test plan
- [x] `python3 scripts/check_duplicate_keys.py pricing/elevenlabs.json` passes
- [x] Schema matches `sync-to-gateway.js`'s `validatePricingSchema` (verified by reading the validator directly, not just the docs)
- [x] Cents-per-unit convention cross-checked against `openai.json` (gpt-4o) and matches this same repo's format exactly