### PR TITLE
Add Claude Fable 5.1 model metadata and pricing

### DIFF
--- a/general/anthropic.json
+++ b/general/anthropic.json
@@ -715,10 +715,21 @@
           },
           "display": {
             "type": "string",
-            "enum": ["omitted", "summarized", "updates"]
+            "enum": ["omitted", "summarized"]
           }
         },
         "defaultValue": { "type": "adaptive" },
+        "skipValues": [null]
+      },
+      {
+        "key": "output_config",
+        "properties": {
+          "effort": {
+            "type": "string",
+            "enum": ["low", "medium", "high", "xhigh", "max"]
+          }
+        },
+        "defaultValue": { "effort": "high" },
         "skipValues": [null]
       },
       {

--- a/general/anthropic.json
+++ b/general/anthropic.json
@@ -704,7 +704,41 @@
     "removeParams": ["temperature", "top_p", "top_k"]
   },
   "claude-fable-5-1": {
-    "params": [{ "key": "max_tokens", "maxValue": 128000 }],
+    "params": [
+      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["adaptive"]
+          },
+          "display": {
+            "type": "string",
+            "enum": ["omitted", "summarized", "updates"]
+          }
+        },
+        "defaultValue": { "type": "adaptive" },
+        "skipValues": [null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          { "value": "none", "name": "None" },
+          { "value": "auto", "name": "Auto" }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "removeParams": ["temperature", "top_p", "top_k"]
   }

--- a/general/anthropic.json
+++ b/general/anthropic.json
@@ -702,5 +702,10 @@
     ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "removeParams": ["temperature", "top_p", "top_k"]
+  },
+  "claude-fable-5-1": {
+    "params": [{ "key": "max_tokens", "maxValue": 128000 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["temperature", "top_p", "top_k"]
   }
 }

--- a/general/bedrock.json
+++ b/general/bedrock.json
@@ -5626,10 +5626,21 @@
           },
           "display": {
             "type": "string",
-            "enum": ["omitted", "summarized", "updates"]
+            "enum": ["omitted", "summarized"]
           }
         },
         "defaultValue": { "type": "adaptive" },
+        "skipValues": [null]
+      },
+      {
+        "key": "output_config",
+        "properties": {
+          "effort": {
+            "type": "string",
+            "enum": ["low", "medium", "high", "xhigh", "max"]
+          }
+        },
+        "defaultValue": { "effort": "high" },
         "skipValues": [null]
       },
       {
@@ -5665,10 +5676,21 @@
           },
           "display": {
             "type": "string",
-            "enum": ["omitted", "summarized", "updates"]
+            "enum": ["omitted", "summarized"]
           }
         },
         "defaultValue": { "type": "adaptive" },
+        "skipValues": [null]
+      },
+      {
+        "key": "output_config",
+        "properties": {
+          "effort": {
+            "type": "string",
+            "enum": ["low", "medium", "high", "xhigh", "max"]
+          }
+        },
+        "defaultValue": { "effort": "high" },
         "skipValues": [null]
       },
       {
@@ -5704,10 +5726,21 @@
           },
           "display": {
             "type": "string",
-            "enum": ["omitted", "summarized", "updates"]
+            "enum": ["omitted", "summarized"]
           }
         },
         "defaultValue": { "type": "adaptive" },
+        "skipValues": [null]
+      },
+      {
+        "key": "output_config",
+        "properties": {
+          "effort": {
+            "type": "string",
+            "enum": ["low", "medium", "high", "xhigh", "max"]
+          }
+        },
+        "defaultValue": { "effort": "high" },
         "skipValues": [null]
       },
       {

--- a/general/bedrock.json
+++ b/general/bedrock.json
@@ -5615,17 +5615,119 @@
     "removeParams": ["top_p", "temperature", "top_k"]
   },
   "anthropic.claude-fable-5-1": {
-    "params": [{ "key": "max_tokens", "maxValue": 128000 }],
+    "params": [
+      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["adaptive"]
+          },
+          "display": {
+            "type": "string",
+            "enum": ["omitted", "summarized", "updates"]
+          }
+        },
+        "defaultValue": { "type": "adaptive" },
+        "skipValues": [null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          { "value": "none", "name": "None" },
+          { "value": "auto", "name": "Auto" }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "removeParams": ["top_p", "temperature", "top_k"]
   },
   "us.anthropic.claude-fable-5-1": {
-    "params": [{ "key": "max_tokens", "maxValue": 128000 }],
+    "params": [
+      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["adaptive"]
+          },
+          "display": {
+            "type": "string",
+            "enum": ["omitted", "summarized", "updates"]
+          }
+        },
+        "defaultValue": { "type": "adaptive" },
+        "skipValues": [null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          { "value": "none", "name": "None" },
+          { "value": "auto", "name": "Auto" }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "removeParams": ["top_p", "temperature", "top_k"]
   },
   "global.anthropic.claude-fable-5-1": {
-    "params": [{ "key": "max_tokens", "maxValue": 128000 }],
+    "params": [
+      { "key": "max_tokens", "maxValue": 128000 },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["adaptive"]
+          },
+          "display": {
+            "type": "string",
+            "enum": ["omitted", "summarized", "updates"]
+          }
+        },
+        "defaultValue": { "type": "adaptive" },
+        "skipValues": [null]
+      },
+      {
+        "key": "tool_choice",
+        "type": "non-view-manage-data",
+        "defaultValue": null,
+        "options": [
+          { "value": "none", "name": "None" },
+          { "value": "auto", "name": "Auto" }
+        ],
+        "skipValues": [null, []],
+        "rule": {
+          "default": {
+            "condition": "tools",
+            "then": "auto",
+            "else": null
+          }
+        }
+      }
+    ],
     "type": { "primary": "chat", "supported": ["image", "tools"] },
     "removeParams": ["top_p", "temperature", "top_k"]
   },

