### PR TITLE
Add deepseek-ocr-maas to vertex-ai (chat, image)

### DIFF
--- a/general/vertex-ai.json
+++ b/general/vertex-ai.json
@@ -2527,6 +2527,12 @@
       "supported": ["tools"]
     }
   },
+  "deepseek-ocr-maas": {
+    "type": {
+      "primary": "chat",
+      "supported": ["image"]
+    }
+  },
   "jamba-large-1.6": {
     "type": {
       "primary": "chat",

--- a/pricing/vertex-ai.json
+++ b/pricing/vertex-ai.json
@@ -16309,6 +16309,18 @@
       }
     }
   },
+  "deepseek-ocr-maas": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00003
+        },
+        "response_token": {
+          "price": 0.00012
+        }
+      }
+    }
+  },
   "jamba-large-1.6": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
## Summary
Adds `deepseek-ocr-maas` to the `vertex-ai` provider (`general/vertex-ai.json` and `pricing/vertex-ai.json`) as a `chat` model with `image` input support.

## Notes

- It is supported over the OpenAI compatible chat/completions endpoint, so `type.primary` would be `chat` and not `ocr`
- We can add support for it by just adding it to the models repo, but the model has already been deprecated by provider as of **21st July 2026**, and its scheduled **retirement date is 21st October 2026**.

## Reference Links
- **Pricing:** https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing?hl=en
- **Model Card:** https://console.cloud.google.com/agent-platform/publishers/deepseek-ai/model-garden/deepseek-ocr?pli=1
- **Deprecation Notification:** https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/deprecations/open-models