### PR TITLE
Add pricing for Nova 2 Lite, deepseek-v4-flash-0731, and Voyage models

### DIFF
--- a/general/fireworks-ai.json
+++ b/general/fireworks-ai.json
@@ -741,5 +741,10 @@
     "name": "kimi-k3",
     "params": [{ "key": "max_tokens", "maxValue": 131072 }],
     "type": { "primary": "chat", "supported": ["tools", "image"] }
+  },
+  "accounts/fireworks/models/deepseek-v4-flash-0731": {
+    "name": "deepseek-v4-flash-0731",
+    "params": [{ "key": "max_tokens", "maxValue": 32768 }],
+    "type": { "primary": "chat", "supported": ["tools"] }
   }
 }

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -15305,13 +15305,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3e-07
+          "price": 0.00003
         },
         "response_token": {
-          "price": 2.5e-06
+          "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 7.5e-08
+          "price": 0.0000075
         },
         "cache_write_input_token": {
           "price": 0
@@ -15323,13 +15323,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3e-07
+          "price": 0.00003
         },
         "response_token": {
-          "price": 2.5e-06
+          "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 7.5e-08
+          "price": 0.0000075
         },
         "cache_write_input_token": {
           "price": 0
@@ -15341,13 +15341,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 3e-07
+          "price": 0.00003
         },
         "response_token": {
-          "price": 2.5e-06
+          "price": 0.00025
         },
         "cache_read_input_token": {
-          "price": 7.5e-08
+          "price": 0.0000075
         },
         "cache_write_input_token": {
           "price": 0

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -15300,5 +15300,59 @@
         }
       }
     }
+  },
+  "amazon.nova-2-lite-v1:0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3e-07
+        },
+        "response_token": {
+          "price": 2.5e-06
+        },
+        "cache_read_input_token": {
+          "price": 7.5e-08
+        },
+        "cache_write_input_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "jp.amazon.nova-2-lite-v1:0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3e-07
+        },
+        "response_token": {
+          "price": 2.5e-06
+        },
+        "cache_read_input_token": {
+          "price": 7.5e-08
+        },
+        "cache_write_input_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "eu.amazon.nova-2-lite-v1:0": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 3e-07
+        },
+        "response_token": {
+          "price": 2.5e-06
+        },
+        "cache_read_input_token": {
+          "price": 7.5e-08
+        },
+        "cache_write_input_token": {
+          "price": 0
+        }
+      }
+    }
   }
 }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -1182,5 +1182,20 @@
         }
       }
     }
+  },
+  "accounts/fireworks/models/deepseek-v4-flash-0731": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.4e-07
+        },
+        "response_token": {
+          "price": 2.8e-07
+        },
+        "cache_read_input_token": {
+          "price": 3e-08
+        }
+      }
+    }
   }
 }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -1187,13 +1187,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.4e-07
+          "price": 0.000014
         },
         "response_token": {
-          "price": 2.8e-07
+          "price": 0.000028
         },
         "cache_read_input_token": {
-          "price": 3e-08
+          "price": 0.0000028
         }
       }
     }

--- a/pricing/voyage.json
+++ b/pricing/voyage.json
@@ -1,0 +1,267 @@
+{
+  "default": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0
+        },
+        "response_token": {
+          "price": 0
+        }
+      },
+      "calculate": {
+        "request": {
+          "operation": "multiply",
+          "operands": [
+            {
+              "value": "input_tokens"
+            },
+            {
+              "value": "rates.request_token"
+            }
+          ]
+        },
+        "response": {
+          "operation": "multiply",
+          "operands": [
+            {
+              "value": "output_tokens"
+            },
+            {
+              "value": "rates.response_token"
+            }
+          ]
+        }
+      },
+      "currency": "USD"
+    }
+  },
+  "voyage-4-large": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.2e-07
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-4": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 6e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-4-lite": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-3-large": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.8e-07
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-3.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 6e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-3.5-lite": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-code-3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.8e-07
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-finance-2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.2e-07
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-law-2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.2e-07
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-context-3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.8e-07
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-multilingual-2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 1.2e-07
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 6e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "voyage-3-lite": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "rerank-2.5": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "rerank-2.5-lite": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "rerank-1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "rerank-2": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 5e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "rerank-lite-1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  },
+  "rerank-2-lite": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 2e-08
+        },
+        "response_token": {
+          "price": 0
+        }
+      }
+    }
+  }
+}

--- a/pricing/voyage.json
+++ b/pricing/voyage.json
@@ -40,7 +40,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.2e-07
+          "price": 0.000012
         },
         "response_token": {
           "price": 0
@@ -52,7 +52,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 6e-08
+          "price": 0.000006
         },
         "response_token": {
           "price": 0
@@ -64,7 +64,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2e-08
+          "price": 0.000002
         },
         "response_token": {
           "price": 0
@@ -76,7 +76,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.8e-07
+          "price": 0.000018
         },
         "response_token": {
           "price": 0
@@ -88,7 +88,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 6e-08
+          "price": 0.000006
         },
         "response_token": {
           "price": 0
@@ -100,7 +100,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2e-08
+          "price": 0.000002
         },
         "response_token": {
           "price": 0
@@ -112,7 +112,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.8e-07
+          "price": 0.000018
         },
         "response_token": {
           "price": 0
@@ -124,7 +124,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.2e-07
+          "price": 0.000012
         },
         "response_token": {
           "price": 0
@@ -136,7 +136,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.2e-07
+          "price": 0.000012
         },
         "response_token": {
           "price": 0
@@ -148,7 +148,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.8e-07
+          "price": 0.000018
         },
         "response_token": {
           "price": 0
@@ -160,7 +160,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 1.2e-07
+          "price": 0.000012
         },
         "response_token": {
           "price": 0
@@ -172,7 +172,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 6e-08
+          "price": 0.000006
         },
         "response_token": {
           "price": 0
@@ -184,7 +184,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2e-08
+          "price": 0.000002
         },
         "response_token": {
           "price": 0
@@ -196,7 +196,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5e-08
+          "price": 0.000005
         },
         "response_token": {
           "price": 0
@@ -208,7 +208,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2e-08
+          "price": 0.000002
         },
         "response_token": {
           "price": 0
@@ -220,7 +220,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5e-08
+          "price": 0.000005
         },
         "response_token": {
           "price": 0
@@ -232,7 +232,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 5e-08
+          "price": 0.000005
         },
         "response_token": {
           "price": 0
@@ -244,7 +244,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2e-08
+          "price": 0.000002
         },
         "response_token": {
           "price": 0
@@ -256,7 +256,7 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 2e-08
+          "price": 0.000002
         },
         "response_token": {
           "price": 0


### PR DESCRIPTION
- Add amazon.nova-2-lite-v1:0, jp.amazon.nova-2-lite-v1:0, eu.amazon.nova-2-lite-v1:0 to pricing/bedrock.json
- Add accounts/fireworks/models/deepseek-v4-flash-0731 to pricing/fireworks-ai.json and general/fireworks-ai.json
- Create pricing/voyage.json with full Voyage model lineup (voyage-4, voyage-3.5, rerank-2.5, etc.)