### PR TITLE
Add MAI-Image-2.5-Pro model to Azure AI

### DIFF
--- a/general/azure-ai.json
+++ b/general/azure-ai.json
@@ -4598,6 +4598,19 @@
     },
     "disablePlayground": true
   },
+  "MAI-Image-2.5-Pro": {
+    "params": [
+      {
+        "key": "max_tokens",
+        "maxValue": 4096
+      }
+    ],
+    "type": {
+      "primary": "image",
+      "supported": ["image"]
+    },
+    "disablePlayground": true
+  },
   "tts-1": {
     "disablePlayground": true,
     "type": {

--- a/pricing/azure-ai.json
+++ b/pricing/azure-ai.json
@@ -4583,6 +4583,23 @@
       }
     }
   },
+  "MAI-Image-2.5-Pro": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.0005
+        },
+        "response_token": {
+          "price": 0.0106
+        },
+        "additional_units": {
+          "input_image": {
+            "price": 0.0008
+          }
+        }
+      }
+    }
+  },
   "MAI-Thinking-1": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
## Summary
- Adds `MAI-Image-2.5-Pro` general schema entry and pricing for Azure AI
- Pricing: $5/1M text input, $8/1M image input, $106/1M image output ([source](https://microsoft.ai/news/introducing-mai-image-2-5-pro-and-mai-voice-2-flash/))
- No gateway changes needed — existing `mai-image` detection handles this model automatically

## Pylon ticket
https://app.usepylon.com/support/issues/views/4305f6d4-1eeb-4039-92aa-1867128acd4f?issueNumber=8538

## Validation
- Gateway supports additionalUnits.input_image pricing flow