### PR TITLE
Add Muse Spark 1.3 (Meta via OpenRouter) pricing and model catalog entries

### DIFF
--- a/general/openrouter.json
+++ b/general/openrouter.json
@@ -261,6 +261,12 @@
       "supported": ["image", "tools"]
     }
   },
+  "meta/muse-spark-1.3": {
+    "type": {
+      "primary": "chat",
+      "supported": ["image", "tools"]
+    }
+  },
   "meta/muse-spark-1.2": {
     "type": {
       "primary": "chat",

--- a/pricing/openrouter.json
+++ b/pricing/openrouter.json
@@ -275,6 +275,21 @@
       }
     }
   },
+  "meta/muse-spark-1.3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000125
+        },
+        "response_token": {
+          "price": 0.000425
+        },
+        "cache_read_input_token": {
+          "price": 0.000015
+        }
+      }
+    }
+  },
   "meta/muse-spark-1.2": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
## Summary

Adds Meta Muse Spark 1.3 as served by OpenRouter so gateway pricing and model metadata resolve for the new slug.

- `pricing/openrouter.json`: $1.25/M input, $4.25/M output, $0.15/M cached input
- `general/openrouter.json`: chat model with image and tool support, matching the validated Muse Spark 1.2 route contract

## Verification

- repository JSON validation passes
- live Portkey/OpenRouter validation passed basic completion, streaming usage, tool calling, image input, reasoning controls, sampling and output-token parameters, combined tools with reasoning, and the Responses API

## Related

- Gemini catalog: #917