### PR TITLE
[vertex-ai] Add glm-5.2-maas

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -2459,6 +2459,13 @@
       "primary": "chat"
     }
   },
+  "glm-5.2-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": ["tools"]
+    },
+    "params": [{ "key": "max_tokens", "maxValue": 64000 }]
+  },
   "gemma-4-26b-a4b-it-maas": {
     "type": {
       "primary": "chat",

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -15448,6 +15448,21 @@
       }
     }
   },
+  "glm-5.2-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0001
+        },
+        "response_token": {
+          "price": 0.00032
+        },
+        "cache_read_input_token": {
+          "price": 0.00001
+        }
+      }
+    }
+  },
   "gemma-4-26b-a4b-it-maas": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
Add GLM 5.2 model config and pricing for Google Vertex AI provider.
- Input: $1.00/1M tokens, Output: $3.20/1M tokens, Cache hit: $0.10/1M tokens
- Supports: text, function calling, structured output, thinking
- Context length: 1M, Max output: 64K

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

- [x] New model pricing
- [ ] Update existing pricing
- [x] New model configuration
- [ ] Bug fix

## Source Verification

**Source Link:** [Add link here]

> [!IMPORTANT]
> Please include a link to the official pricing page from the provider. Simple "I heard it from somewhere" or screenshot sources are not accepted.

## Checklist

- [x] I have validated the JSON using `jq` or an online validator
- [x] I have verified that prices are in **cents per token** (not dollars)
- [x] I have included the source link above
- [ ] I have signed the CLA (if first-time contributor)

## Related Issue

Fixes # (issue)
