### PR TITLE
Update Gemini 3.7/3.6 Flash to introductory pricing

### DIFF
--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3767,13 +3767,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00015
+          "price": 0.000075
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -3786,10 +3786,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.0000375
         },
         "response_token": {
-          "price": 0.000375
+          "price": 0.0001875
         }
       }
     }
@@ -3798,13 +3798,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00015
+          "price": 0.000075
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -3817,10 +3817,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.0000375
         },
         "response_token": {
-          "price": 0.000375
+          "price": 0.0001875
         }
       }
     }
@@ -3829,13 +3829,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00015
+          "price": 0.000075
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -3848,10 +3848,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.0000375
         },
         "response_token": {
-          "price": 0.000375
+          "price": 0.0001875
         }
       }
     }
@@ -3860,13 +3860,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00015
+          "price": 0.000075
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.000375
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -3879,10 +3879,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.0000375
         },
         "response_token": {
-          "price": 0.000375
+          "price": 0.0001875
         }
       }
     }

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -13705,16 +13705,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00015
+          "price": 0.000075
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.000375
         },
         "cache_write_input_token": {
-          "price": 0.00015
+          "price": 0.000075
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -13733,10 +13733,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.0000375
         },
         "response_token": {
-          "price": 0.000375
+          "price": 0.0001875
         }
       }
     },
