### PR TITLE
[fireworks-ai] Fix Kimi K3 10x pricing error and update stale model prices

### DIFF
--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -184,10 +184,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0008
+          "price": 0.000055
         },
         "response_token": {
-          "price": 0.0008
+          "price": 0.000219
         }
       }
     }
@@ -208,13 +208,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000174
+          "price": 0.000132
         },
         "response_token": {
-          "price": 0.000348
+          "price": 0.000396
         },
         "cache_read_input_token": {
-          "price": 0.000014
+          "price": 0.0000044
         }
       }
     },
@@ -226,13 +226,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000174
+                    "price": 0.000132
                   },
                   "response_token": {
-                    "price": 0.000348
+                    "price": 0.000396
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000145
+                    "price": 0.0000044
                   }
                 }
               }
@@ -241,13 +241,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000261
+                    "price": 0.000165
                   },
                   "response_token": {
-                    "price": 0.000522
+                    "price": 0.000495
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000218
+                    "price": 0.0000055
                   }
                 }
               }
@@ -279,7 +279,7 @@
           "price": 0.00044
         },
         "cache_read_input_token": {
-          "price": 0.000026
+          "price": 0.000014
         }
       }
     }
@@ -648,13 +648,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000014
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000028
+          "price": 0.000066
         },
         "cache_read_input_token": {
-          "price": 0.0000028
+          "price": 0.0000007
         }
       }
     },
@@ -666,13 +666,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.000014
+                    "price": 0.000022
                   },
                   "response_token": {
-                    "price": 0.000028
+                    "price": 0.000066
                   },
                   "cache_read_input_token": {
-                    "price": 0.0000028
+                    "price": 0.0000007
                   }
                 }
               }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -1187,13 +1187,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.000014
+          "price": 0.000022
         },
         "response_token": {
-          "price": 0.000028
+          "price": 0.000066
         },
         "cache_read_input_token": {
-          "price": 0.0000028
+          "price": 0.0000007
         }
       }
     }

--- a/pricing/fireworks-ai.json
+++ b/pricing/fireworks-ai.json
@@ -1149,13 +1149,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.003
+          "price": 0.0003
         },
         "response_token": {
-          "price": 0.015
+          "price": 0.0015
         },
         "cache_read_input_token": {
-          "price": 0.0003
+          "price": 0.00003
         }
       }
     },
@@ -1167,13 +1167,13 @@
               "pricing_config": {
                 "pay_as_you_go": {
                   "request_token": {
-                    "price": 0.003
+                    "price": 0.0003
                   },
                   "response_token": {
-                    "price": 0.015
+                    "price": 0.0015
                   },
                   "cache_read_input_token": {
-                    "price": 0.0003
+                    "price": 0.00003
                   }
                 }
               }


### PR DESCRIPTION
## Summary

Fixes incorrect and stale pricing for Fireworks AI models in `pricing/fireworks-ai.json`.

- **Kimi K3** — prices were **10x too high** due to a unit conversion error (dollars-per-million entered directly instead of converting to cents-per-token)
- **DeepSeek R1** — stale pricing ($8.00/$8.00 → $0.55/$2.19 per 1M)
- **DeepSeek V4 Pro** — updated to current 0813 version pricing (Standard & Priority)
- **DeepSeek V4 Flash** — updated to current 0731 version pricing
- **GLM 5.2** (glm-5p2) — corrected stale cached input price ($0.26 → $0.14 per 1M)

## Pricing References

| Model | Source | Price ($/1M: input / cached / output) |
|---|---|---|
| Kimi K3 | [Fireworks Serverless Pricing](https://docs.fireworks.ai/serverless/pricing) | $3.00 / $0.30 / $15.00 |
| DeepSeek R1 | [Firewor](https://fireworks.ai/models/fireworks/deepseek-r1), [LLM Cost Hub](https://llmcosthub.com/models/fireworks-deepseek-r1/) | $0.55 / — / $2.19 |
| DeepSeek V4 Pro (0813) | [Fireworks Serverless Pricing](https://docs.fireworks.ai/serverless/pricing) | Standard: $1.32 / $0.044 / $3.96, Priority: $1.65 / $0.055 / $4.95 |
| DeepSeek V4 Flash (0731) | [Fireworks Serverless Pricing](https://docs.fireworks.ai/serverless/pricing) | $0.22 / $0.007 / $0.66 |
| GLM 5.2 | [Fireworks Serverless Pricing](https://docs.fireworks.ai/serverless/pricing) | $1.40 / $0.14 / $4.40 |

## Pylon Ticket

https://app.usepylon.com/support/issues/views/4305f6d4-1eeb-4039-92aa-1867128acd4f?view=fs&issueNumber=8480