--- a/general/bedrock.json
+++ b/general/bedrock.json
@@ -5614,6 +5614,21 @@
     },
     "removeParams": ["top_p", "temperature", "top_k"]
   },
+  "anthropic.claude-fable-5-1": {
+    "params": [{ "key": "max_tokens", "maxValue": 128000 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
+  "us.anthropic.claude-fable-5-1": {
+    "params": [{ "key": "max_tokens", "maxValue": 128000 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
+  "global.anthropic.claude-fable-5-1": {
+    "params": [{ "key": "max_tokens", "maxValue": 128000 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] },
+    "removeParams": ["top_p", "temperature", "top_k"]
+  },
 
   "us.xai.grok-4.6": {
     "params": [

--- a/pricing/anthropic.json
+++ b/pricing/anthropic.json
@@ -1238,5 +1238,36 @@
         }
       }
     }
+  },
+  "claude-fable-5-1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.005
+        },
+        "cache_write_input_token": {
+          "price": 0.00125
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.002
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0025
+        }
+      }
+    }
   }
 }

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -14486,6 +14486,75 @@
       }
     }
   },
+  "anthropic.claude-fable-5-1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.005
+        },
+        "cache_write_input_token": {
+          "price": 0.00125
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.002
+          }
+        }
+      }
+    }
+  },
+  "us.anthropic.claude-fable-5-1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0011
+        },
+        "response_token": {
+          "price": 0.0055
+        },
+        "cache_write_input_token": {
+          "price": 0.001375
+        },
+        "cache_read_input_token": {
+          "price": 0.0000275
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.0022
+          }
+        }
+      }
+    }
+  },
+  "global.anthropic.claude-fable-5-1": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.001
+        },
+        "response_token": {
+          "price": 0.005
+        },
+        "cache_write_input_token": {
+          "price": 0.00125
+        },
+        "cache_read_input_token": {
+          "price": 0.000025
+        },
+        "additional_units": {
+          "cache_write_1h": {
+            "price": 0.002
+          }
+        }
+      }
+    }
+  },
   "us.xai.grok-4.6": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/bedrock.json
+++ b/pricing/bedrock.json
@@ -14490,20 +14490,20 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.001
+          "price": 0.0011
         },
         "response_token": {
-          "price": 0.005
+          "price": 0.0055
         },
         "cache_write_input_token": {
-          "price": 0.00125
+          "price": 0.001375
         },
         "cache_read_input_token": {
-          "price": 0.000025
+          "price": 0.0000275
         },
         "additional_units": {
           "cache_write_1h": {
-            "price": 0.002
+            "price": 0.0022
           }
         }
       }


### PR DESCRIPTION
## Summary
- add Claude Fable 5.1 metadata and pricing for Anthropic
- add Bedrock base, US, and global inference IDs with regional/global rates
- expose adaptive thinking with `low` through `max` effort and a `high` default
- restrict tool choice to `auto`/`none` and omit unsupported sampling parameters
- exclude the beta-header-only `updates` thinking display mode

## Validation
- native `validate` CI check passes
- JSON parsing and Prettier pass for all touched files
- targeted ESLint passes for all touched files
- independent final review found no blockers or should-fix issues

Sources: Anthropic Claude Fable 5.1 model documentation and AWS Bedrock model/pricing documentation.