@@ -13748,13 +13748,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00015
+                    "price": 0.0000825
                   },
                   "cache_read_input_token": {
-                    "price": 0.000015
+                    "price": 0.00000825
                   },
                   "response_token": {
-                    "price": 0.00075
+                    "price": 0.0004125
                   },
                   "additional_units": {
                     "web_search": {
@@ -13777,13 +13777,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000075
+                    "price": 0.00004125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000075
+                    "price": 0.000004125
                   },
                   "response_token": {
-                    "price": 0.000375
+                    "price": 0.00020625
                   },
                   "additional_units": {
                     "web_search": {
@@ -13806,13 +13806,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000075
+                    "price": 0.00004125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000075
+                    "price": 0.000004125
                   },
                   "response_token": {
-                    "price": 0.000375
+                    "price": 0.00020625
                   },
                   "additional_units": {
                     "web_search": {
@@ -13835,13 +13835,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00027
+                    "price": 0.0001485
                   },
                   "cache_read_input_token": {
-                    "price": 0.000027
+                    "price": 0.00001485
                   },
                   "response_token": {
-                    "price": 0.00135
+                    "price": 0.0007425
                   },
                   "additional_units": {
                     "web_search": {
@@ -13868,13 +13868,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00015
+                    "price": 0.000075
                   },
                   "cache_read_input_token": {
-                    "price": 0.000015
+                    "price": 0.0000075
                   },
                   "response_token": {
-                    "price": 0.00075
+                    "price": 0.000375
                   },
                   "additional_units": {
                     "web_search": {
@@ -13897,13 +13897,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000075
+                    "price": 0.0000375
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000075
+                    "price": 0.00000375
                   },
                   "response_token": {
-                    "price": 0.000375
+                    "price": 0.0001875
                   },
                   "additional_units": {
                     "web_search": {
@@ -13926,13 +13926,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000075
+                    "price": 0.0000375
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000075
+                    "price": 0.00000375
                   },
                   "response_token": {
-                    "price": 0.000375
+                    "price": 0.0001875
                   },
                   "additional_units": {
                     "web_search": {
@@ -13955,13 +13955,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00027
+                    "price": 0.000135
                   },
                   "cache_read_input_token": {
-                    "price": 0.000027
+                    "price": 0.0000135
                   },
                   "response_token": {
-                    "price": 0.00135
+                    "price": 0.000675
                   },
                   "additional_units": {
                     "web_search": {
@@ -13989,16 +13989,16 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00015
+          "price": 0.000075
         },
         "response_token": {
-          "price": 0.00075
+          "price": 0.000375
         },
         "cache_write_input_token": {
-          "price": 0.00015
+          "price": 0.000075
         },
         "cache_read_input_token": {
-          "price": 0.000015
+          "price": 0.0000075
         },
         "additional_units": {
           "web_search": {
@@ -14017,10 +14017,10 @@
       },
       "batch_config": {
         "request_token": {
-          "price": 0.000075
+          "price": 0.0000375
         },
         "response_token": {
-          "price": 0.000375
+          "price": 0.0001875
         }
       }
     },
@@ -14032,13 +14032,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00015
+                    "price": 0.0000825
                   },
                   "cache_read_input_token": {
-                    "price": 0.000015
+                    "price": 0.00000825
                   },
                   "response_token": {
-                    "price": 0.00075
+                    "price": 0.0004125
                   },
                   "additional_units": {
                     "web_search": {
@@ -14061,13 +14061,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000075
+                    "price": 0.00004125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000075
+                    "price": 0.000004125
                   },
                   "response_token": {
-                    "price": 0.000375
+                    "price": 0.00020625
                   },
                   "additional_units": {
                     "web_search": {
@@ -14090,13 +14090,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000075
+                    "price": 0.00004125
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000075
+                    "price": 0.000004125
                   },
                   "response_token": {
-                    "price": 0.000375
+                    "price": 0.00020625
                   },
                   "additional_units": {
                     "web_search": {
@@ -14119,13 +14119,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00027
+                    "price": 0.0001485
                   },
                   "cache_read_input_token": {
-                    "price": 0.000027
+                    "price": 0.00001485
                   },
                   "response_token": {
-                    "price": 0.00135
+                    "price": 0.0007425
                   },
                   "additional_units": {
                     "web_search": {
@@ -14152,13 +14152,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00015
+                    "price": 0.000075
                   },
                   "cache_read_input_token": {
-                    "price": 0.000015
+                    "price": 0.0000075
                   },
                   "response_token": {
-                    "price": 0.00075
+                    "price": 0.000375
                   },
                   "additional_units": {
                     "web_search": {
@@ -14181,13 +14181,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000075
+                    "price": 0.0000375
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000075
+                    "price": 0.00000375
                   },
                   "response_token": {
-                    "price": 0.000375
+                    "price": 0.0001875
                   },
                   "additional_units": {
                     "web_search": {
@@ -14210,13 +14210,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000075
+                    "price": 0.0000375
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000075
+                    "price": 0.00000375
                   },
                   "response_token": {
-                    "price": 0.000375
+                    "price": 0.0001875
                   },
                   "additional_units": {
                     "web_search": {
@@ -14239,13 +14239,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.00027
+                    "price": 0.000135
                   },
                   "cache_read_input_token": {
-                    "price": 0.000027
+                    "price": 0.0000135
                   },
                   "response_token": {
-                    "price": 0.00135
+                    "price": 0.000675
                   },
                   "additional_units": {
                     "web_search": {


### PR DESCRIPTION
## Summary
- Updates Gemini 3.7 Flash and 3.6 Flash pricing in `google.json` and `vertex-ai.json` to reflect the current introductory rates effective through December 31, 2026.
- Previous values had the standard (post-Jan 2027) pricing.

Vertex AI Ref: https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing?hl=en
Google Gemini Ref: https://ai.google.dev/gemini-api/docs/pricing#standard

## Test plan
- [x] Verify pricing values match Google's published introductory rates
- [x] Confirm no other model entries were affected


### Context
Introductory pricing (50% off standard) is in effect through December 31, 2026. Standard pricing of $1.50/$7.50 per 1M tokens will apply starting January 1, 2027.

## Test plan
- [X] Verify pricing values match Google's published introductory rates across all tiers
- [X] Confirm no other model entries were affected
- [X] Cross-check non-global = 1.1x global pricing for standard/batch/flex, 1.1x for priority