### PR TITLE
Fix qwen3-asr-flash pricing (audio-duration based)

### DIFF
--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -37,6 +37,17 @@
                   "value": "rates.cache_read_input_token"
                 }
               ]
+            },
+            {
+              "operation": "multiply",
+              "operands": [
+                {
+                  "value": "audio_input_tokens"
+                },
+                {
+                  "value": "rates.request_audio_token"
+                }
+              ]
             }
           ]
         },

--- a/pricing/dashscope.json
+++ b/pricing/dashscope.json
@@ -518,10 +518,13 @@
     "pricing_config": {
       "pay_as_you_go": {
         "request_token": {
-          "price": 0.0000035
+          "price": 0
         },
         "response_token": {
-          "price": 0.0000035
+          "price": 0
+        },
+        "request_audio_token": {
+          "price": 0.00014
         }
       }
     }


### PR DESCRIPTION
# Description

Corrects pricing for the Alibaba DashScope `qwen3-asr-flash` model.

- [x] Update existing pricing
- [x] Bug fix

`qwen3-asr-flash` is an ASR (speech-to-text) model that Alibaba bills by **audio duration ($0.000035/sec, international deployment)**, not per text token. It was previously configured as a token-priced chat model (`request_token`/`response_token` = `0.0000035`), which billed on the wrong dimension and at the wrong magnitude.

DashScope's OpenAI-compatible response returns `usage.prompt_tokens_details.audio_tokens`, where **25 audio tokens = 1 second**. Converting Alibaba's rate to the repo's cents-per-token unit:

\`\$0.000035/sec ÷ 25 tokens/sec × 100 = 0.00014 cents per audio token\`

Sanity check: 1s = 25 audio tokens → 25 × 0.00014 = 0.0035 cents = \$0.000035. Matches Alibaba's per-second rate.

Now `request_token` and `response_token` are `0`, and `request_audio_token` is `0.00014`. The paired gateway change (Portkey-AI/gateway-enterprise-node#8360-qwen3-asr-update) reads `audio_tokens` into the billable audio units.

## Source Verification

**Source Link:** https://docs.modelstudio.console.alibabacloud.com/tc/model-studio/qwen3-asr-flash (Audio duration: \$0.000035/sec, international deployment)

## Checklist

- [x] I have validated the JSON
- [x] I have verified that prices are in **cents per token** (not dollars)
- [x] I have included the source link above

## Resources

- Gateway PR Link: http://github.com/Portkey-AI/gateway-enterprise-node/pull/2034
- Asana Ticket: https://app.asana.com/1/11915891072957/project/1215961426480484/task/1218317875645308?focus=true