### PR TITLE
Add Workers AI pricing for GLM 5.3 Flash, GLM 5.3, DeepSeek V4 Pro

### DIFF
--- a/general/workers-ai.json
+++ b/general/workers-ai.json
@@ -95,7 +95,7 @@
     "type": { "primary": "chat" }
   },
   "@cf/zai-org/glm-5.3-flash": {
-    "type": { "primary": "chat" }
+    "type": { "primary": "chat", "supported": ["image"] }
   },
   "@cf/zai-org/glm-5.3": {
     "type": { "primary": "chat" }

--- a/general/workers-ai.json
+++ b/general/workers-ai.json
@@ -116,7 +116,7 @@
     "type": { "primary": "chat" }
   },
   "@cf/moonshotai/kimi-k2.7-code": {
-    "type": { "primary": "chat" }
+    "type": { "primary": "chat", "supported": ["image"] }
   },
   "@cf/moonshotai/kimi-k3": {
     "type": { "primary": "chat", "supported": ["image"] }

--- a/general/workers-ai.json
+++ b/general/workers-ai.json
@@ -94,6 +94,15 @@
   "@cf/zai-org/glm-5.2": {
     "type": { "primary": "chat" }
   },
+  "@cf/zai-org/glm-5.3-flash": {
+    "type": { "primary": "chat" }
+  },
+  "@cf/zai-org/glm-5.3": {
+    "type": { "primary": "chat" }
+  },
+  "@cf/deepseek-ai/deepseek-v4-pro-0813": {
+    "type": { "primary": "chat" }
+  },
   "@cf/nvidia/nemotron-3-120b-a12b": {
     "type": { "primary": "chat" }
   },

--- a/general/workers-ai.json
+++ b/general/workers-ai.json
@@ -95,13 +95,16 @@
     "type": { "primary": "chat" }
   },
   "@cf/zai-org/glm-5.3-flash": {
-    "type": { "primary": "chat", "supported": ["image"] }
+    "params": [{ "key": "max_tokens", "maxValue": 1048576 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "@cf/zai-org/glm-5.3": {
-    "type": { "primary": "chat" }
+    "params": [{ "key": "max_tokens", "maxValue": 1048576 }],
+    "type": { "primary": "chat", "supported": ["tools"] }
   },
   "@cf/deepseek-ai/deepseek-v4-pro-0813": {
-    "type": { "primary": "chat" }
+    "params": [{ "key": "max_tokens", "maxValue": 1048576 }],
+    "type": { "primary": "chat", "supported": ["tools"] }
   },
   "@cf/nvidia/nemotron-3-120b-a12b": {
     "type": { "primary": "chat" }
@@ -116,7 +119,8 @@
     "type": { "primary": "chat" }
   },
   "@cf/moonshotai/kimi-k2.7-code": {
-    "type": { "primary": "chat", "supported": ["image"] }
+    "params": [{ "key": "max_tokens", "maxValue": 262144 }],
+    "type": { "primary": "chat", "supported": ["image", "tools"] }
   },
   "@cf/moonshotai/kimi-k3": {
     "type": { "primary": "chat", "supported": ["image"] }

--- a/pricing/workers-ai.json
+++ b/pricing/workers-ai.json
@@ -382,6 +382,51 @@
       }
     }
   },
+  "@cf/zai-org/glm-5.3-flash": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000015
+        },
+        "cache_read_input_token": {
+          "price": 0.000003
+        },
+        "response_token": {
+          "price": 0.00005
+        }
+      }
+    }
+  },
+  "@cf/zai-org/glm-5.3": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.00014
+        },
+        "cache_read_input_token": {
+          "price": 0.000026
+        },
+        "response_token": {
+          "price": 0.00044
+        }
+      }
+    }
+  },
+  "@cf/deepseek-ai/deepseek-v4-pro-0813": {
+    "pricing_config": {
+      "pay_as_you_go": {
+        "request_token": {
+          "price": 0.000132
+        },
+        "cache_read_input_token": {
+          "price": 0.0000044
+        },
+        "response_token": {
+          "price": 0.000396
+        }
+      }
+    }
+  },
   "@cf/nvidia/nemotron-3-120b-a12b": {
     "pricing_config": {
       "pay_as_you_go": {


### PR DESCRIPTION
## Summary
- add `@cf/zai-org/glm-5.3-flash`, `@cf/zai-org/glm-5.3` and `@cf/deepseek-ai/deepseek-v4-pro-0813` pricing under `workers-ai`
- add the matching chat entries to `general/workers-ai.json` with tool support and the served `max_tokens` cap
- mark `@cf/zai-org/glm-5.3-flash` and the existing `@cf/moonshotai/kimi-k2.7-code` as image-capable, and give Kimi K2.7 Code its tool flag and cap

Rates are from Cloudflare's model catalog (`/accounts/{id}/ai/models/search`) in the repo's cents-per-token convention, matching the existing `@cf/zai-org/glm-5.2` entry:

| Model | Input / M | Cached input / M | Output / M | max_tokens cap | Image |
|---|---|---|---|---|---|
| glm-5.3-flash | $0.15 | $0.03 | $0.50 | 1,048,576 | yes |
| glm-5.3 | $1.40 | $0.26 | $4.40 | 1,048,576 | no |
| deepseek-v4-pro-0813 | $1.32 | $0.044 | $3.96 | 1,048,576 | no |
| kimi-k2.7-code (existing) | unchanged | unchanged | unchanged | 262,144 | yes |

## Validation
- `max_tokens` caps are the values Workers AI reports in its own 400 when a larger value is sent
- image support verified with an `image_url` part on Workers AI's OpenAI-compatible endpoint (GLM 5.3, GLM 5.2 and DeepSeek V4 Pro do not accept image input there and stay text-only); tool calling verified on all four models
- `jq empty` on both files, `scripts/check_duplicate_keys.py`, Prettier and ESLint all pass locally