### PR TITLE
Update GPT-5.6 Sol pricing for OpenAI's Aug 21 promo cut (openai + openrouter)

### DIFF
--- a/pricing/openai.json
+++ b/pricing/openai.json
@@ -12725,16 +12725,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.003
+          "price": 0.002
         },
         "cache_write_input_token": {
-          "price": 0.000625
+          "price": 0.0005
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -12747,16 +12747,16 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.001
         },
         "cache_write_input_token": {
-          "price": 0.0003125
+          "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00002
         }
       }
     },
@@ -12774,16 +12774,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0005
+                        "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 0.00004
                       },
                       "cache_write_input_token": {
-                        "price": 0.000625
+                        "price": 0.0005
                       },
                       "response_token": {
-                        "price": 0.003
+                        "price": 0.002
                       },
                       "additional_units": {
                         "web_search": {
@@ -12800,16 +12800,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.001
+                        "price": 0.0008
                       },
                       "cache_read_input_token": {
-                        "price": 0.0001
+                        "price": 0.00008
                       },
                       "cache_write_input_token": {
-                        "price": 0.00125
+                        "price": 0.001
                       },
                       "response_token": {
-                        "price": 0.0045
+                        "price": 0.003
                       },
                       "additional_units": {
                         "web_search": {
@@ -12830,16 +12830,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00025
+                        "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 0.00002
                       },
                       "cache_write_input_token": {
-                        "price": 0.0003125
+                        "price": 0.00025
                       },
                       "response_token": {
-                        "price": 0.0015
+                        "price": 0.001
                       },
                       "additional_units": {
                         "web_search": {
@@ -12856,16 +12856,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0005
+                        "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 0.00004
                       },
                       "cache_write_input_token": {
-                        "price": 0.000625
+                        "price": 0.0005
                       },
                       "response_token": {
-                        "price": 0.00225
+                        "price": 0.0015
                       },
                       "additional_units": {
                         "web_search": {
@@ -12886,16 +12886,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00025
+                        "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 0.00002
                       },
                       "cache_write_input_token": {
-                        "price": 0.0003125
+                        "price": 0.00025
                       },
                       "response_token": {
-                        "price": 0.0015
+                        "price": 0.001
                       },
                       "additional_units": {
                         "web_search": {
@@ -12912,16 +12912,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0005
+                        "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 0.00004
                       },
                       "cache_write_input_token": {
-                        "price": 0.000625
+                        "price": 0.0005
                       },
                       "response_token": {
-                        "price": 0.00225
+                        "price": 0.0015
                       },
                       "additional_units": {
                         "web_search": {
@@ -12942,16 +12942,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.001
+                        "price": 0.0008
                       },
                       "cache_read_input_token": {
-                        "price": 0.0001
+                        "price": 0.00008
                       },
                       "cache_write_input_token": {
-                        "price": 0.00125
+                        "price": 0.001
                       },
                       "response_token": {
-                        "price": 0.006
+                        "price": 0.004
                       },
                       "additional_units": {
                         "web_search": {
@@ -12976,16 +12976,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00055
+                        "price": 0.00044
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 0.000044
                       },
                       "cache_write_input_token": {
-                        "price": 0.0006875
+                        "price": 0.00055
                       },
                       "response_token": {
-                        "price": 0.0033
+                        "price": 0.0022
                       },
                       "additional_units": {
                         "web_search": {
@@ -13002,16 +13002,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0011
+                        "price": 0.00088
                       },
                       "cache_read_input_token": {
-                        "price": 0.00011
+                        "price": 0.000088
                       },
                       "cache_write_input_token": {
-                        "price": 0.001375
+                        "price": 0.0011
                       },
                       "response_token": {
-                        "price": 0.00495
+                        "price": 0.0033
                       },
                       "additional_units": {
                         "web_search": {
@@ -13032,16 +13032,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000275
+                        "price": 0.00022
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 0.000022
                       },
                       "cache_write_input_token": {
-                        "price": 0.00034375
+                        "price": 0.000275
                       },
                       "response_token": {
-                        "price": 0.00165
+                        "price": 0.0011
                       },
                       "additional_units": {
                         "web_search": {
@@ -13058,16 +13058,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00055
+                        "price": 0.00044
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 0.000044
                       },
                       "cache_write_input_token": {
-                        "price": 0.0006875
+                        "price": 0.00055
                       },
                       "response_token": {
-                        "price": 0.002475
+                        "price": 0.00165
                       },
                       "additional_units": {
                         "web_search": {
@@ -13088,16 +13088,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000275
+                        "price": 0.00022
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 0.000022
                       },
                       "cache_write_input_token": {
-                        "price": 0.00034375
+                        "price": 0.000275
                       },
                       "response_token": {
-                        "price": 0.00165
+                        "price": 0.0011
                       },
                       "additional_units": {
                         "web_search": {
@@ -13114,16 +13114,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00055
+                        "price": 0.00044
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 0.000044
                       },
                       "cache_write_input_token": {
-                        "price": 0.0006875
+                        "price": 0.00055
                       },
                       "response_token": {
-                        "price": 0.002475
+                        "price": 0.00165
                       },
                       "additional_units": {
                         "web_search": {
@@ -13144,16 +13144,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0011
+                        "price": 0.00088
                       },
                       "cache_read_input_token": {
-                        "price": 0.00011
+                        "price": 0.000088
                       },
                       "cache_write_input_token": {
-                        "price": 0.001375
+                        "price": 0.0011
                       },
                       "response_token": {
-                        "price": 0.0066
+                        "price": 0.0044
                       },
                       "additional_units": {
                         "web_search": {
@@ -14533,16 +14533,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.0004
         },
         "response_token": {
-          "price": 0.003
+          "price": 0.002
         },
         "cache_write_input_token": {
-          "price": 0.000625
+          "price": 0.0005
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00004
         },
         "additional_units": {
           "web_search": {
@@ -14555,16 +14555,16 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.001
         },
         "cache_write_input_token": {
-          "price": 0.0003125
+          "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00002
         }
       }
     },
@@ -14582,16 +14582,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0005
+                        "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 0.00004
                       },
                       "cache_write_input_token": {
-                        "price": 0.000625
+                        "price": 0.0005
                       },
                       "response_token": {
-                        "price": 0.003
+                        "price": 0.002
                       },
                       "additional_units": {
                         "web_search": {
@@ -14608,16 +14608,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.001
+                        "price": 0.0008
                       },
                       "cache_read_input_token": {
-                        "price": 0.0001
+                        "price": 0.00008
                       },
                       "cache_write_input_token": {
-                        "price": 0.00125
+                        "price": 0.001
                       },
                       "response_token": {
-                        "price": 0.0045
+                        "price": 0.003
                       },
                       "additional_units": {
                         "web_search": {
@@ -14638,16 +14638,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00025
+                        "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 0.00002
                       },
                       "cache_write_input_token": {
-                        "price": 0.0003125
+                        "price": 0.00025
                       },
                       "response_token": {
-                        "price": 0.0015
+                        "price": 0.001
                       },
                       "additional_units": {
                         "web_search": {
@@ -14664,16 +14664,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0005
+                        "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 0.00004
                       },
                       "cache_write_input_token": {
-                        "price": 0.000625
+                        "price": 0.0005
                       },
                       "response_token": {
-                        "price": 0.00225
+                        "price": 0.0015
                       },
                       "additional_units": {
                         "web_search": {
@@ -14694,16 +14694,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00025
+                        "price": 0.0002
                       },
                       "cache_read_input_token": {
-                        "price": 0.000025
+                        "price": 0.00002
                       },
                       "cache_write_input_token": {
-                        "price": 0.0003125
+                        "price": 0.00025
                       },
                       "response_token": {
-                        "price": 0.0015
+                        "price": 0.001
                       },
                       "additional_units": {
                         "web_search": {
@@ -14720,16 +14720,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0005
+                        "price": 0.0004
                       },
                       "cache_read_input_token": {
-                        "price": 0.00005
+                        "price": 0.00004
                       },
                       "cache_write_input_token": {
-                        "price": 0.000625
+                        "price": 0.0005
                       },
                       "response_token": {
-                        "price": 0.00225
+                        "price": 0.0015
                       },
                       "additional_units": {
                         "web_search": {
@@ -14750,16 +14750,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.001
+                        "price": 0.0008
                       },
                       "cache_read_input_token": {
-                        "price": 0.0001
+                        "price": 0.00008
                       },
                       "cache_write_input_token": {
-                        "price": 0.00125
+                        "price": 0.001
                       },
                       "response_token": {
-                        "price": 0.006
+                        "price": 0.004
                       },
                       "additional_units": {
                         "web_search": {
@@ -14784,16 +14784,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00055
+                        "price": 0.00044
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 0.000044
                       },
                       "cache_write_input_token": {
-                        "price": 0.0006875
+                        "price": 0.00055
                       },
                       "response_token": {
-                        "price": 0.0033
+                        "price": 0.0022
                       },
                       "additional_units": {
                         "web_search": {
@@ -14810,16 +14810,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0011
+                        "price": 0.00088
                       },
                       "cache_read_input_token": {
-                        "price": 0.00011
+                        "price": 0.000088
                       },
                       "cache_write_input_token": {
-                        "price": 0.001375
+                        "price": 0.0011
                       },
                       "response_token": {
-                        "price": 0.00495
+                        "price": 0.0033
                       },
                       "additional_units": {
                         "web_search": {
@@ -14840,16 +14840,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000275
+                        "price": 0.00022
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 0.000022
                       },
                       "cache_write_input_token": {
-                        "price": 0.00034375
+                        "price": 0.000275
                       },
                       "response_token": {
-                        "price": 0.00165
+                        "price": 0.0011
                       },
                       "additional_units": {
                         "web_search": {
@@ -14866,16 +14866,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00055
+                        "price": 0.00044
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 0.000044
                       },
                       "cache_write_input_token": {
-                        "price": 0.0006875
+                        "price": 0.00055
                       },
                       "response_token": {
-                        "price": 0.002475
+                        "price": 0.00165
                       },
                       "additional_units": {
                         "web_search": {
@@ -14896,16 +14896,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.000275
+                        "price": 0.00022
                       },
                       "cache_read_input_token": {
-                        "price": 0.0000275
+                        "price": 0.000022
                       },
                       "cache_write_input_token": {
-                        "price": 0.00034375
+                        "price": 0.000275
                       },
                       "response_token": {
-                        "price": 0.00165
+                        "price": 0.0011
                       },
                       "additional_units": {
                         "web_search": {
@@ -14922,16 +14922,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.00055
+                        "price": 0.00044
                       },
                       "cache_read_input_token": {
-                        "price": 0.000055
+                        "price": 0.000044
                       },
                       "cache_write_input_token": {
-                        "price": 0.0006875
+                        "price": 0.00055
                       },
                       "response_token": {
-                        "price": 0.002475
+                        "price": 0.00165
                       },
                       "additional_units": {
                         "web_search": {
@@ -14952,16 +14952,16 @@
                   "pricing_config": {
                     "pay_as_you_go": {
                       "request_token": {
-                        "price": 0.0011
+                        "price": 0.00088
                       },
                       "cache_read_input_token": {
-                        "price": 0.00011
+                        "price": 0.000088
                       },
                       "cache_write_input_token": {
-                        "price": 0.001375
+                        "price": 0.0011
                       },
                       "response_token": {
-                        "price": 0.0066
+                        "price": 0.0044
                       },
                       "additional_units": {
                         "web_search": {

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -789,16 +789,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0005
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.003
+          "price": 0.001
         },
         "cache_write_input_token": {
-          "price": 0.000625
+          "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.00005
+          "price": 0.00002
         }
       }
     }
@@ -807,13 +807,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.0005
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00001
         }
       }
     }
@@ -822,16 +822,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00025
+          "price": 0.0002
         },
         "response_token": {
-          "price": 0.0015
+          "price": 0.001
         },
         "cache_write_input_token": {
-          "price": 0.0003125
+          "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.00002
         }
       }
     }
@@ -840,13 +840,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000125
+          "price": 0.0001
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.0005
         },
         "cache_read_input_token": {
-          "price": 0.0000125
+          "price": 0.00001
         }
       }
     }


### PR DESCRIPTION
## What

OpenAI [cut GPT-5.6 Sol developer pricing](https://openai.com/index/gpt-5-6/) by 20% on input and ~33% on output, effective Aug 21, 2026 (promotional, running at least through Nov 21, 2026). Reuters coverage [here](https://www.reuters.com/technology/openai-cuts-developer-pricing-frontier-gpt-56-sol-model-by-more-than-20-2026-08-21/).

### `pricing/openai.json` — `gpt-5.6-sol` + `gpt-5.6-sol-2026-07-09`

Per 1M tokens, from OpenAI's [pricing page](https://developers.openai.com/api/docs/pricing):

| Tier | Input | Cached input | Output |
|-|-|-|-|
| Standard (≤272k) | $5 → **$4** | $0.50 → **$0.40** | $30 → **$20** |
| Long context (>272k) | $10 → **$8** | $1 → **$0.80** | $45 → **$30** |
| Batch / Flex (≤272k) | $2.50 → **$2** | $0.25 → **$0.20** | $15 → **$10** |
| Priority (≤272k) | $10 → **$8** | $1 → **$0.80** | $60 → **$40** |

All tiers (including the data-residency region block) scale uniformly: input-side ×0.8, output ×⅔, which matches the published table exactly. Cache-write keeps its 1.25× input ratio. `additional_units` (web_search, file_search) unchanged.

### `pricing/openrouter.json` — `openai/gpt-5.6-sol`, `-pro`, and `:batch` variants

Synced to OpenRouter's live `/api/v1/models` response: $2/M input, $10/M output (batch $1/$5). OpenRouter layers its ongoing 50%-off non-BYOK promo on top of OpenAI's new base price; this file already tracked the promo-discounted listed price, so these values mirror the current API response verbatim.

## Deliberately not changed

- **azure-openai / azure-ai** — no evidence Microsoft has matched the cut yet (trackers and the Azure retail Prices API still show old rates; the promo is scoped to OpenAI's API per the announcement). Should follow up if/when Azure updates.
- **bedrock / bedrock-mantle** — AWS still lists Sol at $5/$30 (+10% regional uplift); AWS sets Bedrock pricing independently.
- **lightning-ai** — no published change found.

## Validation

- `python3 scripts/check_duplicate_keys.py` clean
- `prettier --check` and `eslint --quiet` pass on both files
- Diff touches only `"price"` lines (128 in openai.json, 14 in openrouter.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)