### PR TITLE
Add MAI-Thinking-1 model support for Azure AI

### DIFF
--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -3027,6 +3027,11 @@
       "primary": "chat"
     }
   },
+  "MAI-Thinking-1": {
+    "type": {
+      "primary": "chat"
+    }
+  },
   "Phi-4-mini-reasoning": {
     "type": {
       "primary": "chat"

--- a/pricing/azure-ai.json
+++ b/pricing/azure-ai.json
@@ -4560,6 +4560,18 @@
       }
     }
   },
+  "MAI-Thinking-1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0002
+        },
+        "response_token": {
+          "price": 0.0008
+        }
+      }
+    }
+  },
   "gpt-4o-mini-tts": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
## Summary
- Adds MAI-Thinking-1 (Microsoft's in-house reasoning model) to the Azure AI provider configs
- General schema entry added in `general/azure-ai.json`
- Pricing added in `pricing/azure-ai.json` ($2/1M input, $8/1M output)

## Reference
- [Introducing MAI-Thinking-1 | Microsoft AI](https://microsoft.ai/news/introducing-mai-thinking-1/)

## Test plan
- [ ] Verify model is routable via Azure AI Inference provider
- [x] Verify pricing is correctly applied for usage tracking