### PR TITLE
Add mistral-ocr-2505 general schema and pricing for vertex-ai

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -2504,7 +2504,7 @@
       "supported": ["tools"]
     }
   },
-  "mistral-ocr-2505": {
+  "mistralai.mistral-ocr-2505": {
     "type": {
       "primary": "ocr"
     },

--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -2504,6 +2504,12 @@
       "supported": ["tools"]
     }
   },
+  "mistral-ocr-2505": {
+    "type": {
+      "primary": "ocr"
+    },
+    "disablePlayground": true
+  },
   "deepseek-r1-0528-maas": {
     "type": {
       "primary": "chat"

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -16231,6 +16231,18 @@
       }
     }
   },
+  "mistral-ocr-2505": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00000005
+        },
+        "response_token": {
+          "price": 0.00000005
+        }
+      }
+    }
+  },
   "deepseek-r1-0528-maas": {
     "pricing_config": {
       "pay_as_you_go": {

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -16235,10 +16235,10 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.00000005
+          "price": 0.05
         },
         "response_token": {
-          "price": 0.00000005
+          "price": 0
         }
       }
     }


### PR DESCRIPTION
## Summary
Adds the Mistral OCR (25.05) model to the Vertex AI model configs.

## Changes
- `general/vertex-ai.json`: new `mistral-ocr-2505` entry with `type.primary: ocr` and `disablePlayground: true` (mirrors the existing Mistral/Azure OCR entries).
- `pricing/vertex-ai.json`: new `mistral-ocr-2505` pricing — `request_token: 0.05` (0.05 cents/page = $0.0005/page per the [official Vertex AI pricing](https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing?hl=en#mistral-ais-models), `response_token: 0`. Same cents-per-page convention as `mistral-ai.json`/`azure-ai.json` (where `0.4` = 0.4¢/page).

## Notes
- Keyed as `mistral-ocr-2505` **without** the `mistralai.` publisher prefix. The gateway's `getModelAndProvider` strips the publisher prefix before pricing/type lookup (confirmed in `google-vertex-ai/utils.ts` and `pricing.ts`), consistent with sibling models `mistral-medium-3`, `mistral-small-2503`, `codestral-2`.
- OCR is billed per `pages_processed` (not tokens) in `google-vertex-ai/pricing.ts`.