### PR TITLE
[google] Add gemini-3.8-flash

### DIFF
--- a/general/google.json
+++ b/general/google.json
@@ -1987,6 +1987,62 @@
     ],
     "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools", "audio"] }
   },
+  "gemini-3.8-flash": {
+    "params": [
+      { "key": "max_tokens", "maxValue": 65536 },
+      {
+        "key": "response_format",
+        "defaultValue": null,
+        "options": [
+          {
+            "value": null,
+            "name": "Text"
+          },
+          {
+            "value": "json_object",
+            "name": "JSON Object",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_object" }
+              }
+            }
+          },
+          {
+            "value": "json_schema",
+            "name": "JSON Schema",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string", "value": "json_schema" },
+                "json_schema": { "type": "object" }
+              }
+            },
+            "params": { "key": "json_schema", "defaultValue": null, "type": "json", "skipValues": [null] }
+          }
+        ],
+        "skipValues": [null],
+        "type": "string"
+      },
+      {
+        "key": "thinking",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["enabled"]
+          },
+          "budget_tokens": {
+            "type": "number",
+            "minValue": 128,
+            "maxValue": 32768
+          }
+        },
+        "defaultValue": null,
+        "skipValues": [null]
+      }
+    ],
+    "type": { "primary": "chat", "supported": ["image", "pdf", "doc", "tools", "audio"] }
+  },
   "gemini-3.1-flash-image-preview": {
     "type": {
       "primary": "image"

--- a/pricing/google.json
+++ b/pricing/google.json
@@ -3886,5 +3886,67 @@
         }
       }
     }
+  },
+  "gemini-3.8-flash-lte-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000075
+        },
+        "response_token": {
+          "price": 0.000375
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000375
+        },
+        "response_token": {
+          "price": 0.0001875
+        }
+      }
+    }
+  },
+  "gemini-3.8-flash-gt-128k": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000075
+        },
+        "response_token": {
+          "price": 0.000375
+        },
+        "cache_read_input_token": {
+          "price": 0.0000075
+        },
+        "additional_units": {
+          "web_search": {
+            "price": 1.4
+          },
+          "search": {
+            "price": 1.4
+          }
+        }
+      },
+      "batch_config": {
+        "request_token": {
+          "price": 0.0000375
+        },
+        "response_token": {
+          "price": 0.0001875
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `gemini-3.8-flash` model config and pricing for the Google provider
- Gemini 3.8 Flash is Google's latest GA Flash model (released Sep 2, 2026) with improvements over 3.7 Flash in software engineering, agentic tasks, and multi-step reasoning
- Supports: chat, thinking, structured output (JSON), vision, PDF, doc, tools, audio
- Max output: 65,536 tokens | Context window: 1,048,576 tokens

## Pricing (introductory through Dec 31, 2026)

| Tier | Input ($/1M) | Output ($/1M) | Cents/token (input) | Cents/token (output) |
|------|-------------|--------------|---------------------|---------------------|
| Standard PayGo | $0.75 | $3.75 | 0.000075 | 0.000375 |
| Cached input | $0.075 | — | 0.0000075 | — |
| Batch/Flex | $0.375 | $1.875 | 0.0000375 | 0.0001875 |
| Grounding (search) | $14/1K queries | — | 1.4 per query | — |

**Pricing source:** https://cloud.google.com/vertex-ai/generative-ai/pricing
**Model docs:** https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-8-flash

## Sanity check
Pricing matches the existing `gemini-3.7-flash` entries — both models share the same introductory pricing tier ($0.75/$3.75 per 1M tokens through Dec 31, 2026), confirmed on the official pricing page.

## Validation
- [x] `jq empty` — valid JSON
- [x] `check_duplicate_keys.py` — no duplicates
- [x] `npm run format` — formatted
- [x] `npm run lint` — no errors

## Files changed
- `general/google.json` — added `gemini-3.8-flash` config entry
- `pricing/google.json` — added `gemini-3.8-flash-lte-128k` and `gemini-3.8-flash-gt-128k` pricing entries